### PR TITLE
Removed not working transaction for updating hash length

### DIFF
--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -1442,7 +1442,6 @@ class Util {
     }
     
     $DB = Factory::getAgentFactory()->getDB();
-    $DB->beginTransaction();
     $result = $DB->query("SELECT MAX(LENGTH(" . Hash::HASH . ")) as maxLength FROM " . Factory::getHashFactory()->getModelTable());
     $maxLength = $result->fetch()['maxLength'];
     if ($limit >= $maxLength) {
@@ -1457,7 +1456,6 @@ class Util {
     else {
       return false;
     }
-    $DB->commit();
     return true;
   }
   


### PR DESCRIPTION
In the update hash length function, a database transaction was made around an alter statement. This does not work, because a DDL statement cause an implicit commit (https://dev.mysql.com/doc/refman/8.4/en/implicit-commit.html), thus when our commit statement is reached, there is no transaction anymore, resulting in an error.

closes #1626 