### PR TITLE
Access groups also should be enforced on admin permissions

### DIFF
--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -622,17 +622,14 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     /* Generate filters */
     $filters = $apiClass->getFilters($request);
     $qFs_Filter = $apiClass->makeFilter($filters, $apiClass, $joinFilters);
-    $group = Factory::getRightGroupFactory()->get($apiClass->getCurrentUser()->getRightGroupId());
-    if ($group->getPermissions() !== 'ALL') { // Only add permission filters when no admin user
-      $aFs_ACL = $apiClass->getFilterACL();
-      if (isset($aFs_ACL[Factory::FILTER])) {
-        $qFs_Filter = array_merge($aFs_ACL[Factory::FILTER], $qFs_Filter);
-      }
-      if (isset($aFs_ACL[Factory::JOIN])) {
-        foreach($aFs_ACL[Factory::JOIN] as $filter) {
-          if(!$apiClass::checkJoinExists($joinFilters, $filter->getOtherFactory()->getModelName())) {
-            $joinFilters[] = $filter;
-          }
+    $aFs_ACL = $apiClass->getFilterACL();
+    if (isset($aFs_ACL[Factory::FILTER])) {
+      $qFs_Filter = array_merge($aFs_ACL[Factory::FILTER], $qFs_Filter);
+    }
+    if (isset($aFs_ACL[Factory::JOIN])) {
+      foreach($aFs_ACL[Factory::JOIN] as $filter) {
+        if(!$apiClass::checkJoinExists($joinFilters, $filter->getOtherFactory()->getModelName())) {
+          $joinFilters[] = $filter;
         }
       }
     }


### PR DESCRIPTION
Even an admin which has permissions to do all actions still should only see the objects from the access groups he is in.

Of course he could add himself to other access groups to see the objects then, but for example if he is not part of some access groups to not get his stuff cluttered with other stuff, this feature is needed.

And this way it was done on the current frontend as well.