### PR TITLE
Moved display error handling to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN yes | pecl install xdebug && docker-php-ext-enable xdebug \
     \
     # Configuring PHP \
     && touch "/usr/local/etc/php/conf.d/custom.ini" \
-	&& echo "display_errors = on" >> /usr/local/etc/php/conf.d/custom.ini \
+	&& echo "display_errors = 1" >> /usr/local/etc/php/conf.d/custom.ini \
 	&& echo "memory_limit = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
 	&& echo "upload_max_filesize = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
 	&& echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini \
@@ -163,7 +163,8 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
     && touch "/usr/local/etc/php/conf.d/custom.ini" \
     && echo "memory_limit = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
     && echo "upload_max_filesize = 256m" >> /usr/local/etc/php/conf.d/custom.ini \
-    && echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini
+    && echo "max_execution_time = 60" >> /usr/local/etc/php/conf.d/custom.ini \
+    && echo "display_errors = 0" >> /usr/local/etc/php/conf.d/custom.ini
 
 USER www-data
 # ----END----

--- a/ci/server/setup.php
+++ b/ci/server/setup.php
@@ -38,7 +38,3 @@ catch (PDOException $e) {
   fwrite(STDERR, "Failed to initialize database: " . $e->getMessage());
   exit(-1);
 }
-
-$load = file_get_contents($envPath . "src/inc/startup/load.php");
-$load = str_replace('ini_set("display_errors", "0");', 'ini_set("display_errors", "1");', $load);
-file_put_contents($envPath . "src/inc/startup/load.php", $load);

--- a/doc/faq_tips/faq.md
+++ b/doc/faq_tips/faq.md
@@ -303,7 +303,7 @@ If there is enough RAM available, it is possible to raise PHP's memory limit in 
 1. **Create a file `custom.ini` next to your `docker-compose.yml`**
 
     Adjust your desired memory limit (`M` for Megabytes, or `G` for Gigabytes).
-    The other two values are optional to adjust, but need to remain in there, as otherwise they are overwritten with the new `custom.ini` not containing them.
+    The other three values are optional to adjust, but need to remain in there, as otherwise they are overwritten with the new `custom.ini` not containing them.
 
 
 ```ini
@@ -311,6 +311,7 @@ If there is enough RAM available, it is possible to raise PHP's memory limit in 
 memory_limit = 256M
 upload_max_filesize = 256M
 max_execution_time = 60
+display_errors = 0
 ```
 
 

--- a/src/api/v2/index.php
+++ b/src/api/v2/index.php
@@ -8,7 +8,7 @@ if (!$enabled || $enabled == 'false') {
 
 date_default_timezone_set("UTC");
 error_reporting(E_ALL ^ E_DEPRECATED);
-ini_set("display_errors", '1');
+
 /**
  * Treat warnings as error, very useful during unit testing.
  * TODO: How-ever during Xdebug debugging under VS Code, this is very

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -1371,9 +1371,12 @@ class Util {
     $htmlMessage .= $text;
     $htmlMessage .= "\r\n\r\n--" . $boundary . "--";
     
+    set_error_handler(function() { error_log("Error sending mail"); });
     if (!mail($address, $subject, $plainMessage . $htmlMessage, $headers)) {
+      restore_error_handler();
       return false;
     }
+    restore_error_handler();
     return true;
   }
   

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -1371,12 +1371,9 @@ class Util {
     $htmlMessage .= $text;
     $htmlMessage .= "\r\n\r\n--" . $boundary . "--";
     
-    set_error_handler(function() { error_log("Error sending mail"); });
     if (!mail($address, $subject, $plainMessage . $htmlMessage, $headers)) {
-      restore_error_handler();
       return false;
     }
-    restore_error_handler();
     return true;
   }
   

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -740,7 +740,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
       $primary_cursor_key = key($primary_cursor);
       // Special filtering of id to use for uniform access to model primary key
       $primary_cursor_key = $primary_cursor_key == 'id' ? array_column($aliasedfeatures, 'alias', 'dbname')[$apiClass->getPrimaryKey()] : $primary_cursor_key;
-      $secondary_cursor = $decoded_cursor["secondary"];
+      $secondary_cursor = array_key_exists("secondary", $decoded_cursor) ? $decoded_cursor["secondary"] : null;
       if ($secondary_cursor) {
         $secondary_cursor_key = key($secondary_cursor);
         $secondary_cursor_key = $secondary_cursor_key == '_id' ? array_column($aliasedfeatures, 'alias', 'dbname')[$apiClass->getPrimaryKey()] : $secondary_cursor_key;

--- a/src/inc/startup/include.php
+++ b/src/inc/startup/include.php
@@ -1,9 +1,6 @@
 <?php
 
-// set to 1 for debugging
 use Hashtopolis\inc\Lang;
-
-ini_set("display_errors", "0");
 
 define("APP_NAME", "Hashtopolis");
 

--- a/src/inc/startup/load.php
+++ b/src/inc/startup/load.php
@@ -1,6 +1,5 @@
 <?php
 
-// set to 1 for debugging
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\CSRF;
 use Hashtopolis\inc\Login;
@@ -10,8 +9,6 @@ use Hashtopolis\inc\StartupConfig;
 use Hashtopolis\inc\UI;
 use Hashtopolis\inc\Util;
 use Hashtopolis\inc\utils\AccessControl;
-
-ini_set("display_errors", "0");
 
 session_start();
 

--- a/src/inc/startup/setup.php
+++ b/src/inc/startup/setup.php
@@ -15,9 +15,6 @@ use Hashtopolis\inc\StartupConfig;
 use Hashtopolis\inc\Util;
 use Hashtopolis\inc\utils\AccessUtils;
 
-// set to 1 for debugging
-ini_set("display_errors", "0");
-
 session_start();
 
 require_once(dirname(__FILE__) . "/include.php");


### PR DESCRIPTION
Related to issue #1251

Only the necessary exception details are already shown (e.g. filename and line number are omitted), but I noticed that the PHP display_errors option is scattered across several files:
Dockerfile:	&& echo "display_errors = on" >> /usr/local/etc/php/conf.d/custom.ini \
ci/server/setup.php:$load = str_replace('ini_set("display_errors", "0");', 'ini_set("display_errors", "1");', $load);
src/inc/startup/include.php:ini_set("display_errors", "0");
src/inc/startup/setup.php:ini_set("display_errors", "0");
src/inc/startup/load.php:ini_set("display_errors", "0");
src/api/v2/index.php:ini_set("display_errors", '1');

Changing the value in only one file may not have the desired effect. So I moved the handling to the ./Dockerfile where it's 1 by default for dev and 0 by default for prod.