### PR TITLE
Fixed bug in content length calculation

### DIFF
--- a/src/api/v2/index.php
+++ b/src/api/v2/index.php
@@ -170,11 +170,11 @@ $app->add(new JsonBodyParserMiddleware());
 $app->add("HttpBasicAuthentication");
 $app->add("JwtAuthentication");
 $app->add(new TokenAsParameterMiddleware());
-$app->add(new ContentLengthMiddleware());       // NOTE: Add any middleware which may modify the response body before adding the ContentLengthMiddleware
 $app->add((new DeflateEncoder())->contentType(
   '/^(image\/svg\\+xml|text\/.*|application\/json|"application\/vnd\.api+json)(;.*)?$/'
 )
 );
+$app->add(new ContentLengthMiddleware());       // NOTE: Add any middleware which may modify the response body before adding the ContentLengthMiddleware
 
 $app->add(new CorsHackMiddleware());            // NOTE: The RoutingMiddleware should be added after our CORS middleware so routing is performed first
 // NOTE: The ErrorMiddleware should be added after any middleware which may modify the response body

--- a/src/inc/apiv2/common/openAPISchema.routes.php
+++ b/src/inc/apiv2/common/openAPISchema.routes.php
@@ -949,7 +949,7 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
     ];
     
     $body = $response->getBody();
-    $body->write(json_encode($result, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+    $body->write(json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
     
     return $response->withStatus(200)
       ->withHeader("Content-Type", "application/json");


### PR DESCRIPTION
In the backend, the content length was generated before compressing the payload. The reult was for big files like the openapi.json is that the content length would be too big, making the server time out waiting for data it wont receive