### PR TITLE
Fix for mismatch # of parameters with importSupertask in the User API

### DIFF
--- a/doc/user-api/sections/supertask.tex
+++ b/doc/user-api/sections/supertask.tex
@@ -9,6 +9,7 @@
 			  "section": "supertask",
 			  "request": "importSupertask",
 			  "name": "Mask Supertask",
+			  "maxAgents": 10,
 			  "isCpuOnly": false,
 			  "isSmall": false,
 			  "masks": [
@@ -19,7 +20,7 @@
 			  ],
 			  "optimizedFlag": true,
 			  "crackerTypeId": 1,
-			  "benchtype": "speed",
+			  "benchmarkType": "speed",
 			  "accessKey": "mykey"
 			}
 			\end{verbatim}

--- a/doc/user-api/user-api.tex
+++ b/doc/user-api/user-api.tex
@@ -11,7 +11,9 @@
 	\maketitle
 	\section*{Introduction}
 	The communication for the User API is always in JSON formatted values. When sending a request to the server, it should be a POST containing the JSON data.
-	Every request has a \textit{section} and a \textit{request} field to state which action should be executed. Every response again then contains the requested section and request and gives a \textit{status} to indicate if the query was successful or not. To increase the readability of this document, requests are always in blue, successful responses in green and error messages in red.
+	Every request has a \textit{section} and a \textit{request} field to state which action should be executed. Every response again then contains the requested section and request and gives a \textit{status} to indicate if the query was successful or not. To increase the readability of this document, requests are always in blue, successful responses in green and error messages in red. \\
+
+	The User API can be found at http[s]://[YOUR_SERVER]:8080/api/user.php. All of the below payloads should be sent to that endpoint.
 
 	\section*{Errors}
 	In case of an error with the query which the user sends to the server, the response will have following format with the corresponding action which was requested and the error message which should help in getting information about this error.

--- a/src/inc/user-api/UserAPISupertask.class.php
+++ b/src/inc/user-api/UserAPISupertask.class.php
@@ -114,6 +114,7 @@ class UserAPISupertask extends UserAPIBasic {
     SupertaskUtils::importSupertask(
       $QUERY[UQueryTask::SUPERTASK_NAME],
       $QUERY[UQueryTask::TASK_CPU_ONLY],
+      $QUERY[UQueryTask::TASK_MAX_AGENTS],
       $QUERY[UQueryTask::TASK_SMALL],
       $QUERY[UQueryTask::TASK_OPTIMIZED],
       $QUERY[UQueryTask::TASK_CRACKER_TYPE],

--- a/src/inc/utils/SupertaskUtils.class.php
+++ b/src/inc/utils/SupertaskUtils.class.php
@@ -352,6 +352,7 @@ class SupertaskUtils {
   /**
    * @param string $name
    * @param boolean $isCpuOnly
+   * @param int $maxAgents
    * @param boolean $isSmall
    * @param boolean $useOptimized
    * @param int $crackerBinaryTypeId


### PR DESCRIPTION
Fix for mismatch # of parameters with importSupertask in the User API. I'm not super familiar with the codebase still so please review and let me know if there is a more correct fix.

https://github.com/hashtopolis/server/blob/master/src/inc/utils/SupertaskUtils.class.php#L362 and
https://github.com/hashtopolis/server/blob/master/src/inc/user-api/UserAPISupertask.class.php#L114C21-L121C41

Also, some documentation updates. What is the process for rebuilding the PDF? Can someone help with that please?

Thanks for a great tool!