### PR TITLE
fix: resolve task sorting error by mapping displayName alias to taskWrapperName

### DIFF
--- a/src/dba/models/TaskWrapper.class.php
+++ b/src/dba/models/TaskWrapper.class.php
@@ -48,7 +48,7 @@ class TaskWrapper extends AbstractModel {
     $dict['taskType'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => [0 => "TaskType is Task", 1 => "TaskType is Supertask", ], "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "taskType"];
     $dict['hashlistId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "hashlistId"];
     $dict['accessGroupId'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "accessGroupId"];
-    $dict['taskWrapperName'] = ['read_only' => False, "type" => "str(100)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "taskWrapperName"];
+    $dict['taskWrapperName'] = ['read_only' => False, "type" => "str(100)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "displayName"];
     $dict['isArchived'] = ['read_only' => False, "type" => "bool", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "isArchived"];
     $dict['cracked'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "cracked"];
 


### PR DESCRIPTION
The task overview page was failing to sort by name because the frontend sends `displayName` as the sorting parameter, but the backend expected `taskWrapperName`.

This PR updates the `TaskWrapper` model to map the `displayName` alias to the `taskWrapperName` column. This ensures that the backend's dynamic filtering engine can correctly translate the sorting request into the appropriate database query.