### PR TITLE
ini_set() must use strings for values

### DIFF
--- a/src/api/v2/index.php
+++ b/src/api/v2/index.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 date_default_timezone_set("UTC");
 error_reporting(E_ALL);
-ini_set("display_errors", 1);
+ini_set("display_errors", '1');
 
 use Slim\Factory\AppFactory;
 use Slim\Middleware\ContentLengthMiddleware;


### PR DESCRIPTION
ini_set() arguments should always be strings, and as strict_types is set, it errors (instead of a warning) when trying to access apiv2 in a non-dockerized installation.