### PR TITLE
Add ELSE statement for integers to avoid casting issues

### DIFF
--- a/src/dba/AbstractModelFactory.class.php
+++ b/src/dba/AbstractModelFactory.class.php
@@ -841,12 +841,10 @@ abstract class AbstractModelFactory {
     
     $vals = array();
     
-    $integerValue = false;
     foreach ($updates as $update) {
       $query .= $update->getMassQuery(self::getMappedModelKey($this->getNullObject(),$matchingColumn));
       $vals[] = $update->getMatchValue();
       $vals[] = $update->getUpdateValue();
-      $integerValue = is_int($update->getUpdateValue);
     }
     
     $matchingArr = array();
@@ -858,7 +856,7 @@ abstract class AbstractModelFactory {
     // this covers the specific case when integer values are updated and the db system does not know what type the case statements would have
     // mysql does not really care, but postgres does
     // the trick we use here works for both systems (as opposed to cast it to int/bigint in postgres with ::bigint where we would need to branch based on the db)
-    if ($integerValue) {
+    if (is_int($updates[0]->getUpdateValue())) {
       $query .= " ELSE 2147483648 "; // 32 bit int max + 1
     }
     


### PR DESCRIPTION
A prepared statement like this
```
UPDATE table SET value = (CASE WHEN id=$1 THEN value=$2 WHEN id=$3 THEN value=$4 END) WHERE id IN ($1, $3);
```
does fail in postgres when the type of value is int/bigint as postgres is not able to determine the type of the value to be expected and throws a typing error.

There would be multiple ways to tell postgres that it's an integer, e.g. by casting the whole case statement like:
```
UPDATE table SET value = (CASE WHEN id=$1 THEN value=$2 WHEN id=$3 THEN value=$4 END)::bigint WHERE id IN ($1, $3);
```
The problem is, that this would not be compatible with mysql and we would have to build the query depending on the db system. 
Another option to tell the db what type the case values will have, is by providing an ELSE with a static integer. The problem is, that even if you provide `... ELSE 0.. `, postgres will only interpret it as integer, which will then again not work with a bigint column.

The trick which works is by setting the ELSE value to something bigger than 32bit max int. This way the db system is prepared to accept bigints (if there are), if the column is only integer, that is not a problem, as they way we build these `massSingleUpdate` statements, the ELSE clause never will be reached.
Both db systems (mysql and postgres), work with this ELSE (2^32) statement, with both int and bigint columns.