### PR TITLE
NotificationSlack: Set the content-type header to Application/json. 

### DIFF
--- a/src/inc/notifications/NotificationSlack.class.php
+++ b/src/inc/notifications/NotificationSlack.class.php
@@ -36,6 +36,7 @@ class HashtopolisNotificationSlack extends HashtopolisNotification {
       curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, "true");
     }
     
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
     curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
This makes it compatible with Google Chat webhooks.

https://developers.google.com/chat/how-tos/webhooks#write_the_webhook_script