### PR TITLE
fix: URL-encode and shell-escape sqlx migration DSN

### DIFF
--- a/src/inc/startup/setup.php
+++ b/src/inc/startup/setup.php
@@ -52,8 +52,8 @@ if (!$initialSetup && StartupConfig::getInstance()->getDatabaseType() == "mysql"
 }
 
 $output = [];
-$database_uri = StartupConfig::getInstance()->getDatabaseType() . "://" . StartupConfig::getInstance()->getDatabaseUser() . ":" . StartupConfig::getInstance()->getDatabasePassword() . "@" . StartupConfig::getInstance()->getDatabaseServer() . ":" . StartupConfig::getInstance()->getDatabasePort() . "/" . StartupConfig::getInstance()->getDatabaseDB();
-exec('/usr/bin/sqlx migrate run --source ' . dirname(__FILE__) . '/../../migrations/' . StartupConfig::getInstance()->getDatabaseType() . '/ -D ' . $database_uri, $output, $retval);
+$database_uri = StartupConfig::getInstance()->getDatabaseType() . "://" . rawurlencode(StartupConfig::getInstance()->getDatabaseUser()) . ":" . rawurlencode(StartupConfig::getInstance()->getDatabasePassword()) . "@" . StartupConfig::getInstance()->getDatabaseServer() . ":" . StartupConfig::getInstance()->getDatabasePort() . "/" . StartupConfig::getInstance()->getDatabaseDB();
+exec('/usr/bin/sqlx migrate run --source ' . escapeshellarg(dirname(__FILE__) . '/../../migrations/' . StartupConfig::getInstance()->getDatabaseType() . '/') . ' -D ' . escapeshellarg($database_uri), $output, $retval);
 if ($retval !== 0) {
   echo "Failed to run migrations: \n" . implode("\n", $output);
   exit(-1);


### PR DESCRIPTION
## Problem

In `src/inc/startup/setup.php` the sqlx migration DSN is built by string concatenation and passed **unquoted** and **non-URL-encoded** straight into `exec('/usr/bin/sqlx migrate run ... -D ' . $database_uri)`.

This breaks server startup whenever the database username or password contains:

- URL-special characters (`@ : / # ? [ ]`) — they corrupt the DSN that `sqlx` parses (e.g. an `@` in the password is read as the userinfo/host separator).
- shell-special characters (`$ & ; | < > ( ) *`, space, backtick, etc.) — `sh -c` interprets them before `sqlx` ever runs (e.g. `&` backgrounds the truncated command and splits the DSN).

Hit in production with an auto-generated DB password containing `$` and `&`:

```
Start initialization process...
sh: 1: @<db-host>:3306/<db>: not found
Failed to run migrations:
error: error with configuration: invalid port number
Hashtopolis setup.php failed (exit code 255)
```

This affects both the mysql and postgres DSNs (same construction).

## Fix

Two small, independent hardening changes:

1. `rawurlencode()` the userinfo (username + password) components of the DSN so URL-special characters survive parsing.
2. `escapeshellarg()` the arguments passed to `exec()` (the migrations `--source` path and the `-D` DSN) so shell-special characters are passed literally.

No behavioral change for credentials that contain only safe characters.

Fixes #2174
