### PR TITLE
Save returned user model on creation to retrieve user id correctly

### DIFF
--- a/src/inc/load.php
+++ b/src/inc/load.php
@@ -128,7 +128,7 @@ catch (PDOException $e) {
   $newHash = password_hash($CIPHER, PASSWORD_BCRYPT, $options);
   
   $user = new User(null, $username, $email, $newHash, $newSalt, 1, 1, 0, time(), 3600, $group->getId(), 0, "", "", "", "");
-  Factory::getUserFactory()->save($user);
+  $user = Factory::getUserFactory()->save($user);
   
   // create default group
   $group = AccessUtils::getOrCreateDefaultAccessGroup();


### PR DESCRIPTION
It is not clear to me why this worked so far, as we do `$user->getId()` right after when creating the default access group.