### PR TITLE
Transaction start/commit cleanup in utils

### DIFF
--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -598,19 +598,8 @@ class HashlistUtils {
     switch ($hashlist->getFormat()) {
       case 0:
         $count = Factory::getHashlistFactory()->countFilter([]);
-        if ($count > 1) {
-          $deleted = 1;
-          $qF = new QueryFilter(Hash::HASHLIST_ID, $hashlist->getId(), "=");
-          $oF = new OrderFilter(Hash::HASH_ID, "ASC LIMIT 20000");
-          while ($deleted > 0) {
-            $result = Factory::getHashFactory()->massDeletion([Factory::FILTER => $qF, Factory::ORDER => $oF]);
-            $deleted = $result->rowCount();
-          }
-        }
-        else {
-          // in case there is only one hashlist to delete, truncate the Hash table.
-          Factory::getAgentFactory()->getDB()->query("TRUNCATE TABLE Hash");
-        }
+        $qF = new QueryFilter(Hash::HASHLIST_ID, $hashlist->getId(), "=");
+        Factory::getHashFactory()->massDeletion([Factory::FILTER => $qF]);
         break;
       case 1:
       case 2:


### PR DESCRIPTION
In hashlist deletion and creations there was a lot of trickery done with transactions in order to speed up db processes with larger hashlists. This was already done back then in hashtopus, but never was documented why exactly it was done like that and if it was really useful.

The drawback of this system was that it could cause hashlists half way created/deleted if there was some issue in between. Further, this also causes problems with consistency of transactions, e.g. if the TRUNCATE part was used (which could trigger an autocommit on certain systems as it is DDL).

Therefore, the complete intermediate transaction stuff is removed, wrapping the whole deletion and creation into one transaction to ensure consistency. Performance improvements may be gained by using a different DB system if operations are slow for large hashlists.