### PR TITLE
Correctly use task object to aggregate task information

### DIFF
--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -93,21 +93,23 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
       }
 
       $aggregatedData['status'] = $status;
-
-      $keyspace = $object->getKeyspace();
-      $keyspaceProgress = $object->getKeyspaceProgress();
       
       if ($object->getTaskType() === DTaskTypes::NORMAL) {
+        $task = $tasks[0];
+        
+        $keyspace = $task->getKeyspace();
+        $keyspaceProgress = $task->getKeyspaceProgress();
+        
         if (is_null($aggregateFieldsets) || in_array("dispatched", $aggregateFieldsets['taskwrapperdisplay'])) {
             $aggregatedData["dispatched"] = Util::showperc($keyspaceProgress, $keyspace);
-          }
+        }
         
         if (is_null($aggregateFieldsets) || in_array("searched", $aggregateFieldsets['taskwrapperdisplay'])) {
-          $aggregatedData["searched"] = Util::showperc(TaskUtils::getTaskProgress($object), $keyspace);
+          $aggregatedData["searched"] = Util::showperc(TaskUtils::getTaskProgress($task), $keyspace);
         }
 
         if (!isset($chunks)){
-          $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
+          $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
           $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
         }
         
@@ -137,7 +139,6 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
             }
           }
 
-          $keyspace = $object->getKeyspace();
           $estimatedTime = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
           $aggregatedData["estimatedTime"] = $estimatedTime;
           $aggregatedData["timeSpent"] = $timeSpent;
@@ -146,7 +147,7 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
 
           $assignedAgents = [];
           if (is_null($aggregateFieldsets) || in_array("assignedAgents", $aggregateFieldsets['task'])) {
-            $qF = new QueryFilter(Assignment::TASK_ID, $object->getTaskId(), "=");
+            $qF = new QueryFilter(Assignment::TASK_ID, $task->getId(), "=");
             $assignedAgents = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);
             $aggregatedData["totalAssignedAgents"] = $assignedAgents;
           }

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -94,11 +94,11 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
 
       $aggregatedData['status'] = $status;
       
+      $keyspace = $object->getKeyspace();
+      $keyspaceProgress = $object->getKeyspaceProgress();
+      
       if ($object->getTaskType() === DTaskTypes::NORMAL) {
         $task = $tasks[0];
-        
-        $keyspace = $task->getKeyspace();
-        $keyspaceProgress = $task->getKeyspaceProgress();
         
         if (is_null($aggregateFieldsets) || in_array("dispatched", $aggregateFieldsets['taskwrapperdisplay'])) {
             $aggregatedData["dispatched"] = Util::showperc($keyspaceProgress, $keyspace);


### PR DESCRIPTION
For the aggregations instead of the task ID, the taskwrapper ID was used, causing wrong values for the resulting data.