### PR TITLE
Removed isChunkingAvilable references

### DIFF
--- a/doc/user_manual/crackers_binary.md
+++ b/doc/user_manual/crackers_binary.md
@@ -16,7 +16,7 @@ This page displays some basic information about all the crackers configured in h
 
 As mentioned above, Hashtopolis supports other crackers than Hashcat. To deploy a new cracker, two steps are required, first the creation of the type of cracker and then adding a version for it. 
 
-By clicking on the ``*New Cracker*'' button, a new page opens in which you can set the name for the new cracker and declare if the chunking is available for this cracker. In order to be compatible with chunking, a cracker must have the following features:
+By clicking on the ``*New Cracker*'' button, a new page opens in which you can set the name for the new cracker. <!-- and declare if the chunking is available for this cracker. In order to be compatible with chunking, a cracker must have the following features:--> A cracker must have the following features in order to split the work into chunks:
 
 - **--keyspace**: calculate the size of the task to be distributed.
 - **--skip**: define the starting point from where the hashcat instance should start working on the keyspace.
@@ -24,7 +24,8 @@ By clicking on the ``*New Cracker*'' button, a new page opens in which you can s
 
 In other words, the keyspace is the total amount of work related to a task. The combination of skip and limit will define a portion of the keyspace, also called chunk, on wich an agent will be working. That is the main features required to distribute a task among the several agents.
 
-If chunking is not available for a cracker, then a task cannot be split and it must be run by a single agent. WHen selecting such type of cracker during the task creation, the ["small task"](./tasks.md#advanced-parameters) flag will be enabled by default. 
+<!-- If chunking is not available for a cracker, then a task cannot be split and it must be run by a single agent. When selecting such type of cracker during the task creation, the ["small task"](./tasks.md#advanced-parameters) flag will be enabled by default. 
+-->
 
 > [!CAUTION]
 > Creating a new type of cracker is not a simple plug-and-play process with Hashtopolis. In addition to defining the new cracker type, you must also modify the agent itself. Specifically, this involves writing a dedicated Python handler file for your cracker.

--- a/src/dba/models/CrackerBinaryType.php
+++ b/src/dba/models/CrackerBinaryType.php
@@ -28,7 +28,7 @@ class CrackerBinaryType extends AbstractModel {
     $dict = array();
     $dict['crackerBinaryTypeId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => True, "protected" => True, "private" => False, "alias" => "crackerBinaryTypeId", "public" => False, "dba_mapping" => False];
     $dict['typeName'] = ['read_only' => False, "type" => "str(30)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "typeName", "public" => False, "dba_mapping" => False];
-    $dict['isChunkingAvailable'] = ['read_only' => False, "type" => "bool", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "isChunkingAvailable", "public" => False, "dba_mapping" => False];
+    $dict['isChunkingAvailable'] = ['read_only' => False, "type" => "bool", "subtype" => "unset", "choices" => "unset", "null" => True, "pk" => False, "protected" => False, "private" => False, "alias" => "isChunkingAvailable", "public" => False, "dba_mapping" => False];
 
     return $dict;
   }

--- a/src/inc/apiv2/model/CrackerBinaryTypeAPI.php
+++ b/src/inc/apiv2/model/CrackerBinaryTypeAPI.php
@@ -43,7 +43,7 @@ class CrackerBinaryTypeAPI extends AbstractModelAPI {
   function getAllPostParameters(array $features): array {
     
     //for documentation purposes isChunkingAvailable has to be removed
-    // because it is currently not settable by the user
+    // because it is currently not settable by the user and not fully supported yet
     $features = parent::getAllPostParameters($features);
     unset($features[CrackerBinaryType::IS_CHUNKING_AVAILABLE]);
     return $features;


### PR DESCRIPTION
isChunkingAvilable is not required anymore for crackertypes because Hashtopolis currently only supports crackers which support chunking. In the UI the options to set that value have been removed as well.

[The api docs](https://docs.hashtopolis.org/api/#tag/CrackerBinaryTypes/paths/~1api~1v2~1ui~1crackertypes/post) already list typeName as the only required value.

This closes issue #1342 