### PR TITLE
Adding migration to fix mysql silently altering table entries on autoincrement

### DIFF
--- a/src/migrations/mysql/20260602074349_mysql-autoincrement-fix.sql
+++ b/src/migrations/mysql/20260602074349_mysql-autoincrement-fix.sql
@@ -1,0 +1,13 @@
+-- The previous migration could affect the HashType 0 to be changed due to mysql silently on autoincrement application.
+UPDATE HashType
+SET hashTypeId = 0
+WHERE hashTypeId = 100000
+  AND description = 'MD5'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM (
+             SELECT 1
+             FROM HashType
+             WHERE hashTypeId = 0
+         ) AS temp_check
+);

--- a/src/migrations/postgres/20260602074349_mysql-autoincrement-fix.sql
+++ b/src/migrations/postgres/20260602074349_mysql-autoincrement-fix.sql
@@ -1,0 +1,1 @@
+-- This migration is only a placeholder to keep migrations parallel


### PR DESCRIPTION
When altering a table and add autoincrement for a column in MySQL, it silently just generates new IDs for entries where the value is 0 (not NULL, but MySQL by default thinks on 0 it should also auto increment). This behavior caused the previous migration to update the Hashtype of MD5 from 0 to 100000.

This migration now fixes the entry in case this happened and sets it back to 0 (which is not conflicting with the autoincrement).