### PR TITLE
check if global constant needs to be defined or not

### DIFF
--- a/src/inc/startup/include.php
+++ b/src/inc/startup/include.php
@@ -3,7 +3,9 @@
 // set to 1 for debugging
 ini_set("display_errors", "0");
 
-define("APP_NAME", "Hashtopolis");
+if(!defined("APP_NAME")) {
+  define("APP_NAME", "Hashtopolis");
+}
 
 $baseDir = dirname(__FILE__) . "/..";
 


### PR DESCRIPTION
This gets rid of a warning message on the docker startup as the define gets called twice.