### PR TITLE
Fix statement building in DBA on empty filters

### DIFF
--- a/src/dba/AbstractModelFactory.class.php
+++ b/src/dba/AbstractModelFactory.class.php
@@ -746,6 +746,9 @@ abstract class AbstractModelFactory {
         array_push($vals, $v);
       }
     }
+    if (sizeof($parts) == 0) {
+      return "";
+    }
     return " WHERE " . implode(" AND ", $parts);
   }
   


### PR DESCRIPTION
only include a WHERE statement into the query when at least one filter part is present

closes #1759 