### PR TITLE
Aggregation improvements

### DIFF
--- a/ci/apiv2/test_task.py
+++ b/ci/apiv2/test_task.py
@@ -15,7 +15,7 @@ class TaskTest(BaseTest):
         dummy_agent.send_process(progress=50)
         dummy_agent.send_process(progress=100, state=ProcessState.EXHAUSTED)
         dummy_agent.get_chunk()
-        return Task.objects.get(taskId=retval['task'].id)
+        return Task.objects.params(**{"aggregate[task]": "totalNumberOfChunks"}).get(taskId=retval['task'].id)
 
     def create_test_object(self, **kwargs):
         hashlist_kwargs = kwargs.copy()

--- a/ci/apiv2/test_taskwrapperdisplay.py
+++ b/ci/apiv2/test_taskwrapperdisplay.py
@@ -1,18 +1,31 @@
-from hashtopolis import TaskWrapperDisplay
+from hashtopolis import TaskWrapperDisplay, Helper, TaskWrapper
+
 from utils import BaseTest
 class TaskWrapperDisplayTest(BaseTest):
     model_class = TaskWrapperDisplay
-    
+
     def create_test_object(self, *nargs, delete=True, **kwargs):
         # Always cleanup hashlist when done, this is potentially confusing,
         # since it will also remove the related task
         hashlist = self.create_hashlist()
         task = self.create_task(hashlist, delete=delete)
         return TaskWrapperDisplay.objects.get(pk=task.taskWrapperId)
-    
+
+
     def test_task_wrapper_display_should_return_color_field(self):
         task_wrapper_display_object = self.create_test_object()
         expected_color_value = str(task_wrapper_display_object.color)
         self.assertIsNotNone(task_wrapper_display_object.color)
         self.assertEqual(task_wrapper_display_object.color, expected_color_value)
         self.assertNotEqual("FFFFFF", task_wrapper_display_object.color)
+
+    def test_number_of_chunks_on_supertask(self):
+        pretasks = [self.create_pretask() for _ in range(2)]
+        supertask = self.create_supertask(pretasks=pretasks)
+        cracker = self.create_cracker()
+        hashlist = self.create_hashlist()
+
+        helper = Helper()
+        task_wrapper = helper.create_supertask(supertask, hashlist, cracker)
+        task_wrapper_display = TaskWrapperDisplay.objects.params(**{"aggregate[taskwrapperdisplay]": "timeSpent"}).get(taskWrapperId=task_wrapper.id)
+        assert not hasattr(task_wrapper_display, 'timeSpent'), "Attribute 'timeSpent' should not be set"

--- a/ci/phpunit/dba/AbstractModelFactoryTest.php
+++ b/ci/phpunit/dba/AbstractModelFactoryTest.php
@@ -590,6 +590,49 @@ final class AbstractModelFactoryTest extends TestBase {
   }
   
   /**
+   * Test receiving the column of a query with an order
+   *
+   * @return void
+   * @throws Exception
+   */
+  public function testColumnFilterSuccessOrdered(): void {
+    $testid = uniqid();
+    $this->createDatabaseObject(Factory::getHashTypeFactory(), new HashType(null, 'hashtype1' . $testid, 1, 0));
+    $this->createDatabaseObject(Factory::getHashTypeFactory(), new HashType(null, 'hashtype2' . $testid, 125, 0));
+    $this->createDatabaseObject(Factory::getHashTypeFactory(), new HashType(null, 'hashtype3' . $testid, 72, 0));
+    
+    $qF = new LikeFilter(HashType::DESCRIPTION, "%" . $testid);
+    $oF = new OrderFilter(HashType::IS_SALTED, "ASC");
+    $column = Factory::getHashTypeFactory()->columnFilter([Factory::FILTER => $qF, Factory::ORDER => $oF], HashType::IS_SALTED);
+    $this->assertEquals([1, 72, 125], $column);
+    
+    $oF = new OrderFilter(HashType::IS_SALTED, "DESC");
+    $column = Factory::getHashTypeFactory()->columnFilter([Factory::FILTER => $qF, Factory::ORDER => $oF], HashType::IS_SALTED);
+    $this->assertEquals([125, 72, 1], $column);
+  }
+  
+  /**
+   * Test querying multiple columns with the column filter
+   *
+   * @return void
+   * @throws Exception
+   */
+  public function testColumnFilterSuccessMultiple(): void {
+    $testid = uniqid();
+    $this->createDatabaseObject(Factory::getHashTypeFactory(), new HashType(null, 'hashtype1' . $testid, 1, 0));
+    $this->createDatabaseObject(Factory::getHashTypeFactory(), new HashType(null, 'hashtype2' . $testid, 125, 0));
+    $this->createDatabaseObject(Factory::getHashTypeFactory(), new HashType(null, 'hashtype3' . $testid, 72, 1));
+    
+    $qF = new LikeFilter(HashType::DESCRIPTION, "%" . $testid);
+    $columns = Factory::getHashTypeFactory()->columnFilter([Factory::FILTER => $qF], [HashType::IS_SALTED, HashType::IS_SLOW_HASH]);
+    $this->assertEquals([[1, 0], [125, 0], [72, 1]], $columns);
+    
+    $oF = new OrderFilter(HashType::IS_SALTED, "ASC");
+    $columns = Factory::getHashTypeFactory()->columnFilter([Factory::FILTER => $qF, Factory::ORDER => $oF], [HashType::IS_SALTED, HashType::IS_SLOW_HASH]);
+    $this->assertEquals([[1, 0], [72, 1], [125, 0]], $columns);
+  }
+  
+  /**
    * Test receiving the column of a query on a mapped column
    *
    * @return void
@@ -1137,8 +1180,9 @@ final class AbstractModelFactoryTest extends TestBase {
     // hashlist 1 and 3 should be returned
     $this->assertSame([$hashlist_1->getId(), $hashlist_3->getId()], $ids);
     
-    $qF = new QueryFilter(Hashlist::CRACKED, 5000, ">");
-    $ids = Factory::getHashlistFactory()->columnFilter([Factory::FILTER => $qF, Factory::ORDER => $oF], Hashlist::HASHLIST_ID);
+    $qF1 = new QueryFilter(Hashlist::CRACKED, 5000, ">");
+    $qF2 = new LikeFilter(Hashlist::HASHLIST_NAME, "%" . $testid);
+    $ids = Factory::getHashlistFactory()->columnFilter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF], Hashlist::HASHLIST_ID);
     $this->assertSame([], $ids);
   }
   

--- a/src/dba/AbstractModelFactory.php
+++ b/src/dba/AbstractModelFactory.php
@@ -486,13 +486,19 @@ abstract class AbstractModelFactory {
   
   /**
    * @param $options array options of query (filters and joins)
-   * @param $column string single column key which should be retrieved
+   * @param $columns array|string single column key or array of column keys which should be retrieved
    * @return array of the column entries returned from this query
    * @throws Exception
    */
