### PR TITLE
Remove order from countFilter

### DIFF
--- a/src/dba/AbstractModelFactory.class.php
+++ b/src/dba/AbstractModelFactory.class.php
@@ -483,18 +483,6 @@ abstract class AbstractModelFactory {
       $query .= $this->applyFilters($vals, $options['filter']);
     }
     
-    if (!array_key_exists("order", $options)) {
-      // Add a asc order on the primary keys as a standard
-      $oF = new OrderFilter($this->getNullObject()->getPrimaryKey(), "ASC");
-      $orderOptions = array(
-        $oF
-      );
-      $options['order'] = $orderOptions;
-    }
-    if (count($options['order']) != 0) {
-      $query .= $this->applyOrder($options['order']);
-    }
-    
     $dbh = self::getDB();
     $stmt = $dbh->prepare($query);
     $stmt->execute($vals);


### PR DESCRIPTION
It does not make sense to have 'order' at all on countFilter as it will always be one single value.

Further, the default adding ASC order technically is not allowed in all SQL as the count is an aggregation column and if we then sort by the ID unnecessarily, there is an aggregation function missing for the ID column.