### PR TITLE
Replace aliasing for joins with more general character

### DIFF
--- a/src/dba/AbstractModelFactory.class.php
+++ b/src/dba/AbstractModelFactory.class.php
@@ -638,7 +638,7 @@ abstract class AbstractModelFactory {
         $k = strtolower($k);
         foreach ($factories as $factory) {
           if (Util::startsWith($k, strtolower($factory->getMappedModelTable()))) {
-            $column = str_replace(strtolower($factory->getMappedModelTable()) . ".", "", $k);
+            $column = str_replace(strtolower($factory->getMappedModelTable()) . "_", "", $k);
             $values[$factory->getModelTable()][strtolower($column)] = $v;
           }
         }

--- a/src/dba/Util.class.php
+++ b/src/dba/Util.class.php
@@ -37,7 +37,7 @@ class Util {
   public static function createPrefixedString(string $table, array $keys): string {
     $arr = array();
     foreach ($keys as $key) {
-      $arr[] = "$table.$key AS '$table.$key'";
+      $arr[] = "$table.$key AS " . $table . "_" . $key;
     }
     return implode(", ", $arr);
   }


### PR DESCRIPTION
Instead of doing `<table>.<column> AS '<table>.<column>'` for aliases (which is weird, but accepted by MySQL), this replaces it to use underscore (`<table>.<column> AS <table>_<column>`) to be a less "problematic" character for use without extra quotes and be less dependent on MySQL (e.g. because it then requires specific quoting with a dot in the alias).