### PR TITLE
Set batch size of inserts on hashlist creation to 5000

### DIFF
--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -879,7 +879,7 @@ class HashlistUtils {
             $preFound++;
           }
           $bufferCount++;
-          if ($bufferCount >= 10000) {
+          if ($bufferCount >= 5000) {
             $result = Factory::getHashFactory()->massSave($values);
             $added += $result->rowCount();
             $values = array();


### PR DESCRIPTION
With large hashlists it can happen that the number of parameters exceeds 65000, which causes an SQL error in postgres. The batch size is reduced to 5000 to avoid this being possible.