### PR TITLE
Optimized check for already cracked hashes

### DIFF
--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -852,7 +852,7 @@ class HashlistUtils {
         $db = Factory::getAgentFactory()->getDB();
         $db->query(
           "CREATE TEMPORARY TABLE tmp_hashes (
-            hash VARCHAR(255)
+            hash VARCHAR(1024)
           ) ENGINE=InnoDB"
         );
 


### PR DESCRIPTION
The check, whether hashes from a new hashlist are already cracked in another list, got optimized.
Instead of searching each hashline in the database, the entire comparion got sourced out to the database.
A temporary table of the new hashes is created and via join cracked hashes will be determined.

This will speed up the comparison for lists of a bigger size.

I haven't done comprehensive performance tests, but with my hashtopolis hash table containing 10 million rows and a 500k lines hashfile, I achieved 40 seconds instead of 1 minute and 15 seconds.