-  public function columnFilter(array $options, string $column): array {
-    $query = "SELECT " . Util::createPrefixedString($this->getMappedModelTable(), [self::getMappedModelKey($this->getNullObject(), $column)]);
-    $query = $query . " FROM " . $this->getMappedModelTable();
+  public function columnFilter(array $options, array|string $columns): array {
+    if (!is_array($columns)) {
+      $columns = [$columns];
+    }
+    $elements = [];
+    foreach ($columns as $column) {
+      $elements[] = Util::createPrefixedString($this->getMappedModelTable(), [self::getMappedModelKey($this->getNullObject(), $column)]);
+    }
+    $query = "SELECT " . join(",", $elements) . " FROM " . $this->getMappedModelTable();
     
     $vals = array();
     
@@ -502,12 +508,18 @@ abstract class AbstractModelFactory {
     if (array_key_exists(Factory::FILTER, $options)) {
       $query .= $this->applyFilters($vals, $options[Factory::FILTER]);
     }
+    if (array_key_exists(Factory::ORDER, $options)) {
+      $query .= $this->applyOrder($options[Factory::ORDER]);
+    }
     
     $dbh = self::getDB();
     $stmt = $dbh->prepare($query);
     $stmt->execute($vals);
     
-    return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    if (sizeof($elements) == 1) {
+      return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+    return $stmt->fetchAll(PDO::FETCH_NUM);
   }
   
   /**

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -187,7 +187,7 @@ abstract class AbstractBaseAPI {
   public function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     return [];
   }
-
+  
   /**
    * Return supported aggregate fieldsets/options for this endpoint.
    *
@@ -658,6 +658,7 @@ abstract class AbstractBaseAPI {
    * Convert DB object JSON:API Resource Object
    * @throws NotFoundExceptionInterface
    * @throws ContainerExceptionInterface
+   * @throws HttpError
    */
   protected function obj2Resource(object $obj, array &$expandResult = [], ?array $sparseFieldsets = null, ?array $aggregateFieldsets = null): array {
     // Convert values to JSON supported types
@@ -702,11 +703,27 @@ abstract class AbstractBaseAPI {
     
     if ($this instanceof AbstractModelAPI && get_class($obj) !== $this->getDBAClass()) {
       $apiClassObject = new $apiClass($this->container);
-    } else {
+    }
+    else {
       // use instance of this when the object is of the dba class of this api endpoint.
       // This way its possible to set object attributes in the post to be used in the aggregateData function.
       $apiClassObject = $this;
     }
+    
+    if (is_array($aggregateFieldsets)) {
+      $availableFieldsets = $apiClassObject->getAggregateFieldsets();
+      foreach ($aggregateFieldsets as $name => $aggregateFieldset) {
+        if (!array_key_exists($name, $availableFieldsets)) {
+          throw new HttpError("Invalid aggregation object requested!");
+        }
+        foreach ($aggregateFieldset as $field) {
+          if (!in_array($field, $availableFieldsets[$name])) {
+            throw new HttpError("Invalid aggregation requested!");
+          }
+        }
+      }
+    }
+    
     $aggregatedData = $apiClassObject->aggregateData($obj, $expandResult, $aggregateFieldsets);
     $attributes = array_merge($attributes, $aggregatedData);
     
@@ -1124,9 +1141,9 @@ abstract class AbstractBaseAPI {
   function getFilters(Request $request): array {
     return $this->getQueryParameterFamily($request, 'filter');
   }
-
+  
   protected static function checkJoinExists(array $joins, string $modelName) {
-    foreach($joins as $join) {
+    foreach ($joins as $join) {
       if ($join->getOtherFactory()->getModelName() === $modelName) {
         return true;
       }
@@ -1154,13 +1171,13 @@ abstract class AbstractBaseAPI {
       $cast_key = $matches['key'] == 'id' ? array_column($features, 'alias', 'dbname')[$this->getPrimaryKey()] : $matches['key'];
       if (strpos($cast_key, ".")) {
         //When the key contains a "." it should be a relation in format: "task.taskname" where task is the relation.
-          $relationObject = $this->retrieveRelationKey($cast_key);
-          $factory = $relationObject->factory;
-          $cast_key = $relationObject->cast_key;
-          if (!self::checkJoinExists($joinFilters, $factory->getModelName())) {
-            $joinFilters[] = new JoinFilter($factory, $relationObject->joinKey, $relationObject->key);
-          }
-          $features = $relationObject->features_relation;
+        $relationObject = $this->retrieveRelationKey($cast_key);
+        $factory = $relationObject->factory;
+        $cast_key = $relationObject->cast_key;
+        if (!self::checkJoinExists($joinFilters, $factory->getModelName())) {
+          $joinFilters[] = new JoinFilter($factory, $relationObject->joinKey, $relationObject->key);
+        }
+        $features = $relationObject->features_relation;
       }
       
       if (!array_key_exists($cast_key, $features)) {
@@ -1259,7 +1276,7 @@ abstract class AbstractBaseAPI {
     }
     return $qFs;
   }
-
+  
   /**
    * Retrieves the relation from a sort/filter value. ex task.taskName when task is a relation for the current
    * Model endpoint. This works only for relations of 1 deep
@@ -1277,17 +1294,19 @@ abstract class AbstractBaseAPI {
         $key = $relations[$relationString]['key'];
         $features_relation = $relationFeatures;
         $value = $parts[1];
-        return (object) [
+        return (object)[
           "factory" => $factory,
           "joinKey" => $joinKey,
           "key" => $key,
           "features_relation" => $features_relation,
           "cast_key" => $value
         ];
-      } else {
+      }
+      else {
         throw new HttpError("Invalid relation: " . $relationString);
       }
-    } else {
+    }
+    else {
       throw new HttpForbidden("Invalid key, multiple '.' found in key, but only relationships of one deep is allowed");
     }
   }
@@ -1376,7 +1395,7 @@ abstract class AbstractBaseAPI {
     $expandKeys = array_keys($expandResult);
     $diffs = array_diff($expandKeys, $expands);
     $expands = array_merge($expands, $diffs);
-
+    
     foreach ($expands as $expand) {
       if (!array_key_exists($object->getId(), $expandResult[$expand])) {
         continue;
@@ -1417,7 +1436,7 @@ abstract class AbstractBaseAPI {
     else {
       $rightgroup_perms = json_decode($permissions, true);
     }
-
+    
     if ($aud === "user_hashtopolis") {
       // Validate if no undefined permissions are set in $acl_mapping for the legacy permissions
       assert(count(array_diff(array_keys($rightgroup_perms), array_keys(self::$acl_mapping))) == 0);
@@ -1428,7 +1447,8 @@ abstract class AbstractBaseAPI {
           $user_available_perms = array_unique(array_merge($user_available_perms, self::$acl_mapping[$rightgroup_perm]));
         }
       };
-    } else {
+    }
+    else {
       $user_available_perms = array_keys($rightgroup_perms, true, true);
     }
     
@@ -1641,7 +1661,7 @@ abstract class AbstractBaseAPI {
    * Get single Resource
    */
   protected static function getOneResource(object $apiClass, object $object, Request $request, Response $response, int $statusCode = 200): Response {
-    $apiClass->preCommon($request);  
+    $apiClass->preCommon($request);
     $validExpandables = $apiClass->getExpandables();
     $expands = $apiClass->makeExpandables($request, $validExpandables);
     

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -191,11 +191,14 @@ abstract class AbstractBaseAPI {
       foreach ($fieldsets as $name => $fieldset) {
         if (array_key_exists($name, $aggregateFieldsets)) {
           $aggregateFieldsets[$name] = explode(",", $aggregateFieldsets[$name]);
-          foreach($aggregateFieldsets[$name] as $field) {
-            if(!array_key_exists($field, $fieldset)) {
+          foreach ($aggregateFieldsets[$name] as $field) {
+            if (!array_key_exists($field, $fieldset)) {
               throw new HttpError("Invalid aggregation requested!");
             }
-            $aggregatedData[$field] = $fieldset[$field]($object);
+            $data = $fieldset[$field]($object);
+            if ($data !== null) {
+              $aggregatedData[$field] = $data;
+            }
           }
         }
       }

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -716,6 +716,7 @@ abstract class AbstractBaseAPI {
         if (!array_key_exists($name, $availableFieldsets)) {
           throw new HttpError("Invalid aggregation object requested!");
         }
+        $aggregateFieldset = explode(",", $aggregateFieldset);
         foreach ($aggregateFieldset as $field) {
           if (!in_array($field, $availableFieldsets[$name])) {
             throw new HttpError("Invalid aggregation requested!");

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -8,9 +8,7 @@ use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\apiv2\error\InternalError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\AccessControl;
-use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\defines\DAccessControl;
-use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\JoinFilter;
 use Hashtopolis\inc\HTException;
 use JsonException;
@@ -183,17 +181,35 @@ abstract class AbstractBaseAPI {
    *
    * Implementations should use $includedData to collect related resources that should be included
    * in the API response, such as related entities or additional data.
+   * @throws HttpError
    */
   public function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
-    return [];
+    $aggregatedData = [];
+    
+    if (is_array($aggregateFieldsets)) {
+      $fieldsets = $this->getAggregateFieldsets();
+      foreach ($fieldsets as $name => $fieldset) {
+        if (array_key_exists($name, $aggregateFieldsets)) {
+          $aggregateFieldsets[$name] = explode(",", $aggregateFieldsets[$name]);
+          foreach($aggregateFieldsets[$name] as $field) {
+            if(!array_key_exists($field, $fieldset)) {
+              throw new HttpError("Invalid aggregation requested!");
+            }
+            $aggregatedData[$field] = $fieldset[$field]($object);
+          }
+        }
+      }
+    }
+    return $aggregatedData;
   }
   
   /**
-   * Return supported aggregate fieldsets/options for this endpoint.
+   * Return supported aggregate fieldsets/options for this endpoint, providing a callback to call to actually retrieve
+   * this aggregation on a specific object. All callbacks expect one argument being the api object.
    *
    * Format:
    * [
-   *   'resourceKey' => ['option1', 'option2']
+   *   'resourceKey' => ['option1' => [class, function], 'option2' => [class, function]]
    * ]
    */
   public function getAggregateFieldsets(): array {
@@ -708,21 +724,6 @@ abstract class AbstractBaseAPI {
       // use instance of this when the object is of the dba class of this api endpoint.
       // This way its possible to set object attributes in the post to be used in the aggregateData function.
       $apiClassObject = $this;
-    }
-    
-    if (is_array($aggregateFieldsets)) {
-      $availableFieldsets = $apiClassObject->getAggregateFieldsets();
-      foreach ($aggregateFieldsets as $name => $aggregateFieldset) {
-        if (!array_key_exists($name, $availableFieldsets)) {
-          throw new HttpError("Invalid aggregation object requested!");
-        }
-        $aggregateFieldset = explode(",", $aggregateFieldset);
-        foreach ($aggregateFieldset as $field) {
-          if (!in_array($field, $availableFieldsets[$name])) {
-            throw new HttpError("Invalid aggregation requested!");
-          }
-        }
-      }
     }
     
     $aggregatedData = $apiClassObject->aggregateData($obj, $expandResult, $aggregateFieldsets);

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -772,7 +772,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     
     // Convert objects to data resources 
     foreach ($objects as $object) {
-      // Create object  
+      // Create object
       $newObject = $apiClass->obj2Resource($object, $expandResult, $request->getQueryParams()['fields'] ?? null, $request->getQueryParams()['aggregate'] ?? null);
       $includedResources = $apiClass->processExpands($apiClass, $expands, $object, $expandResult, $includedResources, $request->getQueryParams()['fields'] ?? null, $request->getQueryParams()['aggregate'] ?? null);
       

--- a/src/inc/apiv2/common/openAPISchema.routes.php
+++ b/src/inc/apiv2/common/openAPISchema.routes.php
@@ -699,8 +699,8 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
               if (empty($options)) {
                 continue;
               }
-              $aggregateExamples["aggregate[" . $fieldset . "]"] = implode(",", $options);
-              $aggregateDescriptionParts[] = $fieldset . ": " . implode(", ", $options);
+              $aggregateExamples["aggregate[" . $fieldset . "]"] = implode(",", array_keys($options));
+              $aggregateDescriptionParts[] = $fieldset . ": " . implode(", ", array_keys($options));
             }
 
             if (!empty($aggregateExamples)) {

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -84,8 +84,8 @@ class AgentAPI extends AbstractModelAPI {
       if (in_array("crackingTime", $aggregateFieldsets['agent'])) {
         // in order to make sense of the diff, we need to make sure that both values solve time and dispatch time are set (i.e. >0).
         $qF1 = new QueryFilter(Chunk::AGENT_ID, $agentId, "=");
-        $qF2 = new QueryFilter(Chunk::SOLVE_TIME, ">", 0);
-        $qF3 = new QueryFilter(Chunk::DISPATCH_TIME, ">", 0);
+        $qF2 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
+        $qF3 = new QueryFilter(Chunk::DISPATCH_TIME, 0, ">");
         $agg1 = new Aggregation(Chunk::SOLVE_TIME, Aggregation::SUM);
         $agg2 = new Aggregation(Chunk::DISPATCH_TIME, Aggregation::SUM);
         $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg1, $agg2]);

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -50,9 +50,25 @@ class AgentAPI extends AbstractModelAPI {
   public function getAggregateFieldsets(): array {
     return [
       'agent' => [
-        'crackingTime',
+        'crackingTime' => [$this, 'getAggregateCrackingTime'],
       ]
     ];
+  }
+  
+  /**
+   * @param object $object
+   * @return int
+   * @throws Exception
+   */
+  protected function getAggregateCrackingTime(object $object): int {
+    // in order to make sense of the diff, we need to make sure that both values solve time and dispatch time are set (i.e. >0).
+    $qF1 = new QueryFilter(Chunk::AGENT_ID, $object->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
+    $qF3 = new QueryFilter(Chunk::DISPATCH_TIME, 0, ">");
+    $agg1 = new Aggregation(Chunk::SOLVE_TIME, Aggregation::SUM);
+    $agg2 = new Aggregation(Chunk::DISPATCH_TIME, Aggregation::SUM);
+    $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg1, $agg2]);
+    return $results[$agg1->getName()] - $results[$agg2->getName()];
   }
   
   /**
@@ -66,8 +82,6 @@ class AgentAPI extends AbstractModelAPI {
    * @throws Exception
    */
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
-    $aggregatedData = [];
-    
     $agentId = $object->getId();
     $qFs = [];
     $qFs[] = new QueryFilter(Chunk::AGENT_ID, $agentId, "=");
@@ -78,22 +92,7 @@ class AgentAPI extends AbstractModelAPI {
       $includedData["chunks"][$agentId] = [$active_chunk];
     }
     
-    if (!is_null($aggregateFieldsets) && array_key_exists('agent', $aggregateFieldsets)) {
-      $aggregateFieldsets['agent'] = explode(",", $aggregateFieldsets['agent']);
-      
-      if (in_array("crackingTime", $aggregateFieldsets['agent'])) {
-        // in order to make sense of the diff, we need to make sure that both values solve time and dispatch time are set (i.e. >0).
-        $qF1 = new QueryFilter(Chunk::AGENT_ID, $agentId, "=");
-        $qF2 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
-        $qF3 = new QueryFilter(Chunk::DISPATCH_TIME, 0, ">");
-        $agg1 = new Aggregation(Chunk::SOLVE_TIME, Aggregation::SUM);
-        $agg2 = new Aggregation(Chunk::DISPATCH_TIME, Aggregation::SUM);
-        $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg1, $agg2]);
-        $aggregatedData["crackingTime"] = $results[$agg1->getName()] - $results[$agg2->getName()];
-      }
-    }
-    
-    return $aggregatedData;
+    return parent::aggregateData($object, $includedData, $aggregateFieldsets);
   }
   
   protected function getSingleACL(User $user, object $object): bool {

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
+use Hashtopolis\dba\Aggregation;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\AgentUtils;
 use Hashtopolis\inc\defines\DHashcatStatus;
@@ -45,16 +47,27 @@ class AgentAPI extends AbstractModelAPI {
     ];
   }
   
+  public function getAggregateFieldsets(): array {
+    return [
+      'agent' => [
+        'crackingTime',
+      ]
+    ];
+  }
+  
   /**
    * Overridable function to aggregate data in the object. active chunk of agent is appended to
    * $included_data.
    *
    * @param object $object the agent object were data is aggregated from
-   * @param array &$included_data
+   * @param array &$includedData
    * @param array|null $aggregateFieldsets
    * @return array not used here
+   * @throws Exception
    */
-  function aggregateData(object $object, array &$included_data = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
+    $aggregatedData = [];
+    
     $agentId = $object->getId();
     $qFs = [];
     $qFs[] = new QueryFilter(Chunk::AGENT_ID, $agentId, "=");
@@ -62,10 +75,25 @@ class AgentAPI extends AbstractModelAPI {
     
     $active_chunk = Factory::getChunkFactory()->filter([Factory::FILTER => $qFs], true);
     if ($active_chunk !== NULL) {
-      $included_data["chunks"][$agentId] = [$active_chunk];
+      $includedData["chunks"][$agentId] = [$active_chunk];
     }
     
-    return [];
+    if (array_key_exists('agent', $aggregateFieldsets)) {
+      $aggregateFieldsets['agent'] = explode(",", $aggregateFieldsets['agent']);
+      
+      if (in_array("crackingTime", $aggregateFieldsets['agent'])) {
+        // in order to make sense of the diff, we need to make sure that both values solve time and dispatch time are set (i.e. >0).
+        $qF1 = new QueryFilter(Chunk::AGENT_ID, $agentId, "=");
+        $qF2 = new QueryFilter(Chunk::SOLVE_TIME, ">", 0);
+        $qF3 = new QueryFilter(Chunk::DISPATCH_TIME, ">", 0);
+        $agg1 = new Aggregation(Chunk::SOLVE_TIME, Aggregation::SUM);
+        $agg2 = new Aggregation(Chunk::DISPATCH_TIME, Aggregation::SUM);
+        $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg1, $agg2]);
+        $aggregatedData["crackingTime"] = $results[$agg1->getName()] - $results[$agg2->getName()];
+      }
+    }
+    
+    return $aggregatedData;
   }
   
   protected function getSingleACL(User $user, object $object): bool {

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -78,7 +78,7 @@ class AgentAPI extends AbstractModelAPI {
       $includedData["chunks"][$agentId] = [$active_chunk];
     }
     
-    if (array_key_exists('agent', $aggregateFieldsets)) {
+    if (!is_null($aggregateFieldsets) && array_key_exists('agent', $aggregateFieldsets)) {
       $aggregateFieldsets['agent'] = explode(",", $aggregateFieldsets['agent']);
       
       if (in_array("crackingTime", $aggregateFieldsets['agent'])) {

--- a/src/inc/apiv2/model/ApiTokenAPI.php
+++ b/src/inc/apiv2/model/ApiTokenAPI.php
@@ -108,7 +108,7 @@ class ApiTokenAPI extends AbstractModelAPI {
     return $token->getId();
   }
 
-  function aggregateData(object $object, array &$included_data = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     // $token is only set in POST, this way the actual token is only returned after creation.
     $aggregatedData = [];
     $token = $this->getJwtToken();

--- a/src/inc/apiv2/model/ApiTokenAPI.php
+++ b/src/inc/apiv2/model/ApiTokenAPI.php
@@ -9,6 +9,8 @@ use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\StartupConfig;
 
 use Hashtopolis\inc\utils\AccessUtils;
@@ -17,15 +19,15 @@ use Hashtopolis\inc\utils\JwtTokenUtils;
 class ApiTokenAPI extends AbstractModelAPI {
   const API_AUD = "api_hashtopolis";
   private ?string $jwtToken = null;
-
+  
   private function setJwtToken(string $token): void {
-      $this->jwtToken = $token;
+    $this->jwtToken = $token;
   }
-
+  
   private function getJwtToken(): ?string {
     return $this->jwtToken;
   }
-
+  
   public static function getBaseUri(): string {
     return "/api/v2/ui/apiTokens";
   }
@@ -48,14 +50,14 @@ class ApiTokenAPI extends AbstractModelAPI {
       ]
     ];
   }
-
+  
   public function getFormFields(): array {
     // TODO Form declarations in more generic class to allow auto-generated OpenAPI specifications
     return [
       "scopes" => ['type' => 'array', 'subtype' => 'string']
     ];
   }
-
+  
   protected function getSingleACL(User $user, object $object): bool {
     return ($object->getUserId() === $user->getId());
   }
@@ -68,29 +70,31 @@ class ApiTokenAPI extends AbstractModelAPI {
       ]
     ];
   }
+  
   /**
    * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   protected function createObject(array $data): int {
     //Scopes is an array of permissions in format [permFileTaskUpdate, permAgentDelete]
     $scopes = explode(",", $data["scopes"]);
-
+    
     $userCrudPerms = AccessUtils::getPermissionArrayConverted(
       $this->getRightGroup($this->getCurrentUser()->getRightGroupId())->getPermissions()
     );
-
+    
     // Modern CRUD scope dict: true if the perm was requested AND the user has it.
     $requestedScopes = [];
     foreach ($userCrudPerms as $perm => $granted) {
       $requestedScopes[$perm] = $granted && in_array($perm, $scopes, true);
     }
-
+    
     $secret = StartupConfig::getInstance()->getPepper(0);
     $iat = $data[JwtApiKey::START_VALID];
     $expires = $data[JwtApiKey::END_VALID];
     $token = JwtTokenUtils::createKey($this->getCurrentUser()->getId(), $iat, $expires);
     $jti = $token->getId();
-
+    
     $payload = [
       "iat" => $iat,
       "exp" => $expires,
@@ -99,15 +103,15 @@ class ApiTokenAPI extends AbstractModelAPI {
       "scope" => json_encode($requestedScopes),
       "iss" => "Hashtopolis",
       "aud" => $this::API_AUD,
-      "kid" =>  hash("sha256", $secret)
+      "kid" => hash("sha256", $secret)
     ];
-
+    
     $tokenEncoded = JWT::encode($payload, $secret, "HS256");
     $this->setJwtToken($tokenEncoded);
-
+    
     return $token->getId();
   }
-
+  
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     // $token is only set in POST, this way the actual token is only returned after creation.
     $aggregatedData = [];
@@ -115,12 +119,13 @@ class ApiTokenAPI extends AbstractModelAPI {
     if ($token !== null) {
       $aggregatedData["token"] = $token;
     }
-
-    return $aggregatedData;
+    
+    return array_merge_recursive($aggregatedData, parent::aggregateData($object, $includedData, $aggregateFieldsets));
   }
   
   /**
-   * @throws HttpError
+   * @param object $object
+   * @throws HttpForbidden
    */
   protected function deleteObject(object $object): void {
     JwtTokenUtils::deleteKey($object);

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -46,6 +46,34 @@ class PreTaskAPI extends AbstractModelAPI {
     ];
   }
   
+  public function getAggregateFieldsets(): array {
+    return [
+      'pretask' => [
+        'auxiliaryKeyspace' => [$this, 'getAggregateAuxiliaryKeyspace'],
+      ]
+    ];
+  }
+  
+  /**
+   * @param object $object
+   * @return int
+   */
+  protected function getAggregateAuxiliaryKeyspace(object $object): int {
+    $qF1 = new QueryFilter(FilePretask::PRETASK_ID, $object->getId(), "=", Factory::getFilePretaskFactory());
+    $jF1 = new JoinFilter(Factory::getFilePretaskFactory(), File::FILE_ID, FilePretask::FILE_ID);
+    $files = Factory::getFileFactory()->filter([Factory::FILTER => $qF1, Factory::JOIN => $jF1]);
+    $files = $files[Factory::getFileFactory()->getModelName()];
+    
+    $lineCountProduct = 1;
+    foreach ($files as $file) {
+      $lineCount = $file->getLineCount();
+      if ($lineCount !== null) {
+        $lineCountProduct = $lineCountProduct * $lineCount;
+      }
+    }
+    return $lineCountProduct;
+  }
+  
   /**
    * @throws HttpError
    */
@@ -66,39 +94,6 @@ class PreTaskAPI extends AbstractModelAPI {
       $data[PreTask::PRIORITY]
     );
     return $pretask->getId();
-  }
-  
-  
-  /**
-   * @param object $object
-   * @param array $includedData
-   * @param array|null $aggregateFieldsets
-   * @return array
-   */
-  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
-    $aggregatedData = [];
-    
-    if (!is_null($aggregateFieldsets) && array_key_exists('pretask', $aggregateFieldsets)) {
-      $aggregateFieldsets['pretask'] = explode(",", $aggregateFieldsets['pretask']);
-      
-      if (in_array("auxiliaryKeyspace", $aggregateFieldsets['pretask'])) {
-        $qF1 = new QueryFilter(FilePretask::PRETASK_ID, $object->getId(), "=", Factory::getFilePretaskFactory());
-        $jF1 = new JoinFilter(Factory::getFilePretaskFactory(), File::FILE_ID, FilePretask::FILE_ID);
-        $files = Factory::getFileFactory()->filter([Factory::FILTER => $qF1, Factory::JOIN => $jF1]);
-        $files = $files[Factory::getFileFactory()->getModelName()];
-        
-        $lineCountProduct = 1;
-        foreach ($files as $file) {
-          $lineCount = $file->getLineCount();
-          if ($lineCount !== null) {
-            $lineCountProduct = $lineCountProduct * $lineCount;
-          }
-        }
-        $aggregatedData["auxiliaryKeyspace"] = $lineCountProduct;
-      }
-    }
-    
-    return $aggregatedData;
   }
   
   protected function getUpdateHandlers($id, $current_user): array {

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -78,7 +78,7 @@ class PreTaskAPI extends AbstractModelAPI {
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
     
-    if (array_key_exists('pretask', $aggregateFieldsets)) {
+    if (!is_null($aggregateFieldsets) && array_key_exists('pretask', $aggregateFieldsets)) {
       $aggregateFieldsets['pretask'] = explode(",", $aggregateFieldsets['pretask']);
       
       if (in_array("auxiliaryKeyspace", $aggregateFieldsets['pretask'])) {

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -68,24 +68,34 @@ class PreTaskAPI extends AbstractModelAPI {
     return $pretask->getId();
   }
   
-  //TODO make aggregate data queryable and not included by default
+  
+  /**
+   * @param object $object
+   * @param array $includedData
+   * @param array|null $aggregateFieldsets
+   * @return array
+   */
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
-    if (is_null($aggregateFieldsets) || array_key_exists('pretask', $aggregateFieldsets)) {
+    
+    if (array_key_exists('pretask', $aggregateFieldsets)) {
+      $aggregateFieldsets['pretask'] = explode(",", $aggregateFieldsets['pretask']);
       
-      $qF1 = new QueryFilter(FilePretask::PRETASK_ID, $object->getId(), "=", Factory::getFilePretaskFactory());
-      $jF1 = new JoinFilter(Factory::getFilePretaskFactory(), File::FILE_ID, FilePretask::FILE_ID);
-      $files = Factory::getFileFactory()->filter([Factory::FILTER => $qF1, Factory::JOIN => $jF1]);
-      $files = $files[Factory::getFileFactory()->getModelName()];
-      
-      $lineCountProduct = 1;
-      foreach ($files as $file) {
-        $lineCount = $file->getLineCount();
-        if ($lineCount !== null) {
-          $lineCountProduct = $lineCountProduct * $lineCount;
+      if (in_array("auxiliaryKeyspace", $aggregateFieldsets['pretask'])) {
+        $qF1 = new QueryFilter(FilePretask::PRETASK_ID, $object->getId(), "=", Factory::getFilePretaskFactory());
+        $jF1 = new JoinFilter(Factory::getFilePretaskFactory(), File::FILE_ID, FilePretask::FILE_ID);
+        $files = Factory::getFileFactory()->filter([Factory::FILTER => $qF1, Factory::JOIN => $jF1]);
+        $files = $files[Factory::getFileFactory()->getModelName()];
+        
+        $lineCountProduct = 1;
+        foreach ($files as $file) {
+          $lineCount = $file->getLineCount();
+          if ($lineCount !== null) {
+            $lineCountProduct = $lineCountProduct * $lineCount;
+          }
         }
+        $aggregatedData["auxiliaryKeyspace"] = $lineCountProduct;
       }
-      $aggregatedData["auxiliaryKeyspace"] = $lineCountProduct;
     }
     
     return $aggregatedData;

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -69,7 +69,7 @@ class PreTaskAPI extends AbstractModelAPI {
   }
   
   //TODO make aggregate data queryable and not included by default
-  function aggregateData(object $object, array &$included_data = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
     if (is_null($aggregateFieldsets) || array_key_exists('pretask', $aggregateFieldsets)) {
       

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -199,7 +199,7 @@ class TaskAPI extends AbstractModelAPI {
     /** @var $object Task */
     $aggregatedData = [];
     
-    if (array_key_exists('task', $aggregateFieldsets)) {
+    if (!is_null($aggregateFieldsets) && array_key_exists('task', $aggregateFieldsets)) {
       $aggregateFieldsets['task'] = explode(",", $aggregateFieldsets['task']);
       
       if (in_array("assignedAgents", $aggregateFieldsets['task'])) {

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -142,17 +142,106 @@ class TaskAPI extends AbstractModelAPI {
   public function getAggregateFieldsets(): array {
     return [
       'task' => [
-        'totalAssignedAgents',
-        'dispatched',
-        'searched',
-        'status',
-        'totalNumberOfChunks',
-        'currentSpeed',
-        'estimatedTime',
-        'cprogress',
-        'timeSpent'
+        'totalAssignedAgents' => [$this, 'getAggregateTotalAssignedAgents'],
+        'dispatched' => [$this, 'getAggregateDispatched'],
+        'searched' => [$this, 'getAggregateSearched'],
+        'status' => [$this, 'getAggregateStatus'],
+        'totalNumberOfChunks' => [$this, 'getAggregateTotalChunks'],
+        'currentSpeed' => [$this, 'getAggregateCurrentSpeed'],
+        'estimatedTime' => [$this, 'getAggregateEstimatedTime'],
+        'cprogress' => [$this, 'getAggregateCProgress'],
+        'timeSpent' => [$this, 'getAggregateTimeSpent'],
       ]
     ];
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateTotalAssignedAgents(object $object): int {
+    $qF = new QueryFilter(Assignment::TASK_ID, $object->getId(), "=");
+    return Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);
+  }
+  
+  protected function getAggregateDispatched(object $object): string {
+    /** @var Task $object */
+    $keyspace = $object->getKeyspace();
+    $keyspaceProgress = $object->getKeyspaceProgress();
+    return Util::showperc($keyspaceProgress, $keyspace);
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateSearched(object $object): string {
+    /** @var Task $object */
+    $keyspace = $object->getKeyspace();
+    return Util::showperc(TaskUtils::getTaskProgress($object), $keyspace);
+  }
+  
+  protected function getAggregateStatus(object $object): int {
+    /** @var Task $object */
+    $keyspace = $object->getKeyspace();
+    $keyspaceProgress = $object->getKeyspaceProgress();
+    
+    // the filter for progress is needed so we reduce the checked chunks numbers by a lot
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+    $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+    return TaskUtils::getStatus($chunks, $keyspace, $keyspaceProgress);
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateTotalChunks(object $object): int {
+    $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
+    return Factory::getChunkFactory()->countFilter([Factory::FILTER => $qF]);
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateCurrentSpeed(object $object): int {
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
+    $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+    $agg = new Aggregation(Chunk::SPEED, Aggregation::SUM);
+    $speed = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg])[$agg->getName()];
+    if ($speed == null) {
+      $speed = 0;
+    }
+    return $speed;
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateEstimatedTime(object $object): int {
+    /** @var Task $object */
+    $keyspace = $object->getKeyspace();
+    
+    // not a 100% efficient, but we would have to break up the nice generic handling of the aggregations to deal with this
+    $cProgress = $this->getAggregateCProgress($object);
+    $timeSpent = $this->getAggregateTimeSpent($object);
+    
+    return ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateCProgress(object $object): int {
+    /** @var Task $object */
+    return TaskUtils::getTaskProgress($object);
+  }
+  
+  /**
+   * @throws Exception
+   */
+  protected function getAggregateTimeSpent(object $object): int {
+    /** @var Task $object */
+    return TaskUtils::getTimeSpentOnTask($object);
   }
   
   /**
@@ -186,86 +275,6 @@ class TaskAPI extends AbstractModelAPI {
     );
     
     return $task->getId();
-  }
-  
-  /**
-   * @param object $object
-   * @param array $includedData
-   * @param array|null $aggregateFieldsets
-   * @return array
-   * @throws Exception
-   */
-  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
-    /** @var Task $object */
-    $aggregatedData = [];
-    
-    if (!is_null($aggregateFieldsets) && array_key_exists('task', $aggregateFieldsets)) {
-      $aggregateFieldsets['task'] = explode(",", $aggregateFieldsets['task']);
-      
-      if (in_array("assignedAgents", $aggregateFieldsets['task'])) {
-        $qF = new QueryFilter(Assignment::TASK_ID, $object->getId(), "=");
-        $assignedAgents = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);
-        $aggregatedData["totalAssignedAgents"] = $assignedAgents;
-      }
-      
-      $keyspace = $object->getKeyspace();
-      $keyspaceProgress = $object->getKeyspaceProgress();
-      
-      if (in_array("dispatched", $aggregateFieldsets['task'])) {
-        $aggregatedData["dispatched"] = Util::showperc($keyspaceProgress, $keyspace);
-      }
-      
-      if (in_array("searched", $aggregateFieldsets['task'])) {
-        $aggregatedData["searched"] = Util::showperc(TaskUtils::getTaskProgress($object), $keyspace);
-      }
-      
-      if (in_array("status", $aggregateFieldsets['task'])) {
-        // the filter for progress is needed so we reduce the checked chunks numbers by a lot
-        $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
-        $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
-        $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
-        $aggregatedData["status"] = TaskUtils::getStatus($chunks, $keyspace, $keyspaceProgress);
-      }
-      
-      if (in_array("totalNumberOfChunks", $aggregateFieldsets['task'])) {
-        $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
-        $aggregatedData["totalNumberOfChunks"] = Factory::getChunkFactory()->countFilter([Factory::FILTER => $qF]);
-      }
-      
-      if (in_array("currentSpeed", $aggregateFieldsets['task'])) {
-        $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
-        $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
-        $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
-        $agg = new Aggregation(Chunk::SPEED, Aggregation::SUM);
-        $speed = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg])[$agg->getName()];
-        if ($speed == null) {
-          $speed = 0;
-        }
-        $aggregatedData["currentSpeed"] = $speed;
-      }
-      
-      if (in_array("estimatedTime", $aggregateFieldsets['task']) ||
-        in_array("timeSpent", $aggregateFieldsets['task']) ||
-        in_array("cprogress", $aggregateFieldsets['task'])) {
-        
-        $cProgress = TaskUtils::getTaskProgress($object);
-        if (in_array("cprogress", $aggregateFieldsets['task'])) {
-          $aggregatedData["cprogress"] = $cProgress;
-        }
-        
-        $timeSpent = TaskUtils::getTimeSpentOnTask($object);
-        
-        if (in_array("timeSpent", $aggregateFieldsets['task'])) {
-          $aggregatedData["timeSpent"] = $timeSpent;
-        }
-        
-        if (in_array("estimatedTime", $aggregateFieldsets['task'])) {
-          $aggregatedData["estimatedTime"] = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
-        }
-      }
-    }
-    
-    return $aggregatedData;
   }
   
   protected function deleteObject(object $object): void {

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -183,7 +183,7 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   //TODO make aggregate data queryable and not included by default
-  function aggregateData(object $object, array &$included_data = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
     
     if (is_null($aggregateFieldsets) || array_key_exists('task', $aggregateFieldsets)) {

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
+use Hashtopolis\dba\OrderFilter;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DPrince;
 use Hashtopolis\inc\utils\AccessUtils;
@@ -136,15 +138,19 @@ class TaskAPI extends AbstractModelAPI {
       "files" => ['type' => 'array', 'subtype' => 'int'],
     ];
   }
-
+  
   public function getAggregateFieldsets(): array {
     return [
       'task' => [
-        'assignedAgents',
+        'totalAssignedAgents',
         'dispatched',
         'searched',
-        'isActive',
-        'taskExtraDetails',
+        'status',
+        'totalNumberOfChunks',
+        'currentSpeed',
+        'estimatedTime',
+        'cprogress',
+        'timeSpent'
       ]
     ];
   }
@@ -182,88 +188,88 @@ class TaskAPI extends AbstractModelAPI {
     return $task->getId();
   }
   
-  //TODO make aggregate data queryable and not included by default
+  /**
+   * @param object $object
+   * @param array $includedData
+   * @param array|null $aggregateFieldsets
+   * @return array
+   * @throws Exception
+   */
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
+    /** @var $object Task */
     $aggregatedData = [];
     
-    if (is_null($aggregateFieldsets) || array_key_exists('task', $aggregateFieldsets)) {
-      if (!is_null($aggregateFieldsets)) {
-        $aggregateFieldsets['task'] = explode(",", $aggregateFieldsets['task']);
-      }
+    if (array_key_exists('task', $aggregateFieldsets)) {
+      $aggregateFieldsets['task'] = explode(",", $aggregateFieldsets['task']);
       
-      $assignedAgents = [];
-      if (is_null($aggregateFieldsets) || in_array("assignedAgents", $aggregateFieldsets['task'])) {
+      if (in_array("assignedAgents", $aggregateFieldsets['task'])) {
         $qF = new QueryFilter(Assignment::TASK_ID, $object->getId(), "=");
         $assignedAgents = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);
         $aggregatedData["totalAssignedAgents"] = $assignedAgents;
       }
+      
       $keyspace = $object->getKeyspace();
       $keyspaceProgress = $object->getKeyspaceProgress();
       
-      if (is_null($aggregateFieldsets) || in_array("dispatched", $aggregateFieldsets['task'])) {
+      if (in_array("dispatched", $aggregateFieldsets['task'])) {
         $aggregatedData["dispatched"] = Util::showperc($keyspaceProgress, $keyspace);
       }
       
-      if (is_null($aggregateFieldsets) || in_array("searched", $aggregateFieldsets['task'])) {
+      if (in_array("searched", $aggregateFieldsets['task'])) {
         $aggregatedData["searched"] = Util::showperc(TaskUtils::getTaskProgress($object), $keyspace);
       }
-
-      $chunks = null;
-      if (is_null($aggregateFieldsets) || in_array("isActive", $aggregateFieldsets['task'])) {
-        $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
-        $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
+      
+      if (in_array("status", $aggregateFieldsets['task'])) {
+        // the filter for progress is needed so we reduce the checked chunks numbers by a lot
+        $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
+        $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+        $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
         $aggregatedData["status"] = TaskUtils::getStatus($chunks, $keyspace, $keyspaceProgress);
       }
-      if (is_null($aggregateFieldsets) || in_array("totalNumberOfChunks", $aggregateFieldsets['task'])) {
+      
+      if (in_array("totalNumberOfChunks", $aggregateFieldsets['task'])) {
         $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
         $aggregatedData["totalNumberOfChunks"] = Factory::getChunkFactory()->countFilter([Factory::FILTER => $qF]);
       }
-      if (is_null($aggregateFieldsets) || in_array("taskExtraDetails", $aggregateFieldsets['task'])) {
-        $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
-        if (!isset($chunks)){
-          $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
+      
+      if (in_array("currentSpeed", $aggregateFieldsets['task'])) {
+        $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
+        $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
+        $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+        $agg = new Aggregation(Chunk::SPEED, Aggregation::SUM);
+        $speed = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg])[$agg->getName()];
+        if ($speed == null) {
+          $speed = 0;
+        }
+        $aggregatedData["currentSpeed"] = $speed;
+      }
+      
+      if (in_array("estimatedTime", $aggregateFieldsets['task']) ||
+        in_array("timeSpent", $aggregateFieldsets['task']) ||
+        in_array("cprogress", $aggregateFieldsets['task'])) {
+        
+        $cProgress = TaskUtils::getTaskProgress($object);
+        if (in_array("cprogress", $aggregateFieldsets['task'])) {
+          $aggregatedData["cprogress"] = $cProgress;
         }
         
-        $currentSpeed = 0;
-        $cProgress = 0;
+        $timeSpent = TaskUtils::getTimeSpentOnTask($object);
         
-        foreach ($chunks as $chunk) {
-          $cProgress += $chunk->getCheckpoint() - $chunk->getSkip();
-          if (time() - max($chunk->getSolveTime(), $chunk->getDispatchTime()) < SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT) && $chunk->getProgress() < 10000) {
-            $currentSpeed += $chunk->getSpeed();
-          }
+        if (in_array("timeSpent", $aggregateFieldsets['task'])) {
+          $aggregatedData["timeSpent"] = $timeSpent;
         }
-          
-        $timeChunks = $chunks;
-        usort($timeChunks, ["Hashtopolis\inc\Util", "compareChunksTime"]);
-        $timeSpent = 0;
-        $current = 0;
         
-        foreach ($timeChunks as $c) {
-          if ($c->getDispatchTime() > $current) {
-            $timeSpent += $c->getSolveTime() - $c->getDispatchTime();
-            $current = $c->getSolveTime();
-          }
-          else if ($c->getSolveTime() > $current) {
-            $timeSpent += $c->getSolveTime() - $current;
-            $current = $c->getSolveTime();
-          }
+        if (in_array("estimatedTime", $aggregateFieldsets['task'])) {
+          $aggregatedData["estimatedTime"] = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
         }
-
-        $keyspace = $object->getKeyspace();
-        $estimatedTime = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
-        
-        $aggregatedData["estimatedTime"] = $estimatedTime;
-        $aggregatedData["timeSpent"] = $timeSpent;
-        $aggregatedData["currentSpeed"] = $currentSpeed;
-        $aggregatedData["cprogress"] = $cProgress;
       }
     }
-
+    
     return $aggregatedData;
   }
   
   protected function deleteObject(object $object): void {
+    /** @var $object Task */
     TaskUtils::deleteTask($object);
   }
   

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -196,7 +196,7 @@ class TaskAPI extends AbstractModelAPI {
    * @throws Exception
    */
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
-    /** @var $object Task */
+    /** @var Task $object */
     $aggregatedData = [];
     
     if (!is_null($aggregateFieldsets) && array_key_exists('task', $aggregateFieldsets)) {
@@ -269,7 +269,7 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   protected function deleteObject(object $object): void {
-    /** @var $object Task */
+    /** @var Task $object */
     TaskUtils::deleteTask($object);
   }
   

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -93,9 +93,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   /**
    * @throws HttpError
    */
-  protected function getAggregateDispatched(object $object): string {
+  protected function getAggregateDispatched(object $object): ?string {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
-      throw new HttpError("Not possible to aggregate dispatched on other types than normal task!");
+      return null;
     }
     
     $keyspace = $object->getKeyspace();
@@ -107,9 +107,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateSearched(object $object): string {
+  protected function getAggregateSearched(object $object): ?string {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
-      throw new HttpError("Not possible to aggregate searched on other types than normal task!");
+      return null;
     }
     
     $keyspace = $object->getKeyspace();
@@ -153,9 +153,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateCurrentSpeed(object $object): int {
+  protected function getAggregateCurrentSpeed(object $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
-      throw new HttpError("Not possible to aggregate currentSpeed on other types than normal task!");
+      return null;
     }
     
     $task = TaskUtils::getTasksOfWrapper($object->getId())[0];
@@ -175,9 +175,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateEstimatedTime(object $object): int {
+  protected function getAggregateEstimatedTime(object $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
-      throw new HttpError("Not possible to aggregate estimatedTime on other types than normal task!");
+      return null;
     }
     
     $keyspace = $object->getKeyspace();
@@ -190,9 +190,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateCProgress(object $object): int {
+  protected function getAggregateCProgress(object $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
-      throw new HttpError("Not possible to aggregate cprogress on other types than normal task!");
+      return null;
     }
     
     $task = TaskUtils::getTasksOfWrapper($object->getId())[0];
@@ -203,9 +203,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateTimeSpent(object $object): int {
+  protected function getAggregateTimeSpent(object $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
-      throw new HttpError("Not possible to aggregate timeSpent on other types than normal task!");
+      return null;
     }
     
     $task = TaskUtils::getTasksOfWrapper($object->getId())[0];

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
+use Hashtopolis\dba\Aggregation;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\Factory;
@@ -61,95 +63,118 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
       ]
     ];
   }
-
-  //TODO make aggregate data queryable and not included by default
+  
+  public function getAggregateFieldsets(): array {
+    return [
+      'taskwrapperdisplay' => [
+        'totalAssignedAgents',
+        'dispatched',
+        'searched',
+        'status',
+        'currentSpeed',
+        'estimatedTime',
+        'cprogress',
+        'timeSpent'
+      ]
+    ];
+  }
+  
+  /**
+   * @param object $object
+   * @param array $includedData
+   * @param array|null $aggregateFieldsets
+   * @return array
+   * @throws Exception
+   */
   function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
-    if (is_null($aggregateFieldsets) || array_key_exists('taskwrapperdisplay', $aggregateFieldsets)) {
-      $tasks = TaskUtils::getTasksOfWrapper($object->getId());
-      $completed = 0;
-      $total = 0;
-      $status = 0;
-      foreach($tasks as $task) {
-        $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-        $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
-        $taskStatus = TaskUtils::getStatus($chunks, $task->getKeyspace(), $task->getKeyspaceProgress());
-        // if one task of the wrapper is running, it is running
-        if ($taskStatus === 1) {
-          $status = 1;
-          break;
+    
+    if (!is_null($aggregateFieldsets) && array_key_exists('taskwrapperdisplay', $aggregateFieldsets)) {
+      $aggregateFieldsets['taskwrapperdisplay'] = explode(",", $aggregateFieldsets['taskwrapperdisplay']);
+      
+      if (in_array("status", $aggregateFieldsets['taskwrapperdisplay'])) {
+        // TODO: this could be optimized by only requesting taskId, keyspace and keyspaceProgress of all tasks of that wrapper (columnFilter)
+        $tasks = TaskUtils::getTasksOfWrapper($object->getId());
+        $completed = 0;
+        $total = 0;
+        $status = 0;
+        foreach($tasks as $task) {
+          $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+          $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+          $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+          $taskStatus = TaskUtils::getStatus($chunks, $task->getKeyspace(), $task->getKeyspaceProgress());
+          // if one task of the wrapper is running, it is running
+          if ($taskStatus === 1) {
+            $status = 1;
+            break;
+          }
+          if ($taskStatus === 3) {
+            $completed++;
+          }
+          $total++;
         }
-        if ($taskStatus === 3) {
-          $completed++;
+        if ($status !== 1) {
+          if ($total > 0 && $completed === $total) {
+            $status = 3;
+          } else {
+            $status = 2;
+          }
         }
-        $total++;
+        $aggregatedData['status'] = $status;
       }
-      if ($status !== 1) {
-        if ($total > 0 && $completed === $total) {
-          $status = 3;
-        } else {
-          $status = 2;
-        }
+      
+      if (in_array("totalAssignedAgents", $aggregateFieldsets['taskwrapperdisplay'])) {
+        $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $object->getId(), "=", Factory::getTaskFactory());
+        $jF = new JoinFilter(Factory::getTaskFactory(), Assignment::TASK_ID, Task::TASK_ID);
+        
+        $assignedAgents = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
+        $aggregatedData["totalAssignedAgents"] = $assignedAgents;
       }
-
-      $aggregatedData['status'] = $status;
       
       $keyspace = $object->getKeyspace();
       $keyspaceProgress = $object->getKeyspaceProgress();
       
       if ($object->getTaskType() === DTaskTypes::NORMAL) {
+        $tasks = TaskUtils::getTasksOfWrapper($object->getId());
         $task = $tasks[0];
         
-        if (is_null($aggregateFieldsets) || in_array("dispatched", $aggregateFieldsets['taskwrapperdisplay'])) {
+        if (in_array("dispatched", $aggregateFieldsets['taskwrapperdisplay'])) {
             $aggregatedData["dispatched"] = Util::showperc($keyspaceProgress, $keyspace);
         }
         
-        if (is_null($aggregateFieldsets) || in_array("searched", $aggregateFieldsets['taskwrapperdisplay'])) {
+        if (in_array("searched", $aggregateFieldsets['taskwrapperdisplay'])) {
           $aggregatedData["searched"] = Util::showperc(TaskUtils::getTaskProgress($task), $keyspace);
         }
-
-        if (!isset($chunks)){
-          $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-          $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
+        
+        if (in_array("currentSpeed", $aggregateFieldsets['taskwrapperdisplay'])) {
+          $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+          $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
+          $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+          $agg = new Aggregation(Chunk::SPEED, Aggregation::SUM);
+          $speed = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg])[$agg->getName()];
+          if ($speed == null) {
+            $speed = 0;
+          }
+          $aggregatedData["currentSpeed"] = $speed;
         }
         
-        if (is_null($aggregateFieldsets) || in_array("taskExtraDetails", $aggregateFieldsets['taskwrapperdisplay'])) {
-          $currentSpeed = 0;
-          $cProgress = 0;
+        if (in_array("estimatedTime", $aggregateFieldsets['taskwrapperdisplay']) ||
+          in_array("timeSpent", $aggregateFieldsets['taskwrapperdisplay']) ||
+          in_array("cprogress", $aggregateFieldsets['taskwrapperdisplay'])) {
           
-          foreach ($chunks as $chunk) {
-            $cProgress += $chunk->getCheckpoint() - $chunk->getSkip();
-            if (time() - max($chunk->getSolveTime(), $chunk->getDispatchTime()) < SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT) && $chunk->getProgress() < 10000) {
-              $currentSpeed += $chunk->getSpeed();
-            }
+          $cProgress = TaskUtils::getTaskProgress($task);
+          if (in_array("cprogress", $aggregateFieldsets['taskwrapperdisplay'])) {
+            $aggregatedData["cprogress"] = $cProgress;
           }
-          $timeChunks = $chunks;
-          usort($timeChunks, ["Hashtopolis\inc\Util", "compareChunksTime"]);
-          $timeSpent = 0;
-          $current = 0;
           
-          foreach ($timeChunks as $c) {
-            if ($c->getDispatchTime() > $current) {
-              $timeSpent += $c->getSolveTime() - $c->getDispatchTime();
-              $current = $c->getSolveTime();
-            }
-            else if ($c->getSolveTime() > $current) {
-              $timeSpent += $c->getSolveTime() - $current;
-              $current = $c->getSolveTime();
-            }
+          $timeSpent = TaskUtils::getTimeSpentOnTask($task);
+          
+          if (in_array("timeSpent", $aggregateFieldsets['taskwrapperdisplay'])) {
+            $aggregatedData["timeSpent"] = $timeSpent;
           }
-
-          $estimatedTime = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
-          $aggregatedData["estimatedTime"] = $estimatedTime;
-          $aggregatedData["timeSpent"] = $timeSpent;
-          $aggregatedData["currentSpeed"] = $currentSpeed;
-          $aggregatedData["cprogress"] = $cProgress;
-
-          $assignedAgents = [];
-          if (is_null($aggregateFieldsets) || in_array("assignedAgents", $aggregateFieldsets['task'])) {
-            $qF = new QueryFilter(Assignment::TASK_ID, $task->getId(), "=");
-            $assignedAgents = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);
-            $aggregatedData["totalAssignedAgents"] = $assignedAgents;
+          
+          if (in_array("estimatedTime", $aggregateFieldsets['taskwrapperdisplay'])) {
+            $aggregatedData["estimatedTime"] = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
           }
         }
       }

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -28,18 +28,19 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/taskwrapperdisplays";
   }
-
+  
   public static function getAvailableMethods(): array {
     return ['GET'];
   }
+  
   public function getRequiredPermissions(string $method): array {
     return [Task::PERM_READ, TaskWrapper::PERM_READ];
   }
-
+  
   public static function getDBAclass(): string {
     return TaskWrapperDisplay::class;
   }
-
+  
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
@@ -49,9 +50,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
     $wrappers = Factory::getTaskWrapperFactory()->filter([Factory::FILTER => [$qF1, $qF2], Factory::JOIN => $jF])[Factory::getTaskWrapperFactory()->getModelName()];
     return count($wrappers) > 0;
   }
-
+  
   protected function getFilterACL(): array {
-
+    
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     
     return [
@@ -67,142 +68,171 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   public function getAggregateFieldsets(): array {
     return [
       'taskwrapperdisplay' => [
-        'totalAssignedAgents',
-        'dispatched',
-        'searched',
-        'status',
-        'currentSpeed',
-        'estimatedTime',
-        'cprogress',
-        'timeSpent'
+        'totalAssignedAgents' => [$this, 'getAggregateTotalAssignedAgents'],
+        'dispatched' => [$this, 'getAggregateDispatched'],
+        'searched' => [$this, 'getAggregateSearched'],
+        'status' => [$this, 'getAggregateStatus'],
+        'currentSpeed' => [$this, 'getAggregateCurrentSpeed'],
+        'estimatedTime' => [$this, 'getAggregateEstimatedTime'],
+        'cprogress' => [$this, 'getAggregateCProgress'],
+        'timeSpent' => [$this, 'getAggregateTimeSpent'],
       ]
     ];
   }
   
   /**
-   * @param object $object
-   * @param array $includedData
-   * @param array|null $aggregateFieldsets
-   * @return array
    * @throws Exception
    */
-  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
-    $aggregatedData = [];
+  protected function getAggregateTotalAssignedAgents(object $object): int {
+    $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $object->getId(), "=", Factory::getTaskFactory());
+    $jF = new JoinFilter(Factory::getTaskFactory(), Assignment::TASK_ID, Task::TASK_ID);
     
-    if (!is_null($aggregateFieldsets) && array_key_exists('taskwrapperdisplay', $aggregateFieldsets)) {
-      $aggregateFieldsets['taskwrapperdisplay'] = explode(",", $aggregateFieldsets['taskwrapperdisplay']);
-      
-      if (in_array("status", $aggregateFieldsets['taskwrapperdisplay'])) {
-        // TODO: this could be optimized by only requesting taskId, keyspace and keyspaceProgress of all tasks of that wrapper (columnFilter)
-        $tasks = TaskUtils::getTasksOfWrapper($object->getId());
-        $completed = 0;
-        $total = 0;
-        $status = 0;
-        foreach($tasks as $task) {
-          $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-          $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
-          $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
-          $taskStatus = TaskUtils::getStatus($chunks, $task->getKeyspace(), $task->getKeyspaceProgress());
-          // if one task of the wrapper is running, it is running
-          if ($taskStatus === 1) {
-            $status = 1;
-            break;
-          }
-          if ($taskStatus === 3) {
-            $completed++;
-          }
-          $total++;
-        }
-        if ($status !== 1) {
-          if ($total > 0 && $completed === $total) {
-            $status = 3;
-          } else {
-            $status = 2;
-          }
-        }
-        $aggregatedData['status'] = $status;
+    return Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
+  }
+  
+  /**
+   * @throws HttpError
+   */
+  protected function getAggregateDispatched(object $object): string {
+    if ($object->getTaskType() !== DTaskTypes::NORMAL) {
+      throw new HttpError("Not possible to aggregate dispatched on other types than normal task!");
+    }
+    
+    $keyspace = $object->getKeyspace();
+    $keyspaceProgress = $object->getKeyspaceProgress();
+    return Util::showperc($keyspaceProgress, $keyspace);
+  }
+  
+  /**
+   * @throws HttpError
+   * @throws Exception
+   */
+  protected function getAggregateSearched(object $object): string {
+    if ($object->getTaskType() !== DTaskTypes::NORMAL) {
+      throw new HttpError("Not possible to aggregate searched on other types than normal task!");
+    }
+    
+    $keyspace = $object->getKeyspace();
+    $task = TaskUtils::getTasksOfWrapper($object->getId())[0];
+    return Util::showperc(TaskUtils::getTaskProgress($task), $keyspace);
+  }
+  
+  protected function getAggregateStatus(object $object): int {
+    // TODO: this could be optimized by only requesting taskId, keyspace and keyspaceProgress of all tasks of that wrapper (columnFilter)
+    $tasks = TaskUtils::getTasksOfWrapper($object->getId());
+    $completed = 0;
+    $total = 0;
+    $status = 0;
+    foreach ($tasks as $task) {
+      $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+      $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+      $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
+      $taskStatus = TaskUtils::getStatus($chunks, $task->getKeyspace(), $task->getKeyspaceProgress());
+      // if one task of the wrapper is running, it is running
+      if ($taskStatus === 1) {
+        $status = 1;
+        break;
       }
-      
-      if (in_array("totalAssignedAgents", $aggregateFieldsets['taskwrapperdisplay'])) {
-        $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $object->getId(), "=", Factory::getTaskFactory());
-        $jF = new JoinFilter(Factory::getTaskFactory(), Assignment::TASK_ID, Task::TASK_ID);
-        
-        $assignedAgents = Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
-        $aggregatedData["totalAssignedAgents"] = $assignedAgents;
+      if ($taskStatus === 3) {
+        $completed++;
       }
-      
-      $keyspace = $object->getKeyspace();
-      $keyspaceProgress = $object->getKeyspaceProgress();
-      
-      if ($object->getTaskType() === DTaskTypes::NORMAL) {
-        $tasks = TaskUtils::getTasksOfWrapper($object->getId());
-        $task = $tasks[0];
-        
-        if (in_array("dispatched", $aggregateFieldsets['taskwrapperdisplay'])) {
-            $aggregatedData["dispatched"] = Util::showperc($keyspaceProgress, $keyspace);
-        }
-        
-        if (in_array("searched", $aggregateFieldsets['taskwrapperdisplay'])) {
-          $aggregatedData["searched"] = Util::showperc(TaskUtils::getTaskProgress($task), $keyspace);
-        }
-        
-        if (in_array("currentSpeed", $aggregateFieldsets['taskwrapperdisplay'])) {
-          $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
-          $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
-          $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
-          $agg = new Aggregation(Chunk::SPEED, Aggregation::SUM);
-          $speed = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg])[$agg->getName()];
-          if ($speed == null) {
-            $speed = 0;
-          }
-          $aggregatedData["currentSpeed"] = $speed;
-        }
-        
-        if (in_array("estimatedTime", $aggregateFieldsets['taskwrapperdisplay']) ||
-          in_array("timeSpent", $aggregateFieldsets['taskwrapperdisplay']) ||
-          in_array("cprogress", $aggregateFieldsets['taskwrapperdisplay'])) {
-          
-          $cProgress = TaskUtils::getTaskProgress($task);
-          if (in_array("cprogress", $aggregateFieldsets['taskwrapperdisplay'])) {
-            $aggregatedData["cprogress"] = $cProgress;
-          }
-          
-          $timeSpent = TaskUtils::getTimeSpentOnTask($task);
-          
-          if (in_array("timeSpent", $aggregateFieldsets['taskwrapperdisplay'])) {
-            $aggregatedData["timeSpent"] = $timeSpent;
-          }
-          
-          if (in_array("estimatedTime", $aggregateFieldsets['taskwrapperdisplay'])) {
-            $aggregatedData["estimatedTime"] = ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
-          }
-        }
+      $total++;
+    }
+    if ($status !== 1) {
+      if ($total > 0 && $completed === $total) {
+        $status = 3;
+      }
+      else {
+        $status = 2;
       }
     }
-    return $aggregatedData;
+    return $status;
   }
-
+  
+  /**
+   * @throws HttpError
+   * @throws Exception
+   */
+  protected function getAggregateCurrentSpeed(object $object): int {
+    if ($object->getTaskType() !== DTaskTypes::NORMAL) {
+      throw new HttpError("Not possible to aggregate currentSpeed on other types than normal task!");
+    }
+    
+    $task = TaskUtils::getTasksOfWrapper($object->getId())[0];
+    
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
+    $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
+    $agg = new Aggregation(Chunk::SPEED, Aggregation::SUM);
+    $speed = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => [$qF1, $qF2, $qF3]], [$agg])[$agg->getName()];
+    if ($speed == null) {
+      $speed = 0;
+    }
+    return $speed;
+  }
+  
+  /**
+   * @throws HttpError
+   * @throws Exception
+   */
+  protected function getAggregateEstimatedTime(object $object): int {
+    if ($object->getTaskType() !== DTaskTypes::NORMAL) {
+      throw new HttpError("Not possible to aggregate estimatedTime on other types than normal task!");
+    }
+    
+    $keyspace = $object->getKeyspace();
+    $cProgress = $this->getAggregateCProgress($object);
+    $timeSpent = $this->getAggregateTimeSpent($object);
+    return ($keyspace > 0 && $cProgress > 0) ? round($timeSpent / ($cProgress / $keyspace) - $timeSpent) : 0;
+  }
+  
+  /**
+   * @throws HttpError
+   * @throws Exception
+   */
+  protected function getAggregateCProgress(object $object): int {
+    if ($object->getTaskType() !== DTaskTypes::NORMAL) {
+      throw new HttpError("Not possible to aggregate cprogress on other types than normal task!");
+    }
+    
+    $task = TaskUtils::getTasksOfWrapper($object->getId())[0];
+    return TaskUtils::getTaskProgress($task);
+  }
+  
+  /**
+   * @throws HttpError
+   * @throws Exception
+   */
+  protected function getAggregateTimeSpent(object $object): int {
+    if ($object->getTaskType() !== DTaskTypes::NORMAL) {
+      throw new HttpError("Not possible to aggregate timeSpent on other types than normal task!");
+    }
+    
+    $task = TaskUtils::getTasksOfWrapper($object->getId())[0];
+    return TaskUtils::getTimeSpentOnTask($task);
+  }
+  
   /**
    * @throws HttpError
    */
   protected function createObject(array $data): int {
     throw new HttpError("TaskWrapperDisplays cannot be created via API");
   }
-
+  
   /**
    * @throws HttpError
    */
   public function updateObject(int $objectId, array $data): void {
     throw new HttpError("TaskWrapperDisplays cannot be updated via API");
   }
-
+  
   /**
    * @throws HttpError
    */
   protected function deleteObject(object $object): void {
     throw new HttpError("TaskWrapperDisplays cannot be deleted via API");
   }
-
+  
   public static function getToManyRelationships(): array {
     return [
       'tasks' => [

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -63,7 +63,7 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
 
   //TODO make aggregate data queryable and not included by default
-  function aggregateData(object $object, array &$included_data = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
     if (is_null($aggregateFieldsets) || array_key_exists('taskwrapperdisplay', $aggregateFieldsets)) {
       $tasks = TaskUtils::getTasksOfWrapper($object->getId());

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -1395,7 +1395,7 @@ class TaskUtils {
   
   /**
    * @param $task Task
-   * @return mixed
+   * @return int
    * @throws Exception
    */
   public static function getTaskProgress(Task $task): int {

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\dba\models\AccessGroup;
 use Hashtopolis\dba\models\AccessGroupAgent;
@@ -124,7 +125,7 @@ class TaskUtils {
     $task = TaskUtils::getTask($taskId, $user);
     Factory::getTaskFactory()->set($task, Task::NOTES, $notes);
   }
-
+  
   // Function for taskwrapper api to determine based on the chunks if a task is running, idle or completed.
   // Status 1 is running, 2 is idle and 3 is completed.
   public static function getStatus($chunks, $keyspace, $keyspaceProgress) {
@@ -132,10 +133,11 @@ class TaskUtils {
     $status = 2;
     if ($keyspaceProgress >= $keyspace && $keyspaceProgress > 0) {
       $status = 3;
-    } else {
+    }
+    else {
       $now = time();
       $chunkTimeOut = SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT);
-
+      
       foreach ($chunks as $chunk) {
         if ($now - max($chunk->getSolveTime(), $chunk->getDispatchTime()) < $chunkTimeOut && $chunk->getProgress() < 10000) {
           $status = 1;
@@ -863,7 +865,8 @@ class TaskUtils {
     }
     else if ($benchtype != 'speed' && $benchtype != 'runtime') {
       throw new HttpError("Invalid benchmark type!");
-    } else if ($enforcePipe < 0 || $enforcePipe > 1) {
+    }
+    else if ($enforcePipe < 0 || $enforcePipe > 1) {
       throw new HttpError("Invalid enforce pipe value");
     }
     $benchtype = ($benchtype == 'speed') ? 1 : 0;
@@ -1390,13 +1393,47 @@ class TaskUtils {
       ($task->getMaxAgents() > 0 && $numAssignments >= $task->getMaxAgents()); // at least maxAgents agents are already assigned
   }
   
-  public static function getTaskProgress($task) {
+  /**
+   * @param $task Task
+   * @return mixed
+   * @throws Exception
+   */
+  public static function getTaskProgress(Task $task): int {
     $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     
     $agg1 = new Aggregation(Chunk::CHECKPOINT, Aggregation::SUM);
     $agg2 = new Aggregation(Chunk::SKIP, Aggregation::SUM);
     $results = Factory::getChunkFactory()->multicolAggregationFilter([Factory::FILTER => $qF1], [$agg1, $agg2]);
-    $progress = $results[$agg1->getName()] - $results[$agg2->getName()];
-    return $progress;
+    return $results[$agg1->getName()] - $results[$agg2->getName()];
+  }
+  
+  /**
+   * Get the time spent on a task (not including parallel running).
+   *
+   * @param Task $task
+   * @return int
+   * @throws Exception
+   */
+  public static function getTimeSpentOnTask(Task $task): int {
+    $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
+    $qF2 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
+    $qF3 = new QueryFilter(Chunk::DISPATCH_TIME, 0, ">");
+    $oF = new OrderFilter(Chunk::DISPATCH_TIME, "ASC");
+    $columnRows = Factory::getChunkFactory()->columnFilter([Factory::FILTER => [$qF1, $qF2, $qF3], Factory::ORDER => $oF], [Chunk::DISPATCH_TIME, Chunk::SOLVE_TIME]);
+    
+    $timeSpent = 0;
+    $current = 0;
+    
+    foreach ($columnRows as $row) {
+      if ($row[0] > $current) {
+        $timeSpent += $row[1] - $row[0];
+        $current = $row[1];
+      }
+      else if ($row[1] > $current) {
+        $timeSpent += $row[1] - $current;
+        $current = $row[1];
+      }
+    }
+    return $timeSpent;
   }
 }


### PR DESCRIPTION
This PR changes the behavior of aggregated fields on the API. By default, there will no aggregations be included anymore.

This is needed because at a lot of places where objects are retrieved, the aggregated data is not needed, and this causes a ton of unnecessary load on the queries. The frontend should request required aggregation fields when needed instead of just assuming they are there.

Also all aggregation fields are now called exactly the same as they are requested to be consistent.

NOTE: this PR can only be merged after the frontend is adapted to this.