### PR TITLE
1973 bug edit superhashlist bug in hashlist datasource

### DIFF
--- a/ci/apiv2/test_hashlist.py
+++ b/ci/apiv2/test_hashlist.py
@@ -1,4 +1,6 @@
-from hashtopolis import Hashlist, Helper, File
+import requests
+
+from hashtopolis import Hashlist, Helper, File, HashtopolisConnector, HashtopolisConfig
 from utils import BaseTest
 
 
@@ -158,3 +160,27 @@ class HashlistTest(BaseTest):
     def test_bulk_delete(self):
         hashlists = [self.create_test_object(delete=False) for i in range(5)]
         Hashlist.objects.delete_many(hashlists)
+
+    def test_superhashlist_edit_returns_meta_page_total_elements(self):
+        hashlist1 = self.create_test_object()
+        hashlist2 = self.create_test_object()
+
+        helper = Helper()
+        superhashlist = helper.create_superhashlist(
+            name="SuperhashList edit test",
+            hashlists=[hashlist1, hashlist2]
+        )
+        self.delete_after_test(superhashlist)
+
+        config = HashtopolisConfig()
+        connector = HashtopolisConnector('/ui/hashlists',config)
+        connector.authenticate()
+
+        uri = connector._api_endpoint + connector._model_uri + f'/{superhashlist.id}?include=hashlists,hashType'
+        req = requests.get(uri, headers=connector._headers)
+        response = req.json()
+
+        self.assertIn('meta', response)
+        self.assertIn('page', response['meta'])
+        self.assertIn('total_elements', response['meta']['page'])
+        self.assertEqual(response['meta']['page']['total_elements'], 2)

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -1659,6 +1659,24 @@ abstract class AbstractBaseAPI {
     $links = ["self" => $linksSelf];
     
     $metaData = [];
+
+    $toManyRelations = $apiClass::getToManyRelationships();
+    $hasToManyExpand = false;
+    $totalExpanded = 0;
+    foreach ($expands as $expand) {
+      if (array_key_exists($expand, $toManyRelations)) {
+        $hasToManyExpand = true;
+        if (isset($expandResult[$expand])) {
+          foreach ($expandResult[$expand] as $objectList) {
+            $totalExpanded += count($objectList);
+          }
+        }
+      }
+    }
+    if ($hasToManyExpand) {
+      $metaData["page"] = ["total_elements" => $totalExpanded];
+    }
+
     if ($apiClass->permissionErrors !== null) {
       $metaData["Include errors"] = $apiClass->permissionErrors;
     }


### PR DESCRIPTION
## Summary
Fix missing meta.page.total_elements in getOneResource for to-many includes.

Frontend got a TypeError when editing a superhashlist because
response.meta.page.total_elements was undefined in the API response.

## Changes
- AbstractBaseAPI.php: getOneResource now returns meta.page.total_elements
  when the request includes a to-many relationship (e.g. include=hashlists)

## Known limitation
The current implementation counts total expanded objects across all to-many
relationships in a single value. This works correctly today because no
endpoint includes multiple to-many relationships simultaneously. If that
changes in the future, total_elements may return an incorrect combined count
and will need to be revisited.

## Test
Added test_superhashlist_edit_returns_meta_page_total_elements in
test_hashlist.py to verify that meta.page.total_elements is returned
correctly when fetching a superhashlist with include=hashlists.

The test makes a direct HTTP request instead of using the hashtopolis
Python library, because the library only returns the deserialized data
object (response['data']) and discards the meta field. By using
requests.get() directly we get the raw JSON:API response and can assert
that meta.page.total_elements exists and has the correct value.