### PR TITLE
Updated nginx docs to recent syntax and status code 308 for redirect

### DIFF
--- a/doc/installation_guidelines/tls.md
+++ b/doc/installation_guidelines/tls.md
@@ -55,12 +55,13 @@ http {
     server {
         listen 80;
         server_name localhost;
-        return 301 https://$host$request_uri;
+        return 308 https://$host$request_uri;
     }
 
     server {
         client_max_body_size 2G;
-        listen 443 ssl http2;
+        listen 443 ssl;
+        http2 on;
         server_name localhost;
 
         ssl_certificate /etc/nginx/ssl/nginx.crt;


### PR DESCRIPTION
Updated docs for tls setup with nginx:

-Updated redirect status code to 308 (moved permanently) which makes more sense and is also needed to be able to redirect POST requests, which the agents need to work. 
-Updated the http2 syntax from deprecated syntax to new syntax