### PR TITLE
Fix/handle both exceptions and errors

### DIFF
--- a/src/inc/handlers/AccessControlHandler.php
+++ b/src/inc/handlers/AccessControlHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AccessControlUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DAccessControlAction;
 use Hashtopolis\inc\UI;
 
@@ -37,7 +37,7 @@ class AccessControlHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/AccessGroupHandler.php
+++ b/src/inc/handlers/AccessGroupHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AccessGroupUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DAccessGroupAction;
 use Hashtopolis\inc\UI;
 
@@ -46,7 +46,7 @@ class AccessGroupHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/AccountHandler.php
+++ b/src/inc/handlers/AccountHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AccountUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\defines\DAccountAction;
 use Hashtopolis\inc\Login;
@@ -78,7 +78,7 @@ class AccountHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
     

--- a/src/inc/handlers/AgentBinaryHandler.php
+++ b/src/inc/handlers/AgentBinaryHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AgentBinaryUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DAgentBinaryAction;
 use Hashtopolis\inc\Login;
 use Hashtopolis\inc\UI;
@@ -52,7 +52,7 @@ class AgentBinaryHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/AgentHandler.php
+++ b/src/inc/handlers/AgentHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AgentUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\defines\DAgentAction;
 use Hashtopolis\inc\HTException;
@@ -104,7 +104,7 @@ class AgentHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/ApiHandler.php
+++ b/src/inc/handlers/ApiHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\ApiUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DApiAction;
 use Hashtopolis\inc\UI;
 
@@ -46,7 +46,7 @@ class ApiHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/ConfigHandler.php
+++ b/src/inc/handlers/ConfigHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\ConfigUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DConfigAction;
 use Hashtopolis\inc\Login;
 use Hashtopolis\inc\UI;
@@ -41,7 +41,7 @@ class ConfigHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/CrackerHandler.php
+++ b/src/inc/handlers/CrackerHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\CrackerUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DCrackerBinaryAction;
 use Hashtopolis\inc\UI;
 
@@ -45,7 +45,7 @@ class CrackerHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/FileHandler.php
+++ b/src/inc/handlers/FileHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\FileUtils;
 use Hashtopolis\inc\defines\DFileAction;
 use Hashtopolis\inc\UI;
@@ -45,7 +45,7 @@ class FileHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/ForgotHandler.php
+++ b/src/inc/handlers/ForgotHandler.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\handlers;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DForgotAction;
 use Hashtopolis\inc\UI;
 use Hashtopolis\inc\utils\UserUtils;
@@ -24,7 +24,7 @@ class ForgotHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/HashlistHandler.php
+++ b/src/inc/handlers/HashlistHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\DataSet;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\models\Hashlist;
 use Hashtopolis\dba\Factory;
@@ -130,7 +130,7 @@ class HashlistHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/HashtypeHandler.php
+++ b/src/inc/handlers/HashtypeHandler.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\handlers;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DHashtypeAction;
 use Hashtopolis\inc\utils\HashtypeUtils;
 use Hashtopolis\inc\Login;
@@ -29,7 +29,7 @@ class HashtypeHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/HealthHandler.php
+++ b/src/inc/handlers/HealthHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DHealthCheckAction;
 use Hashtopolis\inc\utils\HealthUtils;
 use Hashtopolis\inc\HTException;
