### PR TITLE
Made dockerfile smaller by using smaller slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM rust:1.91-trixie AS prebuild
+FROM rust:1.91-slim-trixie AS prebuild
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev
 
 RUN cargo install sqlx-cli --no-default-features --features native-tls,mysql,postgres
 


### PR DESCRIPTION
Since we only use the prebuilt image for compiling sqlx-cli, we can get away with a smaller image