### PR TITLE
Parse comma in filter

### DIFF
--- a/src/dba/PaginationFilter.php
+++ b/src/dba/PaginationFilter.php
@@ -40,8 +40,8 @@ class PaginationFilter extends Filter {
     //ex. SELECT hashTypeId, description, isSalted, isSlowHash FROM HashType 
     //    where (HashType.isSalted < 1) OR (HashType.isSalted = 1 and HashType.hashTypeId < 12600) 
     //    ORDER BY HashType.isSalted DESC, HashType.hashTypeId DESC LIMIT 25;
-    $queryString = "(" . $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->key) . $this->operator . "?" . ") OR (" . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->key) . "=" . "?"
-      . " AND " . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->tieBreakerKey) . $this->operator . "?";
+    $queryString = "(" . $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->key) . $this->operator . "?" . ") OR (" . $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->key) . "=" . "?"
+      . " AND " . $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->tieBreakerKey) . $this->operator . "?";
     if (count($this->filters) > 0) {
       $queryString = $queryString . " AND " . implode(" AND ", $parts);
     }

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -1150,7 +1150,11 @@ abstract class AbstractBaseAPI {
         throw new HttpForbidden("Filter parameter '" . $filter . "' is not valid (key not valid field)");
       };
       
-      $valueList = explode(",", $value);
+      // Only __in and __nin support comma-separated multiple values;
+      // all other operators treat the value as a literal string.
+      $operator = $matches['operator'];
+      $isListOperator = in_array($operator, ['__in', '__nin']);
+      $valueList = $isListOperator ? explode(",", $value) : [$value];
       
       // TODO Merge/Combine with validate parameters 
       foreach ($valueList as &$value) {
@@ -1178,7 +1182,6 @@ abstract class AbstractBaseAPI {
       
       $amount_values = count($valueList);
       $single_val = $valueList[0];
-      $operator = $matches['operator'];
       $query_operator = "";
       switch (true) {
         case (($operator == '__eq' | $operator == '') && $amount_values == 1):


### PR DESCRIPTION
This pull request fixes 2 things: it solves that filters that allow only 1 value to contain ','. And it fixes a  bug in pagination for tasks because the pagination filter did not use the $factory for the table correctly. Which resulted in an error for the task table because of ambigious column.

closes #1978 