@@ -33,7 +33,7 @@ class HealthHandler implements Handler {
           throw new HTException("Invalid action!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/NotificationHandler.php
+++ b/src/inc/handlers/NotificationHandler.php
@@ -5,7 +5,6 @@ namespace Hashtopolis\inc\handlers;
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\DataSet;
-use Exception;
 use Hashtopolis\dba\models\NotificationSetting;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\Factory;
@@ -48,7 +47,7 @@ class NotificationHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/PreprocessorHandler.php
+++ b/src/inc/handlers/PreprocessorHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DPreprocessorAction;
 use Hashtopolis\inc\utils\PreprocessorUtils;
 use Hashtopolis\inc\UI;
@@ -36,7 +36,7 @@ class PreprocessorHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/PretaskHandler.php
+++ b/src/inc/handlers/PretaskHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DPretaskAction;
 use Hashtopolis\inc\utils\PretaskUtils;
 use Hashtopolis\inc\UI;
@@ -71,7 +71,7 @@ class PretaskHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/SearchHandler.php
+++ b/src/inc/handlers/SearchHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\DataSet;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\models\Hash;
@@ -36,7 +36,7 @@ class SearchHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/SupertaskHandler.php
+++ b/src/inc/handlers/SupertaskHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DSupertaskAction;
 use Hashtopolis\inc\Login;
 use Hashtopolis\inc\utils\SupertaskUtils;
@@ -51,7 +51,7 @@ class SupertaskHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/TaskHandler.php
+++ b/src/inc/handlers/TaskHandler.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\DataSet;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\FileDownloadUtils;
 use Hashtopolis\dba\models\AccessGroupUser;
 use Hashtopolis\dba\models\FileTask;
@@ -150,7 +150,7 @@ class TaskHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/handlers/UsersHandler.php
+++ b/src/inc/handlers/UsersHandler.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\handlers;
 
 use Hashtopolis\inc\utils\AccessControl;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\DUserAction;
 use Hashtopolis\inc\Login;
 use Hashtopolis\inc\UI;
@@ -52,7 +52,7 @@ class UsersHandler implements Handler {
           break;
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       UI::addMessage(UI::ERROR, $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIAccess.php
+++ b/src/inc/user_api/UserAPIAccess.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\AccessControlUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\apiv2\common\error\HttpConflict;
 use Hashtopolis\inc\apiv2\common\error\HttpError;
 use Hashtopolis\inc\defines\UQuery;
@@ -38,7 +38,7 @@ class UserAPIAccess extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIAccount.php
+++ b/src/inc/user_api/UserAPIAccount.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\AccountUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\UQuery;
 use Hashtopolis\inc\defines\UQueryAccount;
 use Hashtopolis\inc\defines\UQueryTask;
@@ -33,7 +33,7 @@ class UserAPIAccount extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIAgent.php
+++ b/src/inc/user_api/UserAPIAgent.php
@@ -4,7 +4,7 @@ namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\AgentUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\models\AccessGroupAgent;
@@ -72,7 +72,7 @@ class UserAPIAgent extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQuery::SECTION], $QUERY[UQuery::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIConfig.php
+++ b/src/inc/user_api/UserAPIConfig.php
@@ -4,6 +4,7 @@ namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\ConfigUtils;
 use Exception;
+use Throwable;
 use Hashtopolis\dba\models\Config;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DConfigType;
@@ -36,7 +37,7 @@ class UserAPIConfig extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPICracker.php
+++ b/src/inc/user_api/UserAPICracker.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\CrackerUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\UQuery;
 use Hashtopolis\inc\defines\UQueryCracker;
 use Hashtopolis\inc\defines\UQueryTask;
@@ -41,7 +41,7 @@ class UserAPICracker extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIFile.php
+++ b/src/inc/user_api/UserAPIFile.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\user_api;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\FileUtils;
 use Hashtopolis\inc\defines\DFileType;
 use Hashtopolis\inc\defines\UQuery;
@@ -42,7 +42,7 @@ class UserAPIFile extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIGroup.php
+++ b/src/inc/user_api/UserAPIGroup.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\AccessGroupUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\UQuery;
 use Hashtopolis\inc\defines\UQueryGroup;
 use Hashtopolis\inc\defines\UQueryTask;
@@ -47,7 +47,7 @@ class UserAPIGroup extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIHashlist.php
+++ b/src/inc/user_api/UserAPIHashlist.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\user_api;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\inc\defines\DHashlistFormat;
@@ -61,7 +61,7 @@ class UserAPIHashlist extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIPretask.php
+++ b/src/inc/user_api/UserAPIPretask.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\user_api;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\UQuery;
 use Hashtopolis\inc\defines\UQueryTask;
 use Hashtopolis\inc\defines\UResponseTask;
@@ -53,7 +53,7 @@ class UserAPIPretask extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPISuperhashlist.php
+++ b/src/inc/user_api/UserAPISuperhashlist.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\AccessUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\inc\defines\DHashlistFormat;
 use Hashtopolis\inc\defines\UQuery;
@@ -36,7 +36,7 @@ class UserAPISuperhashlist extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPISupertask.php
+++ b/src/inc/user_api/UserAPISupertask.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\user_api;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\UQuery;
 use Hashtopolis\inc\defines\UQueryTask;
 use Hashtopolis\inc\defines\UResponseTask;
@@ -40,7 +40,7 @@ class UserAPISupertask extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPITask.php
+++ b/src/inc/user_api/UserAPITask.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\user_api;
 
 use Hashtopolis\inc\utils\AgentUtils;
-use Exception;
+use Throwable;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DTaskTypes;
@@ -105,7 +105,7 @@ class UserAPITask extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }

--- a/src/inc/user_api/UserAPIUser.php
+++ b/src/inc/user_api/UserAPIUser.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\user_api;
 
-use Exception;
+use Throwable;
 use Hashtopolis\inc\defines\UQuery;
 use Hashtopolis\inc\defines\UQueryTask;
 use Hashtopolis\inc\defines\UQueryUser;
@@ -41,7 +41,7 @@ class UserAPIUser extends UserAPIBasic {
           $this->sendErrorResponse($QUERY[UQuery::SECTION], "INV", "Invalid section request!");
       }
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       $this->sendErrorResponse($QUERY[UQueryTask::SECTION], $QUERY[UQueryTask::REQUEST], $e->getMessage());
     }
   }


### PR DESCRIPTION
As we introduce typing in function signatures we can get `TypeError` throws where we earlier got regular exceptions, by substitue the error handling to `Throwable` we preserve the current error handling towards web ui.

- All handlers in src/inc/handlers do handle `Throwable` instead of `Exception`
- All APIBasic implementations in src/inc/api do handle `Throwable` instead of `Exception`
