### PR TITLE
Force aggregation names to be lowercase always

### DIFF
--- a/src/dba/Aggregation.class.php
+++ b/src/dba/Aggregation.class.php
@@ -24,7 +24,7 @@ class Aggregation {
   }
   
   function getName() {
-    return strtolower($this->function) . "_" . $this->column;
+    return strtolower($this->function) . "_" . strtolower($this->column);
   }
   
   function getQueryString(AbstractModelFactory $factory, bool $includeTable = false) {


### PR DESCRIPTION
With mixed case, in postgres, these aggregations will not work as the returned column name is different.