### PR TITLE
Remove `version` attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   hashtopolis-backend:
     container_name: hashtopolis-backend


### PR DESCRIPTION
Docker Compose v2.39.2 warns:

```
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```