### PR TITLE
Added migration to add backtick to postgres default blacklist charaters

### DIFF
--- a/src/migrations/mysql/20260617130352_blacklist-chars-sync.sql
+++ b/src/migrations/mysql/20260617130352_blacklist-chars-sync.sql
@@ -1,1 +1,1 @@
-This migration is only a placeholder to keep migrations parallel
+-- This migration is only a placeholder to keep migrations parallel

--- a/src/migrations/mysql/20260617130352_blacklist-chars-sync.sql
+++ b/src/migrations/mysql/20260617130352_blacklist-chars-sync.sql
@@ -1,0 +1,1 @@
+This migration is only a placeholder to keep migrations parallel

--- a/src/migrations/postgres/20260617130352_blacklist-chars-sync.sql
+++ b/src/migrations/postgres/20260617130352_blacklist-chars-sync.sql
@@ -1,0 +1,6 @@
+-- the backtick as default blacklisted character got lost for postgres, so for the cases where people still have the default, we add it
+UPDATE Config
+SET value = '&|"'{}()[]$<>;`'
+WHERE item = 'blacklistChars'
+  AND configSectionId=1
+  AND value = '&|"'{}()[]$<>;';

--- a/src/migrations/postgres/20260617130352_blacklist-chars-sync.sql
+++ b/src/migrations/postgres/20260617130352_blacklist-chars-sync.sql
@@ -1,6 +1,6 @@
 -- the backtick as default blacklisted character got lost for postgres, so for the cases where people still have the default, we add it
 UPDATE Config
-SET value = '&|"'{}()[]$<>;`'
+SET value = '&|"''{}()[]$<>;`'
 WHERE item = 'blacklistChars'
   AND configSectionId=1
-  AND value = '&|"'{}()[]$<>;';
+  AND value = '&|"''{}()[]$<>;';


### PR DESCRIPTION
When introducing postgres, the backtick (`) got lost as default blacklist character in the server config.
This adds it again on setups where the default blacklisted characters were not changed.