### PR TITLE
Bugfix: only use the mask as subtask name in supertask import to avoid too long names

### DIFF
--- a/src/inc/utils/SupertaskUtils.class.php
+++ b/src/inc/utils/SupertaskUtils.class.php
@@ -422,7 +422,7 @@ class SupertaskUtils {
       }
       $cmd = str_replace("COMMA_PLACEHOLDER", "\\,", $cmd);
       $cmd = str_replace("HASH_PLACEHOLDER", "\\#", $cmd);
-      $preTaskName = implode(",", $mask);
+      $preTaskName = $pattern;
       $preTaskName = str_replace("COMMA_PLACEHOLDER", "\\,", $preTaskName);
       $preTaskName = str_replace("HASH_PLACEHOLDER", "\\#", $preTaskName);
       


### PR DESCRIPTION
Does fix it in the backend for #1680.