### PR TITLE
Fixed deprecated feature policy header

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -12,7 +12,7 @@
         Require all granted
 	</Directory>
     Header always set Referrer-Policy "same-origin"
-    Header always set Feature-Policy "geolocation none;midi none;notifications none;push none;sync-xhr self;microphone none;camera none;magnetometer none;gyroscope none;speaker none;vibrate none;fullscreen self;payment none;"
+    Header always set Permissions-Policy "geolocation none;midi none;notifications none;push none;sync-xhr self;microphone none;camera none;magnetometer none;gyroscope none;speaker none;vibrate none;fullscreen self;payment none;bluetooth none;display-capture none;usb none;"
     Header always set Content-Security-Policy "frame-ancestors 'none';"
     Header always set X-Frame-Options "DENY"
     Header always set X-Content-Type-Options "nosniff"


### PR DESCRIPTION
Fixed deprecated feature policy header and added some new permissions to deny that aren't needed.

After this has been reviewed, I'd suggest to also implement it in the /nginx/header.conf of the web-ui repo.