### PR TITLE
Show task owner (username) in tasks table

### DIFF
--- a/src/dba/models/TaskWrapper.class.php
+++ b/src/dba/models/TaskWrapper.class.php
@@ -12,8 +12,9 @@ class TaskWrapper extends AbstractModel {
   private $taskWrapperName;
   private $isArchived;
   private $cracked;
+  private $userId;
   
-  function __construct($taskWrapperId, $priority, $maxAgents, $taskType, $hashlistId, $accessGroupId, $taskWrapperName, $isArchived, $cracked) {
+  function __construct($taskWrapperId, $priority, $maxAgents, $taskType, $hashlistId, $accessGroupId, $taskWrapperName, $isArchived, $cracked, $userId = null) {
     $this->taskWrapperId = $taskWrapperId;
     $this->priority = $priority;
     $this->maxAgents = $maxAgents;
@@ -23,6 +24,7 @@ class TaskWrapper extends AbstractModel {
     $this->taskWrapperName = $taskWrapperName;
     $this->isArchived = $isArchived;
     $this->cracked = $cracked;
+    $this->userId = $userId;
   }
   
   function getKeyValueDict() {
@@ -36,6 +38,7 @@ class TaskWrapper extends AbstractModel {
     $dict['taskWrapperName'] = $this->taskWrapperName;
     $dict['isArchived'] = $this->isArchived;
     $dict['cracked'] = $this->cracked;
+    $dict['userId'] = $this->userId;
     
     return $dict;
   }
@@ -51,6 +54,7 @@ class TaskWrapper extends AbstractModel {
     $dict['taskWrapperName'] = ['read_only' => False, "type" => "str(100)", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "taskWrapperName"];
     $dict['isArchived'] = ['read_only' => False, "type" => "bool", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => False, "private" => False, "alias" => "isArchived"];
     $dict['cracked'] = ['read_only' => False, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => False, "pk" => False, "protected" => True, "private" => False, "alias" => "cracked"];
+    $dict['userId'] = ['read_only' => True, "type" => "int", "subtype" => "unset", "choices" => "unset", "null" => True, "pk" => False, "protected" => True, "private" => False, "alias" => "userId"];
 
     return $dict;
   }
@@ -143,6 +147,14 @@ class TaskWrapper extends AbstractModel {
     $this->cracked = $cracked;
   }
   
+  function getUserId() {
+    return $this->userId;
+  }
+  
+  function setUserId($userId) {
+    $this->userId = $userId;
+  }
+  
   const TASK_WRAPPER_ID = "taskWrapperId";
   const PRIORITY = "priority";
   const MAX_AGENTS = "maxAgents";
@@ -152,6 +164,7 @@ class TaskWrapper extends AbstractModel {
   const TASK_WRAPPER_NAME = "taskWrapperName";
   const IS_ARCHIVED = "isArchived";
   const CRACKED = "cracked";
+  const USER_ID = "userId";
 
   const PERM_CREATE = "permTaskWrapperCreate";
   const PERM_READ = "permTaskWrapperRead";

--- a/src/dba/models/TaskWrapperFactory.class.php
+++ b/src/dba/models/TaskWrapperFactory.class.php
@@ -23,7 +23,7 @@ class TaskWrapperFactory extends AbstractModelFactory {
    * @return TaskWrapper
    */
   function getNullObject() {
-    $o = new TaskWrapper(-1, null, null, null, null, null, null, null, null);
+    $o = new TaskWrapper(-1, null, null, null, null, null, null, null, null, null);
     return $o;
   }
   
@@ -33,7 +33,7 @@ class TaskWrapperFactory extends AbstractModelFactory {
    * @return TaskWrapper
    */
   function createObjectFromDict($pk, $dict) {
-    $o = new TaskWrapper($dict['taskWrapperId'], $dict['priority'], $dict['maxAgents'], $dict['taskType'], $dict['hashlistId'], $dict['accessGroupId'], $dict['taskWrapperName'], $dict['isArchived'], $dict['cracked']);
+    $o = new TaskWrapper($dict['taskWrapperId'], $dict['priority'], $dict['maxAgents'], $dict['taskType'], $dict['hashlistId'], $dict['accessGroupId'], $dict['taskWrapperName'], $dict['isArchived'], $dict['cracked'], $dict['userId']);
     return $o;
   }
   

--- a/src/dba/models/generator.php
+++ b/src/dba/models/generator.php
@@ -424,6 +424,7 @@ $CONF['TaskWrapper'] = [
     ['name' => 'taskWrapperName', 'read_only' => False, 'type' => 'str(100)'],
     ['name' => 'isArchived', 'read_only' => False, 'type' => 'bool'],
     ['name' => 'cracked', 'read_only' => False, 'type' => 'int', 'protected' => True],
+    ['name' => 'userId', 'read_only' => True, 'type' => 'int', 'protected' => True, 'null' => True],
   ],
 ];
 $CONF['User'] = [

--- a/src/inc/Util.class.php
+++ b/src/inc/Util.class.php
@@ -470,10 +470,16 @@ class Util {
     $oF2 = new OrderFilter(TaskWrapper::TASK_WRAPPER_ID, "DESC");
     $taskWrappers = Factory::getTaskWrapperFactory()->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => [$oF1, $oF2]]);
     
+    $usernames = array();
+    foreach (Factory::getUserFactory()->filter([]) as $u) {
+      $usernames[$u->getId()] = $u->getUsername();
+    }
+    
     $taskList = array();
     foreach ($taskWrappers as $taskWrapper) {
       $set = new DataSet();
       $set->addValue('taskType', $taskWrapper->getTaskType());
+      $set->addValue('taskOwner', (isset($usernames[$taskWrapper->getUserId()])) ? $usernames[$taskWrapper->getUserId()] : "");
       
       $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $taskWrapper->getId(), "=");
       if ($taskWrapper->getTaskType() == DTaskTypes::SUPERTASK) {

--- a/src/inc/apiv2/helper/createSupertask.routes.php
+++ b/src/inc/apiv2/helper/createSupertask.routes.php
@@ -42,7 +42,8 @@ class CreateSupertaskHelperAPI extends AbstractHelperAPI {
     SupertaskUtils::runSupertask(
         $supertaskTemplate->getId(),
         $hashlist->getId(),
-        $crackerBinary->getId()
+        $crackerBinary->getId(),
+        $this->getCurrentUser()
     );
    
     /* Quick to retrieve newly created TaskWrapper */

--- a/src/inc/handlers/SupertaskHandler.class.php
+++ b/src/inc/handlers/SupertaskHandler.class.php
@@ -18,7 +18,7 @@ class SupertaskHandler implements Handler {
           break;
         case DSupertaskAction::APPLY_SUPERTASK:
           AccessControl::getInstance()->checkPermission(DSupertaskAction::APPLY_SUPERTASK_PERM);
-          SupertaskUtils::runSupertask($_POST['supertask'], $_POST['hashlist'], $_POST['crackerBinaryVersionId']);
+          SupertaskUtils::runSupertask($_POST['supertask'], $_POST['hashlist'], $_POST['crackerBinaryVersionId'], Login::getInstance()->getUser());
           header("Location: tasks.php");
           die();
         case DSupertaskAction::IMPORT_SUPERTASK:

--- a/src/inc/handlers/TaskHandler.class.php
+++ b/src/inc/handlers/TaskHandler.class.php
@@ -258,7 +258,7 @@ class TaskHandler implements Handler {
     }
     
     Factory::getAgentFactory()->getDB()->beginTransaction();
-    $taskWrapper = new TaskWrapper(null, $priority, $maxAgents, DTaskTypes::NORMAL, $hashlistId, $accessGroup->getId(), "", 0, 0);
+    $taskWrapper = new TaskWrapper(null, $priority, $maxAgents, DTaskTypes::NORMAL, $hashlistId, $accessGroup->getId(), "", 0, 0, Login::getInstance()->getUserID());
     $taskWrapper = Factory::getTaskWrapperFactory()->save($taskWrapper);
     
     if (AccessControl::getInstance()->hasPermission(DAccessControl::CREATE_TASK_ACCESS)) {

--- a/src/inc/user-api/UserAPITask.class.php
+++ b/src/inc/user-api/UserAPITask.class.php
@@ -331,7 +331,7 @@ class UserAPITask extends UserAPIBasic {
     if (!isset($QUERY[UQueryTask::SUPERTASK_ID]) || !isset($QUERY[UQueryTask::TASK_HASHLIST]) || !isset($QUERY[UQueryTask::TASK_CRACKER_VERSION])) {
       throw new HTException("Invalid query!");
     }
-    SupertaskUtils::runSupertask($QUERY[UQueryTask::SUPERTASK_ID], $QUERY[UQueryTask::TASK_HASHLIST], $QUERY[UQueryTask::TASK_CRACKER_VERSION]);
+    SupertaskUtils::runSupertask($QUERY[UQueryTask::SUPERTASK_ID], $QUERY[UQueryTask::TASK_HASHLIST], $QUERY[UQueryTask::TASK_CRACKER_VERSION], $this->user);
     $this->sendSuccessResponse($QUERY);
   }
   
@@ -343,7 +343,7 @@ class UserAPITask extends UserAPIBasic {
     if (!isset($QUERY[UQueryTask::PRETASK_ID]) || !isset($QUERY[UQueryTask::TASK_HASHLIST]) || !isset($QUERY[UQueryTask::TASK_CRACKER_VERSION])) {
       throw new HTException("Invalid query!");
     }
-    PretaskUtils::runPretask($QUERY[UQueryTask::PRETASK_ID], $QUERY[UQueryTask::TASK_HASHLIST], $QUERY[UQueryTask::TASK_NAME], $QUERY[UQueryTask::TASK_CRACKER_VERSION]);
+    PretaskUtils::runPretask($QUERY[UQueryTask::PRETASK_ID], $QUERY[UQueryTask::TASK_HASHLIST], $QUERY[UQueryTask::TASK_NAME], $QUERY[UQueryTask::TASK_CRACKER_VERSION], $this->user);
     $this->sendSuccessResponse($QUERY);
   }
   

--- a/src/inc/utils/HashlistUtils.class.php
+++ b/src/inc/utils/HashlistUtils.class.php
@@ -112,7 +112,7 @@ class HashlistUtils {
           $taskPriority = $priorityBase + $task->getPriority();
         }
         $taskMaxAgent = $task->getMaxAgents();
-        $taskWrapper = new TaskWrapper(null, $taskPriority, $taskMaxAgent, DTaskTypes::NORMAL, $hashlist->getId(), $hashlist->getAccessGroupId(), "", 0, 0);
+        $taskWrapper = new TaskWrapper(null, $taskPriority, $taskMaxAgent, DTaskTypes::NORMAL, $hashlist->getId(), $hashlist->getAccessGroupId(), "", 0, 0, ($user != null) ? $user->getId() : null);
         $taskWrapper = Factory::getTaskWrapperFactory()->save($taskWrapper);
         
         $newTask = new Task(

--- a/src/inc/utils/PretaskUtils.class.php
+++ b/src/inc/utils/PretaskUtils.class.php
@@ -222,7 +222,7 @@ class PretaskUtils {
    * @param int $crackerBinaryId
    * @throws HTException
    */
-  public static function runPretask($pretaskId, $hashlistId, $name, $crackerBinaryId) {
+  public static function runPretask($pretaskId, $hashlistId, $name, $crackerBinaryId, $user = null) {
     $pretask = Factory::getPretaskFactory()->get($pretaskId);
     if ($pretask == null) {
       throw new HTException("Invalid preconfigured task ID!");
@@ -244,7 +244,7 @@ class PretaskUtils {
     }
     
     Factory::getAgentFactory()->getDB()->beginTransaction();
-    $taskWrapper = new TaskWrapper(null, $pretask->getPriority(), $pretask->getMaxAgents(), DTaskTypes::NORMAL, $hashlist->getId(), $hashlist->getAccessGroupId(), "", 0, 0);
+    $taskWrapper = new TaskWrapper(null, $pretask->getPriority(), $pretask->getMaxAgents(), DTaskTypes::NORMAL, $hashlist->getId(), $hashlist->getAccessGroupId(), "", 0, 0, ($user != null) ? $user->getId() : null);
     $taskWrapper = Factory::getTaskWrapperFactory()->save($taskWrapper);
     
     $task = new Task(

--- a/src/inc/utils/SupertaskUtils.class.php
+++ b/src/inc/utils/SupertaskUtils.class.php
@@ -240,7 +240,7 @@ class SupertaskUtils {
    * @param int $crackerId
    * @throws HTException
    */
-  public static function runSupertask($supertaskId, $hashlistId, $crackerId) {
+  public static function runSupertask($supertaskId, $hashlistId, $crackerId, $user = null) {
     $supertask = Factory::getSupertaskFactory()->get($supertaskId);
     if ($supertask == null) {
       throw new HTException("Invalid supertask ID!");
@@ -272,7 +272,7 @@ class SupertaskUtils {
       }
     }    
 
-    $taskWrapper = new TaskWrapper(null, $wrapperPriority, $wrapperMaxAgents, DTaskTypes::SUPERTASK, $hashlist->getId(), $hashlist->getAccessGroupId(), $supertask->getSupertaskName(), 0, 0);
+    $taskWrapper = new TaskWrapper(null, $wrapperPriority, $wrapperMaxAgents, DTaskTypes::SUPERTASK, $hashlist->getId(), $hashlist->getAccessGroupId(), $supertask->getSupertaskName(), 0, 0, ($user != null) ? $user->getId() : null);
     $taskWrapper = Factory::getTaskWrapperFactory()->save($taskWrapper);
     
     foreach ($pretasks as $pretask) {

--- a/src/inc/utils/TaskUtils.class.php
+++ b/src/inc/utils/TaskUtils.class.php
@@ -809,7 +809,7 @@ class TaskUtils {
     }
     
     Factory::getAgentFactory()->getDB()->beginTransaction();
-    $taskWrapper = new TaskWrapper(null, $priority, $maxAgents, DTaskTypes::NORMAL, $hashlist->getId(), $accessGroup->getId(), "", 0, 0);
+    $taskWrapper = new TaskWrapper(null, $priority, $maxAgents, DTaskTypes::NORMAL, $hashlist->getId(), $accessGroup->getId(), "", 0, 0, $user->getId());
     $taskWrapper = Factory::getTaskWrapperFactory()->save($taskWrapper);
     
     $task = new Task(
@@ -896,7 +896,7 @@ class TaskUtils {
     }
     
     // create new tasks as supertask
-    $newWrapper = new TaskWrapper(null, 0, 0, DTaskTypes::SUPERTASK, $taskWrapper->getHashlistId(), $taskWrapper->getAccessGroupId(), $task->getTaskName() . " (From Rule Split)", 0, 0);
+    $newWrapper = new TaskWrapper(null, 0, 0, DTaskTypes::SUPERTASK, $taskWrapper->getHashlistId(), $taskWrapper->getAccessGroupId(), $task->getTaskName() . " (From Rule Split)", 0, 0, $taskWrapper->getUserId());
     $newWrapper = Factory::getTaskWrapperFactory()->save($newWrapper);
     $prio = sizeof($newFiles) + 1;
     foreach ($newFiles as $newFile) {

--- a/src/inc/utils/UserUtils.class.php
+++ b/src/inc/utils/UserUtils.class.php
@@ -6,6 +6,7 @@ use DBA\AccessGroupUser;
 use DBA\Session;
 use DBA\NotificationSetting;
 use DBA\Agent;
+use DBA\TaskWrapper;
 use DBA\Factory;
 
 class UserUtils {
@@ -41,6 +42,9 @@ class UserUtils {
     $qF = new QueryFilter(Agent::USER_ID, $user->getId(), "=");
     $uS = new UpdateSet(Agent::USER_ID, null);
     Factory::getAgentFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);
+    $qF = new QueryFilter(TaskWrapper::USER_ID, $user->getId(), "=");
+    $uS = new UpdateSet(TaskWrapper::USER_ID, null);
+    Factory::getTaskWrapperFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);
     $qF = new QueryFilter(Session::USER_ID, $user->getId(), "=");
     Factory::getSessionFactory()->massDeletion([Factory::FILTER => $qF]);
     $qF = new QueryFilter(AccessGroupUser::USER_ID, $user->getId(), "=");

--- a/src/install/hashtopolis.sql
+++ b/src/install/hashtopolis.sql
@@ -997,7 +997,8 @@ CREATE TABLE `TaskWrapper` (
   `accessGroupId`   INT(11)      DEFAULT NULL,
   `taskWrapperName` VARCHAR(100) NOT NULL,
   `isArchived`      TINYINT(4)   NOT NULL,
-  `cracked`         INT(11)      NOT NULL
+  `cracked`         INT(11)      NOT NULL,
+  `userId`          INT(11)      DEFAULT NULL
 )ENGINE = InnoDB;
 
 CREATE TABLE `User` (
@@ -1252,6 +1253,7 @@ ALTER TABLE `TaskWrapper`
   ADD PRIMARY KEY (`taskWrapperId`),
   ADD KEY `hashlistId` (`hashlistId`),
   ADD KEY `priority` (`priority`),
+  ADD KEY `userId` (`userId`),
   ADD KEY `isArchived` (`isArchived`),
   ADD KEY `accessGroupId` (`accessGroupId`);
 
@@ -1506,7 +1508,8 @@ ALTER TABLE `TaskDebugOutput`
 
 ALTER TABLE `TaskWrapper`
   ADD CONSTRAINT `TaskWrapper_ibfk_1` FOREIGN KEY (`hashlistId`)    REFERENCES `Hashlist` (`hashlistId`),
-  ADD CONSTRAINT `TaskWrapper_ibfk_2` FOREIGN KEY (`accessGroupId`) REFERENCES `AccessGroup` (`accessGroupId`);
+  ADD CONSTRAINT `TaskWrapper_ibfk_2` FOREIGN KEY (`accessGroupId`) REFERENCES `AccessGroup` (`accessGroupId`),
+  ADD CONSTRAINT `TaskWrapper_ibfk_3` FOREIGN KEY (`userId`)        REFERENCES `User` (`userId`);
 
 ALTER TABLE `User`
   ADD CONSTRAINT `User_ibfk_1` FOREIGN KEY (`rightGroupId`) REFERENCES `RightGroup` (`rightGroupId`);

--- a/src/templates/tasks/index.template.html
+++ b/src/templates/tasks/index.template.html
@@ -32,6 +32,7 @@
         <tr>
           <th>ID</th>
           <th>Name</th>
+          <th>Owner</th>
           <th>Hashlist</th>
           <th>Dispatched/Searched</th>
           <th>Cracked</th>
@@ -55,10 +56,10 @@
       $(document).ready(function () {
         $('#tasks').DataTable({
           pageLength: 50,
-          "order": [ [6, 'desc'], [0, 'asc'] ],
+          "order": [ [7, 'desc'], [0, 'asc'] ],
           "columnDefs": [
-            { "orderable": false, "targets": [3, 8] },
-            { "orderable": true, "targets": [0, 1, 2, 4, 5, 6, 7] }
+            { "orderable": false, "targets": [4, 9] },
+            { "orderable": true, "targets": [0, 1, 2, 3, 5, 6, 7, 8] }
           ]
         });
       });

--- a/src/templates/tasks/normal.template.html
+++ b/src/templates/tasks/normal.template.html
@@ -22,6 +22,9 @@
     {{ENDIF}}
   </td>
   <td>
+    [[set.getVal('taskOwner')]]
+  </td>
+  <td>
     {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_HASHLIST_ACCESS]])]]}}
       <a href="hashlists.php?id=[[set.getVal('hashlistId')]]">[[set.getVal('hashlistName')]]</a>
     {{ELSE}}

--- a/src/templates/tasks/supertask.template.html
+++ b/src/templates/tasks/supertask.template.html
@@ -8,6 +8,9 @@
     {{ENDIF}}
   </td>
   <td>
+    [[set.getVal('taskOwner')]]
+  </td>
+  <td>
     {{IF [[accessControl.hasPermission([[$DAccessControl::VIEW_HASHLIST_ACCESS]])]]}}
       <a href="hashlists.php?id=[[set.getVal('hashlistId')]]">[[set.getVal('hashlistName')]]</a>
     {{ELSE}}


### PR DESCRIPTION
Adds an "Owner" column to the tasks list showing the username of the user who created each task/supertask.

The schema previously had no task–user relation, so this introduces one:

TaskWrapper gets a nullable userId column (install schema src/install/hashtopolis.sql, DBA model/factory, generator.php) with FK to User.
The creator's userId is set at all 6 new TaskWrapper(...) creation sites (web task creation, TaskUtils::createTask, pretask/supertask runs, applyPreconfTasks, rule-split inherits the original wrapper's userId). PretaskUtils::runPretask and SupertaskUtils::runSupertask gained an optional $user param, passed from web handlers, user-api, and apiv2 callers.
UserUtils::deleteUser nulls TaskWrapper.userId (same pattern as Agent.userId).
Util::loadTasks resolves usernames (single user query, map lookup) into taskOwner; templates tasks/index|normal|supertask render the new column (DataTable column indices shifted accordingly). Tasks without an owner (e.g. pre-existing or server-generated) show an empty cell.