### PR TITLE
Catch a migration running error and prevent docker-entrypoint to continue further on failure

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -70,6 +70,11 @@ done
 # required to trigger the initialization
 echo "Start initialization process..."
 php -f ${HASHTOPOLIS_DOCUMENT_ROOT}/inc/startup/setup.php
+rc=$? # capture the status
+if (( rc != 0 )); then
+    echo "Hashtopolis setup.php failed (exit code $rc)" >&2
+    exit $rc # propagate the failure to stop docker continuing
+fi
 echo "Initialization complete!"
 
 

--- a/src/inc/startup/setup.php
+++ b/src/inc/startup/setup.php
@@ -54,10 +54,12 @@ if (!$initialSetup && StartupConfig::getInstance()->getDatabaseType() == "mysql"
   include(dirname(__FILE__) . "/../../install/updates/update.php");
 }
 
+$output = [];
 $database_uri = StartupConfig::getInstance()->getDatabaseType() . "://" . StartupConfig::getInstance()->getDatabaseUser() . ":" . StartupConfig::getInstance()->getDatabasePassword() . "@" . StartupConfig::getInstance()->getDatabaseServer() . ":" . StartupConfig::getInstance()->getDatabasePort() . "/" . StartupConfig::getInstance()->getDatabaseDB();
 exec('/usr/bin/sqlx migrate run --source ' . dirname(__FILE__) . '/../../migrations/' . StartupConfig::getInstance()->getDatabaseType() . '/ -D ' . $database_uri, $output, $retval);
 if ($retval !== 0) {
-  die("Failed to run migrations: \n" . implode("\n", $output));
+  echo "Failed to run migrations: \n" . implode("\n", $output);
+  exit(-1);
 }
 
 if ($initialSetup === true) {


### PR DESCRIPTION
This blocks the start of the Hashtopolis backend container in case there was an issue on a migration step. With this, we prevent that failed migrations may go unnoticed and/or can have unwanted side effects if the process just continues to start Hashtopolis.