### PR TITLE
Replaced all LIMIT comma style queries with LIMIT OFFSET

### DIFF
--- a/src/chunks.php
+++ b/src/chunks.php
@@ -32,7 +32,7 @@ if (!isset($_GET['show'])) {
   $numentries = Factory::getChunkFactory()->countFilter([]);
   UI::add('maxpage', floor($numentries / $PAGESIZE));
   $limit = $page * $PAGESIZE;
-  $oF = new OrderFilter(Chunk::SOLVE_TIME, "DESC LIMIT $limit, $PAGESIZE", Factory::getChunkFactory());
+  $oF = new OrderFilter(Chunk::SOLVE_TIME, "DESC LIMIT $PAGESIZE OFFSET $limit", Factory::getChunkFactory());
   UI::add('all', false);
   UI::add('pageTitle', "Chunks Activity (page " . ($page + 1) . ")");
 }

--- a/src/cracks.php
+++ b/src/cracks.php
@@ -68,7 +68,7 @@ UI::add('currentPage', $currentPage);
 
 $qF1 = new QueryFilter(Hash::IS_CRACKED, 1, "=");
 $qF2 = new ContainFilter(Hash::HASHLIST_ID, $hashlistIds);
-$oF = new OrderFilter(Hash::TIME_CRACKED, "DESC LIMIT " . (SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE) * ($currentPage - 1)) . ", " . SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE));
+$oF = new OrderFilter(Hash::TIME_CRACKED, "DESC LIMIT " . SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE) . " OFFSET " . (SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE) * ($currentPage - 1)));
 $hashes = $hashFactory->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF]);
 
 $crackDetailsPrimary = new DataSet();

--- a/src/getFound.php
+++ b/src/getFound.php
@@ -49,7 +49,7 @@ switch ($format) {
       $limit = 0;
       $size = SConfig::getInstance()->getVal(DConfig::BATCH_SIZE);
       do {
-        $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT $limit,$size");
+        $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT $size OFFSET $limit");
         $qF1 = new QueryFilter(Hash::HASHLIST_ID, $hashlist->getId(), "=");
         $qF2 = new QueryFilter(Hash::IS_CRACKED, 1, "=");
         $current = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF]);

--- a/src/getHashlist.php
+++ b/src/getHashlist.php
@@ -57,7 +57,7 @@ switch ($format) {
       $limit = 0;
       $size = SConfig::getInstance()->getVal(DConfig::BATCH_SIZE);
       do {
-        $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT $limit,$size");
+        $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT $size OFFSET $limit");
         $qF1 = new QueryFilter(Hash::HASHLIST_ID, $hashlist->getId(), "=");
         $qF2 = new QueryFilter(Hash::IS_CRACKED, 0, "=");
         if ($brain) {

--- a/src/hashes.php
+++ b/src/hashes.php
@@ -195,7 +195,7 @@ UI::add('nextPage', $nextPage);
 UI::add('previousPage', $previousPage);
 UI::add('currentPage', $currentPage);
 
-$oF = new OrderFilter($hashFactory->getNullObject()->getPrimaryKey(), "ASC LIMIT " . (SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE) * $currentPage) . ", " . SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE));
+$oF = new OrderFilter($hashFactory->getNullObject()->getPrimaryKey(), "ASC LIMIT " . SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE)) . " OFFSET " . (SConfig::getInstance()->getVal(DConfig::HASHES_PER_PAGE) * $currentPage);
 $hashes = $hashFactory->filter([Factory::FILTER => $queryFilters, Factory::ORDER => $oF]);
 
 if (isset($_GET['crackpos']) && $_GET['crackpos'] == 'true') {

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -4,6 +4,7 @@ use DBA\Hash;
 use DBA\QueryFilter;
 use DBA\ContainFilter;
 use DBA\OrderFilter;
+use DBA\LimitFilter;
 use DBA\Hashlist;
 use DBA\HashlistHashlist;
 use DBA\HashBinary;
@@ -198,8 +199,9 @@ class HashlistUtils {
       $size = $hashFactory->countFilter([Factory::FILTER => [$qF1, $qF2]]);
       for ($x = 0; $x * $pagingSize < $size; $x++) {
         $buffer = "";
-        $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT " . ($x * $pagingSize) . ", $pagingSize");
-        $hashes = $hashFactory->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF]);
+        $oF = new OrderFilter(Hash::HASH_ID, "ASC");
+        $lF = new LimitFilter($pagingSize, $x * $pagingSize);
+        $hashes = $hashFactory->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF, Factory::LIMIT => $lF]);
         foreach ($hashes as $hash) {
           $plain = $hash->getPlaintext();
           if (strlen($plain) >= 8 && substr($plain, 0, 5) == "\$HEX[" && substr($plain, strlen($plain) - 1, 1) == "]") {
@@ -714,8 +716,9 @@ class HashlistUtils {
     $separator = SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR);
     $numEntries = 0;
     for ($x = 0; $x * $pagingSize < $count; $x++) {
-      $oF = new OrderFilter($orderObject, "ASC LIMIT " . ($x * $pagingSize) . ",$pagingSize");
-      $entries = $factory->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF]);
+      $oF = new OrderFilter($orderObject, "ASC");
+      $lF = new LimitFilter($pagingSize, $x * $pagingSize);
+      $entries = $factory->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF, Factory::LIMIT => $lF]);
       $buffer = "";
       foreach ($entries as $entry) {
         switch ($format->getFormat()) {
@@ -1103,8 +1106,9 @@ class HashlistUtils {
     }
     $numEntries = 0;
     for ($x = 0; $x * $pagingSize < $count; $x++) {
-      $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT " . ($x * $pagingSize) . ",$pagingSize");
-      $entries = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF]);
+      $oF = new OrderFilter(Hash::HASH_ID, "ASC");
+      $lF = new LimitFilter($pagingSize, $x * $pagingSize);
+      $entries = Factory::getHashFactory()->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF, Factory::LIMIT => $lF]);
       $buffer = "";
       foreach ($entries as $entry) {
         $buffer .= $entry->getHash();

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -257,7 +257,7 @@ if (isset($_GET['id'])) {
       }
       UI::add('page', $page);
       $limit = $page * $chunkPageSize;
-      $oFp = new OrderFilter(Chunk::SOLVE_TIME, "DESC LIMIT $limit, $chunkPageSize", Factory::getChunkFactory());
+      $oFp = new OrderFilter(Chunk::SOLVE_TIME, "DESC LIMIT $chunkPageSize OFFSET $limit", Factory::getChunkFactory());
       UI::add('chunksPageTitle', "All chunks (page " . ($page + 1) . ")");
       
       $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");


### PR DESCRIPTION
The notation with OFFSET is more standard.

Note: 
As we have LimitFilter in the DBA nowadays (which already uses OFFSET), this should not occur on any new code that it has to be done manually. But there were occurrences where it was included in the OrderFilter as back then, this was the only way to make LIMIT queries. 

I changed it just inline for code parts which will be removed with the old UI and rewrote it with LimitFilter in code parts which may remain longer.