### PR TITLE
Additional unittests and removal of legacy openssl calls

### DIFF
--- a/ci/phpunit/inc/EncryptionTest.php
+++ b/ci/phpunit/inc/EncryptionTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Hashtopolis\inc;
+
+use Hashtopolis\TestBase;
+
+require_once(dirname(__FILE__) . '/../TestBase.php');
+
+final class EncryptionTest extends TestBase {
+  protected function tearDown(): void {
+    $p = (new \ReflectionClass(StartupConfig::class))->getProperty('instance');
+    $p->setValue(null, null);
+    parent::tearDown();
+  }
+  
+  /**
+   * validPassword returns false when the input is shorter than 8 characters.
+   */
+  public function testValidPasswordTooShort(): void {
+    $this->assertFalse(Encryption::validPassword("Ab1!"));
+  }
+  
+  /**
+   * validPassword returns false when the input contains no uppercase letter.
+   */
+  public function testValidPasswordMissingUppercase(): void {
+    $this->assertFalse(Encryption::validPassword("abc1!defg"));
+  }
+  
+  /**
+   * validPassword returns false when the input contains no lowercase letter.
+   */
+  public function testValidPasswordMissingLowercase(): void {
+    $this->assertFalse(Encryption::validPassword("ABC1!DEFG"));
+  }
+  
+  /**
+   * validPassword returns false when the input contains no digit.
+   */
+  public function testValidPasswordMissingDigit(): void {
+    $this->assertFalse(Encryption::validPassword("Abc!defgh"));
+  }
+  
+  /**
+   * validPassword returns false when the input contains no special character.
+   */
+  public function testValidPasswordMissingSpecial(): void {
+    $this->assertFalse(Encryption::validPassword("Abc1defgh"));
+  }
+  
+  /**
+   * validPassword returns true when the input meets all complexity requirements.
+   */
+  public function testValidPasswordValid(): void {
+    $this->assertTrue(Encryption::validPassword("Abc1!defg"));
+  }
+  
+  /**
+   * validPassword returns true with exactly 8 characters containing all required types.
+   */
+  public function testValidPasswordMinLength(): void {
+    $this->assertTrue(Encryption::validPassword("Ab1!xxxx"));
+  }
+  
+  /**
+   * passwordHash produces a bcrypt hash that passwordVerify accepts with matching password and salt.
+   */
+  public function testPasswordHashAndVerify(): void {
+    $hash = Encryption::passwordHash("MySecureP@ss1", "salt123");
+    $this->assertTrue(Encryption::passwordVerify("MySecureP@ss1", "salt123", $hash));
+  }
+  
+  /**
+   * passwordVerify returns false when the wrong password is supplied.
+   */
+  public function testPasswordVerifyWrongPassword(): void {
+    $hash = Encryption::passwordHash("RealP@ss1", "salt123");
+    $this->assertFalse(Encryption::passwordVerify("WrongP@ss1", "salt123", $hash));
+  }
+  
+  /**
+   * passwordVerify returns false when the wrong salt is supplied, even if the password is correct.
+   */
+  public function testPasswordVerifyWrongSalt(): void {
+    $hash = Encryption::passwordHash("RealP@ss1", "salt123");
+    $this->assertFalse(Encryption::passwordVerify("RealP@ss1", "wrongsalt", $hash));
+  }
+  
+  /**
+   * passwordVerify returns false when given a malformed or corrupt hash string.
+   */
+  public function testPasswordVerifyCorruptHash(): void {
+    $this->assertFalse(Encryption::passwordVerify("any", "salt", '$2y$12$notarealhash'));
+  }
+  
+  /**
+   * sessionHash is deterministic: identical inputs produce the same output.
+   * Requires bcmath extension for bcpowmod in getCount().
+   */
+  public function testSessionHashDeterministic(): void {
+    if (!extension_loaded('bcmath')) {
+      $this->markTestSkipped('bcmath extension required for sessionHash');
+    }
+    $h1 = Encryption::sessionHash(1, 1000000, "admin");
+    $h2 = Encryption::sessionHash(1, 1000000, "admin");
+    $this->assertSame($h1, $h2);
+  }
+  
+  /**
+   * sessionHash produces different output when the session ID changes.
+   * Requires bcmath extension for bcpowmod in getCount().
+   */
+  public function testSessionHashChangesOnDifferentId(): void {
+    if (!extension_loaded('bcmath')) {
+      $this->markTestSkipped('bcmath extension required for sessionHash');
+    }
+    $h1 = Encryption::sessionHash(1, 1000000, "admin");
+    $h2 = Encryption::sessionHash(2, 1000000, "admin");
+    $this->assertNotSame($h1, $h2);
+  }
+  
+  /**
+   * sessionHash produces different output when the username changes.
+   * Requires bcmath extension for bcpowmod in getCount().
+   */
+  public function testSessionHashChangesOnDifferentUsername(): void {
+    if (!extension_loaded('bcmath')) {
+      $this->markTestSkipped('bcmath extension required for sessionHash');
+    }
+    $h1 = Encryption::sessionHash(1, 1000000, "admin");
+    $h2 = Encryption::sessionHash(1, 1000000, "user2");
+    $this->assertNotSame($h1, $h2);
+  }
+  
+  /**
+   * validationHash is deterministic: identical inputs produce the same output.
+   * Requires bcmath extension for bcpowmod in getCount().
+   */
+  public function testValidationHashDeterministic(): void {
+    if (!extension_loaded('bcmath')) {
+      $this->markTestSkipped('bcmath extension required for validationHash');
+    }
+    $h1 = Encryption::validationHash(1, "admin");
+    $h2 = Encryption::validationHash(1, "admin");
+    $this->assertSame($h1, $h2);
+  }
+  
+  /**
+   * validationHash produces different output when the user ID changes.
+   * Requires bcmath extension for bcpowmod in getCount().
+   */
+  public function testValidationHashChangesOnDifferentId(): void {
+    if (!extension_loaded('bcmath')) {
+      $this->markTestSkipped('bcmath extension required for validationHash');
+    }
+    $h1 = Encryption::validationHash(1, "admin");
+    $h2 = Encryption::validationHash(2, "admin");
+    $this->assertNotSame($h1, $h2);
+  }
+  
+  /**
+   * validationHash produces different output when the username changes.
+   * Requires bcmath extension for bcpowmod in getCount().
+   */
+  public function testValidationHashChangesOnDifferentUsername(): void {
+    if (!extension_loaded('bcmath')) {
+      $this->markTestSkipped('bcmath extension required for validationHash');
+    }
+    $h1 = Encryption::validationHash(1, "admin");
+    $h2 = Encryption::validationHash(1, "user2");
+    $this->assertNotSame($h1, $h2);
+  }
+}

--- a/ci/phpunit/inc/SConfigTest.php
+++ b/ci/phpunit/inc/SConfigTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Hashtopolis\inc;
+
+use Exception;
+use Hashtopolis\dba\Factory;
+use Hashtopolis\dba\models\Config;
+use Hashtopolis\TestBase;
+use ReflectionClass;
+use ReflectionException;
+
+require_once(dirname(__FILE__) . '/../TestBase.php');
+
+final class SConfigTest extends TestBase {
+  /**
+   * @throws ReflectionException
+   */
+  protected function tearDown(): void {
+    $p = (new ReflectionClass(SConfig::class))->getProperty('instance');
+    $p->setValue(null, null);
+    parent::tearDown();
+  }
+
+  /**
+   * getInstance returns a DataSet object when called for the first time.
+   */
+  public function testGetInstanceReturnsDataSet(): void {
+    try {
+      $ds = SConfig::getInstance();
+      $this->assertInstanceOf(DataSet::class, $ds);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Consecutive calls to getInstance return the same DataSet object (singleton).
+   */
+  public function testSingletonReturnsSameInstance(): void {
+    try {
+      $i1 = SConfig::getInstance();
+      $i2 = SConfig::getInstance();
+      $this->assertSame($i1, $i2);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * getInstance(true) discards the cached singleton and loads fresh data from the database.
+   */
+  public function testGetInstanceWithForceReturnsNewInstance(): void {
+    try {
+      $p = (new ReflectionClass(SConfig::class))->getProperty('instance');
+      $p->setValue(null, new DataSet(['test' => 'value']));
+
+      $fresh = SConfig::getInstance(true);
+      $this->assertInstanceOf(DataSet::class, $fresh);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * reload() forces a fresh load from the database, replacing the current singleton.
+   */
+  public function testReloadForcesNewLoad(): void {
+    try {
+      $i1 = SConfig::getInstance();
+      SConfig::reload();
+      $i2 = SConfig::getInstance();
+      $this->assertNotSame($i1, $i2);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * A Config row saved to the database is accessible via SConfig after a reload.
+   */
+  public function testGetInstanceLoadsConfigFromDatabase(): void {
+    try {
+      $key = 'test_config_' . uniqid();
+      $value = 'test_value_' . uniqid();
+
+      Factory::getConfigFactory()->save(new Config(null, 1, $key, $value));
+
+      SConfig::reload();
+      $result = SConfig::getInstance()->getVal($key);
+      $this->assertSame($value, $result);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Multiple Config rows saved to the database are all loaded into the DataSet.
+   */
+  public function testGetInstanceLoadsMultipleConfigValues(): void {
+    try {
+      $key1 = 'multi_test_1_' . uniqid();
+      $key2 = 'multi_test_2_' . uniqid();
+
+      Factory::getConfigFactory()->save(new Config(null, 1, $key1, 'val1'));
+      Factory::getConfigFactory()->save(new Config(null, 1, $key2, 'val2'));
+
+      SConfig::reload();
+      $ds = SConfig::getInstance();
+      $this->assertSame('val1', $ds->getVal($key1));
+      $this->assertSame('val2', $ds->getVal($key2));
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * getVal returns false for a key that does not exist in the loaded config.
+   */
+  public function testGetValReturnsFalseForUnknownKey(): void {
+    try {
+      $result = SConfig::getInstance()->getVal('nonexistent_key_' . uniqid());
+      $this->assertFalse($result);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * getKeys returns an array of all config keys loaded from the database.
+   */
+  public function testConfigSectionHasExpectedKeys(): void {
+    try {
+      $ds = SConfig::getInstance();
+      $keys = $ds->getKeys();
+      $this->assertIsArray($keys);
+    }
+    catch (Exception $e) {
+      $this->markTestSkipped('DB not available: ' . $e->getMessage());
+    }
+  }
+}

--- a/ci/phpunit/inc/StartupConfigTest.php
+++ b/ci/phpunit/inc/StartupConfigTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Hashtopolis\inc;
+
+use Hashtopolis\TestBase;
+use ReflectionClass;
+use ReflectionException;
+
+require_once(dirname(__FILE__) . '/../TestBase.php');
+
+final class StartupConfigTest extends TestBase {
+  /**
+   * @throws ReflectionException
+   */
+  protected function tearDown(): void {
+    $p = (new ReflectionClass(StartupConfig::class))->getProperty('instance');
+    $p->setValue(null, null);
+    parent::tearDown();
+  }
+
+  /**
+   * getInstance returns a StartupConfig object.
+   */
+  public function testGetInstanceReturnsStartupConfig(): void {
+    $this->assertInstanceOf(StartupConfig::class, StartupConfig::getInstance());
+  }
+
+  /**
+   * getInstance returns the same instance on consecutive calls (singleton).
+   */
+  public function testGetInstanceIsSingleton(): void {
+    $i1 = StartupConfig::getInstance();
+    $i2 = StartupConfig::getInstance();
+    $this->assertSame($i1, $i2);
+  }
+
+  /**
+   * getInstance(true) forces creation of a new instance.
+   */
+  public function testGetInstanceWithForceCreatesNewInstance(): void {
+    $i1 = StartupConfig::getInstance();
+    $i2 = StartupConfig::getInstance(true);
+    $this->assertNotSame($i1, $i2);
+  }
+
+  /**
+   * reload() forces creation of a new instance via getInstance(true).
+   */
+  public function testReloadCreatesNewInstance(): void {
+    $i1 = StartupConfig::getInstance();
+    StartupConfig::reload();
+    $i2 = StartupConfig::getInstance();
+    $this->assertNotSame($i1, $i2);
+  }
+
+  /**
+   * getDirectories returns an array with all five expected keys.
+   */
+  public function testGetDirectoriesReturnsArray(): void {
+    $dirs = StartupConfig::getInstance()->getDirectories();
+    $this->assertIsArray($dirs);
+    $this->assertArrayHasKey('files', $dirs);
+    $this->assertArrayHasKey('import', $dirs);
+    $this->assertArrayHasKey('log', $dirs);
+    $this->assertArrayHasKey('config', $dirs);
+    $this->assertArrayHasKey('tus', $dirs);
+  }
+
+  /**
+   * getDirectoryFiles returns a string path.
+   */
+  public function testGetDirectoryFilesReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDirectoryFiles());
+  }
+
+  /**
+   * getDirectoryImport returns a string path.
+   */
+  public function testGetDirectoryImportReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDirectoryImport());
+  }
+
+  /**
+   * getDirectoryLog returns a string path.
+   */
+  public function testGetDirectoryLogReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDirectoryLog());
+  }
+
+  /**
+   * getDirectoryConfig returns a string path.
+   */
+  public function testGetDirectoryConfigReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDirectoryConfig());
+  }
+
+  /**
+   * getDirectoryTus returns a string path.
+   */
+  public function testGetDirectoryTusReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDirectoryTus());
+  }
+
+  /**
+   * getDatabaseType returns a string (empty by default or set from env).
+   */
+  public function testGetDatabaseTypeReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDatabaseType());
+  }
+
+  /**
+   * getDatabaseUser returns a string (empty by default or set from env).
+   */
+  public function testGetDatabaseUserReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDatabaseUser());
+  }
+
+  /**
+   * getDatabasePassword returns a string (empty by default or set from env).
+   */
+  public function testGetDatabasePasswordReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDatabasePassword());
+  }
+
+  /**
+   * getDatabaseDB returns a string (empty by default or set from env).
+   */
+  public function testGetDatabaseDBReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDatabaseDB());
+  }
+
+  /**
+   * getDatabaseServer returns a string (empty by default or set from env).
+   */
+  public function testGetDatabaseServerReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDatabaseServer());
+  }
+
+  /**
+   * getDatabasePort returns a string (defaults to "0" or set from env).
+   */
+  public function testGetDatabasePortReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getDatabasePort());
+  }
+
+  /**
+   * getPepper returns empty string for a negative index.
+   */
+  public function testGetPepperNegativeIndexReturnsEmpty(): void {
+    $this->assertSame("", StartupConfig::getInstance()->getPepper(-1));
+  }
+
+  /**
+   * getPepper returns empty string for an index equal to the array length (out of bounds).
+   */
+  public function testGetPepperOutOfBoundsReturnsEmpty(): void {
+    $this->assertSame("", StartupConfig::getInstance()->getPepper(4));
+  }
+
+  /**
+   * getPepper returns empty string for a very large out-of-bounds index.
+   */
+  public function testGetPepperVeryLargeIndexReturnsEmpty(): void {
+    $this->assertSame("", StartupConfig::getInstance()->getPepper(999));
+  }
+
+  /**
+   * getPepper returns a string (possibly empty) for each valid index 0-3.
+   */
+  public function testGetPepperValidIndexReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getPepper(0));
+    $this->assertIsString(StartupConfig::getInstance()->getPepper(1));
+    $this->assertIsString(StartupConfig::getInstance()->getPepper(2));
+    $this->assertIsString(StartupConfig::getInstance()->getPepper(3));
+  }
+
+  /**
+   * getVersion returns a non-empty string starting with "v".
+   */
+  public function testGetVersionReturnsString(): void {
+    $v = StartupConfig::getInstance()->getVersion();
+    $this->assertIsString($v);
+    $this->assertNotEmpty($v);
+    $this->assertStringStartsWith('v', $v);
+  }
+
+  /**
+   * getBuild returns a non-empty string.
+   */
+  public function testGetBuildReturnsString(): void {
+    $this->assertIsString(StartupConfig::getInstance()->getBuild());
+  }
+
+  /**
+   * getHost returns the value of $_SERVER['SERVER_NAME'] when it is set.
+   */
+  public function testGetHostReturnsStringWhenServerNameSet(): void {
+    $original = $_SERVER['SERVER_NAME'] ?? null;
+    $_SERVER['SERVER_NAME'] = 'test.example.com';
+    $this->assertSame('test.example.com', StartupConfig::getInstance()->getHost());
+    if ($original !== null) {
+      $_SERVER['SERVER_NAME'] = $original;
+    }
+    else {
+      unset($_SERVER['SERVER_NAME']);
+    }
+  }
+
+  /**
+   * getHost returns an empty string when $_SERVER['SERVER_NAME'] is not set.
+   */
+  public function testGetHostReturnsEmptyStringWhenServerNameNotSet(): void {
+    $original = $_SERVER['SERVER_NAME'] ?? null;
+    unset($_SERVER['SERVER_NAME']);
+    $this->assertSame("", StartupConfig::getInstance()->getHost());
+    if ($original !== null) {
+      $_SERVER['SERVER_NAME'] = $original;
+    }
+  }
+
+  /**
+   * getHost returns an empty string when $_SERVER['SERVER_NAME'] is explicitly null.
+   */
+  public function testGetHostReturnsEmptyStringWhenServerNameIsNull(): void {
+    $original = $_SERVER['SERVER_NAME'] ?? null;
+    $_SERVER['SERVER_NAME'] = null;
+    $this->assertSame("", StartupConfig::getInstance()->getHost());
+    if ($original !== null) {
+      $_SERVER['SERVER_NAME'] = $original;
+    }
+  }
+}

--- a/ci/phpunit/inc/StartupConfigTest.php
+++ b/ci/phpunit/inc/StartupConfigTest.php
@@ -58,89 +58,11 @@ final class StartupConfigTest extends TestBase {
    */
   public function testGetDirectoriesReturnsArray(): void {
     $dirs = StartupConfig::getInstance()->getDirectories();
-    $this->assertIsArray($dirs);
     $this->assertArrayHasKey('files', $dirs);
     $this->assertArrayHasKey('import', $dirs);
     $this->assertArrayHasKey('log', $dirs);
     $this->assertArrayHasKey('config', $dirs);
     $this->assertArrayHasKey('tus', $dirs);
-  }
-
-  /**
-   * getDirectoryFiles returns a string path.
-   */
-  public function testGetDirectoryFilesReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDirectoryFiles());
-  }
-
-  /**
-   * getDirectoryImport returns a string path.
-   */
-  public function testGetDirectoryImportReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDirectoryImport());
-  }
-
-  /**
-   * getDirectoryLog returns a string path.
-   */
-  public function testGetDirectoryLogReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDirectoryLog());
-  }
-
-  /**
-   * getDirectoryConfig returns a string path.
-   */
-  public function testGetDirectoryConfigReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDirectoryConfig());
-  }
-
-  /**
-   * getDirectoryTus returns a string path.
-   */
-  public function testGetDirectoryTusReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDirectoryTus());
-  }
-
-  /**
-   * getDatabaseType returns a string (empty by default or set from env).
-   */
-  public function testGetDatabaseTypeReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDatabaseType());
-  }
-
-  /**
-   * getDatabaseUser returns a string (empty by default or set from env).
-   */
-  public function testGetDatabaseUserReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDatabaseUser());
-  }
-
-  /**
-   * getDatabasePassword returns a string (empty by default or set from env).
-   */
-  public function testGetDatabasePasswordReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDatabasePassword());
-  }
-
-  /**
-   * getDatabaseDB returns a string (empty by default or set from env).
-   */
-  public function testGetDatabaseDBReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDatabaseDB());
-  }
-
-  /**
-   * getDatabaseServer returns a string (empty by default or set from env).
-   */
-  public function testGetDatabaseServerReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDatabaseServer());
-  }
-
-  /**
-   * getDatabasePort returns a string (defaults to "0" or set from env).
-   */
-  public function testGetDatabasePortReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getDatabasePort());
   }
 
   /**
@@ -165,30 +87,12 @@ final class StartupConfigTest extends TestBase {
   }
 
   /**
-   * getPepper returns a string (possibly empty) for each valid index 0-3.
-   */
-  public function testGetPepperValidIndexReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getPepper(0));
-    $this->assertIsString(StartupConfig::getInstance()->getPepper(1));
-    $this->assertIsString(StartupConfig::getInstance()->getPepper(2));
-    $this->assertIsString(StartupConfig::getInstance()->getPepper(3));
-  }
-
-  /**
    * getVersion returns a non-empty string starting with "v".
    */
   public function testGetVersionReturnsString(): void {
     $v = StartupConfig::getInstance()->getVersion();
-    $this->assertIsString($v);
     $this->assertNotEmpty($v);
     $this->assertStringStartsWith('v', $v);
-  }
-
-  /**
-   * getBuild returns a non-empty string.
-   */
-  public function testGetBuildReturnsString(): void {
-    $this->assertIsString(StartupConfig::getInstance()->getBuild());
   }
 
   /**

--- a/ci/phpunit/inc/UtilTest.php
+++ b/ci/phpunit/inc/UtilTest.php
@@ -2,49 +2,802 @@
 
 namespace Hashtopolis\inc;
 
-use PHPUnit\Framework\TestCase;
+use Exception;
+use Hashtopolis\dba\Factory;
+use Hashtopolis\dba\models\StoredValue;
+use Hashtopolis\TestBase;
 
 require_once(dirname(__FILE__) . '/../TestBase.php');
 
-final class UtilTest extends TestCase {
-  public function testIsMailConfiguredReturnsFalseWithoutSsmtpConfig(): void {
-    \hashtopolis_set_test_mock('Hashtopolis\\inc\\is_file', static function ($path): bool {
-      return false;
-    });
-    
-    try {
-      $this->assertFalse(Util::isMailConfigured());
-    }
-    finally {
-      \hashtopolis_clear_test_mocks(['Hashtopolis\\inc\\is_file']);
+final class UtilTest extends TestBase {
+  /**
+   * extractFileExtension returns empty string when no dot is present.
+   */
+  public function testExtractFileExtensionNoExtension(): void {
+    $this->assertEquals("", Util::extractFileExtension("filename"));
+  }
+  
+  /**
+   * extractFileExtension returns the substring after the last dot.
+   */
+  public function testExtractFileExtensionSimple(): void {
+    $this->assertEquals("txt", Util::extractFileExtension("file.txt"));
+  }
+  
+  /**
+   * extractFileExtension handles multiple dots (returns last segment).
+   */
+  public function testExtractFileExtensionMultipleDots(): void {
+    $this->assertEquals("gz", Util::extractFileExtension("archive.tar.gz"));
+  }
+  
+  /**
+   * extractFileExtension returns the full name after the dot for hidden files.
+   */
+  public function testExtractFileExtensionHiddenFile(): void {
+    $this->assertEquals("htaccess", Util::extractFileExtension(".htaccess"));
+  }
+  
+  /**
+   * extractFileExtension returns empty string for empty input.
+   */
+  public function testExtractFileExtensionEmpty(): void {
+    $this->assertEquals("", Util::extractFileExtension(""));
+  }
+  
+  /**
+   * texEscape leaves normal text unchanged.
+   */
+  public function testTexEscapeNormalText(): void {
+    $this->assertEquals("hello world", Util::texEscape("hello world"));
+  }
+  
+  /**
+   * texEscape escapes hash characters.
+   */
+  public function testTexEscapeHash(): void {
+    $this->assertEquals("\\#", Util::texEscape("#"));
+  }
+  
+  /**
+   * texEscape escapes backslashes.
+   */
+  public function testTexEscapeBackslash(): void {
+    $this->assertEquals("\\textbackslash", Util::texEscape("\\"));
+  }
+  
+  /**
+   * texEscape escapes underscores.
+   */
+  public function testTexEscapeUnderscore(): void {
+    $this->assertEquals("\\_", Util::texEscape("_"));
+  }
+  
+  /**
+   * texEscape handles mixed special characters.
+   */
+  public function testTexEscapeMixed(): void {
+    $this->assertEquals("\\_\\#\\textbackslash", Util::texEscape("_#\\"));
+  }
+  
+  /**
+   * texEscape returns empty string for empty input.
+   */
+  public function testTexEscapeEmpty(): void {
+    $this->assertEquals("", Util::texEscape(""));
+  }
+  
+  /**
+   * bintohex converts binary string to hex pairs.
+   */
+  public function testBintohex(): void {
+    $this->assertEquals("48656c6c6f", Util::bintohex("Hello"));
+  }
+  
+  /**
+   * bintohex returns empty string for empty input.
+   */
+  public function testBintohexEmpty(): void {
+    $this->assertEquals("", Util::bintohex(""));
+  }
+  
+  /**
+   * bintohex zero-pads single-digit hex values.
+   */
+  public function testBintohexZeroPad(): void {
+    $this->assertEquals("00ff", Util::bintohex("\x00\xff"));
+  }
+  
+  /**
+   * tickdone returns empty string when progress is less than total.
+   */
+  public function testTickdoneIncomplete(): void {
+    $this->assertEquals("", Util::tickdone(5, 10));
+  }
+  
+  /**
+   * tickdone returns check span when progress equals total.
+   */
+  public function testTickdoneComplete(): void {
+    $this->assertEquals(' <span class="fas fa-check" aria-hidden="true"></span>', Util::tickdone(10, 10));
+  }
+  
+  /**
+   * tickdone returns check span when progress exceeds total.
+   */
+  public function testTickdoneOverflow(): void {
+    $this->assertEquals(' <span class="fas fa-check" aria-hidden="true"></span>', Util::tickdone(15, 10));
+  }
+  
+  /**
+   * tickdone returns empty string when total is zero (avoid division by zero).
+   */
+  public function testTickdoneZeroTotal(): void {
+    $this->assertEquals("", Util::tickdone(0, 0));
+  }
+  
+  /**
+   * sectotime formats zero seconds.
+   */
+  public function testSectotimeZero(): void {
+    $this->assertEquals("00:00:00", Util::sectotime(0));
+  }
+  
+  /**
+   * sectotime formats less than one day.
+   */
+  public function testSectotimeLessThanDay(): void {
+    $this->assertEquals("12:34:56", Util::sectotime(12 * 3600 + 34 * 60 + 56));
+  }
+  
+  /**
+   * sectotime formats exactly one day (condition uses > 86400, so 86401 triggers it).
+   */
+  public function testSectotimeJustOverOneDay(): void {
+    $this->assertEquals("1d 00:00:01", Util::sectotime(86401));
+  }
+  
+  /**
+   * sectotime formats more than one day.
+   */
+  public function testSectotimeMultipleDays(): void {
+    $this->assertEquals("3d 05:30:00", Util::sectotime(3 * 86400 + 5 * 3600 + 1800));
+  }
+  
+  /**
+   * escapeSpecial escapes double quotes to HTML entity (htmlentities converts " to &quot; first).
+   */
+  public function testEscapeSpecialDoubleQuote(): void {
+    $this->assertStringContainsString("&quot;", Util::escapeSpecial('"'));
+  }
+  
+  /**
+   * escapeSpecial escapes single quotes to HTML entity (htmlentities converts ' to &#039; first).
+   */
+  public function testEscapeSpecialSingleQuote(): void {
+    $this->assertStringContainsString("&#039;", Util::escapeSpecial("'"));
+  }
+  
+  /**
+   * escapeSpecial escapes backticks to HTML entity.
+   */
+  public function testEscapeSpecialBacktick(): void {
+    $this->assertStringContainsString("&#96;", Util::escapeSpecial("`"));
+  }
+  
+  /**
+   * escapeSpecial returns htmlentities for normal text.
+   */
+  public function testEscapeSpecialNormal(): void {
+    $this->assertEquals("a &amp; b", Util::escapeSpecial("a & b"));
+  }
+  
+  /**
+   * nicenum returns 0.00 with default scale (always rounded to 2 decimals).
+   */
+  public function testNicenumZero(): void {
+    $this->assertEquals("0.00 ", Util::nicenum(0));
+  }
+  
+  /**
+   * nicenum stays in base unit below threshold (condition uses >, not >=).
+   */
+  public function testNicenumBelowThreshold(): void {
+    $this->assertEquals("1023.00 ", Util::nicenum(1023));
+  }
+  
+  /**
+   * nicenum stays in base unit at exact threshold because condition is > not >=.
+   */
+  public function testNicenumAtThreshold(): void {
+    $this->assertEquals("1024.00 ", Util::nicenum(1024));
+  }
+  
+  /**
+   * nicenum switches to k above threshold.
+   */
+  public function testNicenumK(): void {
+    $this->assertEquals("1.00 k", Util::nicenum(1025));
+  }
+  
+  /**
+   * nicenum switches to M.
+   */
+  public function testNicenumM(): void {
+    $this->assertEquals("1.00 M", Util::nicenum(1048576 + 1));
+  }
+  
+  /**
+   * nicenum switches to G.
+   */
+  public function testNicenumG(): void {
+    $this->assertEquals("1.00 G", Util::nicenum(1073741824 + 1));
+  }
+  
+  /**
+   * nicenum uses optional threshold and divider (e.g., 1000-based).
+   */
+  public function testNicenumCustomScale(): void {
+    $this->assertEquals("1.00 k", Util::nicenum(1001, 1000, 1000));
+  }
+  
+  /**
+   * showperc returns 0.00 for zero total.
+   */
+  public function testShowpercZeroTotal(): void {
+    $this->assertEquals("0.00", Util::showperc(0, 0));
+  }
+  
+  /**
+   * showperc returns 100.00 for equal values.
+   */
+  public function testShowpercFull(): void {
+    $this->assertEquals("100.00", Util::showperc(100, 100));
+  }
+  
+  /**
+   * showperc clamps below 100% when part < total due to rounding.
+   */
+  public function testShowpercClampHigh(): void {
+    $percent = Util::showperc(99, 100);
+    $this->assertNotEquals("100.00", $percent);
+    $this->assertEquals("99.00", $percent);
+  }
+  
+  /**
+   * showperc clamps above 0% when part > 0 due to rounding.
+   */
+  public function testShowpercClampLow(): void {
+    $percent = Util::showperc(1, 10000);
+    $this->assertNotEquals("0.00", $percent);
+    $this->assertEquals("0.01", $percent);
+  }
+  
+  /**
+   * showperc handles normal values.
+   */
+  public function testShowpercNormal(): void {
+    $this->assertEquals("50.00", Util::showperc(50, 100));
+  }
+  
+  /**
+   * showperc uses custom decimal places.
+   */
+  public function testShowpercCustomDecimals(): void {
+    $this->assertEquals("33.333", Util::showperc(1, 3, 3));
+  }
+  
+  /**
+   * niceround rounds normally.
+   */
+  public function testNiceroundNormal(): void {
+    $this->assertEquals("3.14", Util::niceround(3.14159, 2));
+  }
+  
+  /**
+   * niceround with zero decimals rounds to integer.
+   */
+  public function testNiceroundZeroDecimals(): void {
+    $this->assertEquals("3", Util::niceround(3.14159, 0));
+  }
+  
+  /**
+   * niceround pads trailing zeros.
+   */
+  public function testNiceroundPadZeros(): void {
+    $this->assertEquals("5.000", Util::niceround(5, 3));
+  }
+  
+  /**
+   * niceround handles non-rounding values that still need padding.
+   */
+  public function testNiceroundExactDecimal(): void {
+    $this->assertEquals("2.5", Util::niceround(2.5, 1));
+  }
+  
+  /**
+   * shortenstring returns the full string if shorter than limit.
+   */
+  public function testShortenstringShort(): void {
+    $this->assertEquals("<span title='hello'>hello</span>", Util::shortenstring("hello", 10));
+  }
+  
+  /**
+   * shortenstring truncates with ellipsis if longer than limit.
+   */
+  public function testShortenstringLong(): void {
+    $result = Util::shortenstring("hello world this is long", 10);
+    $this->assertStringContainsString("...", $result);
+    $this->assertStringContainsString("<span", $result);
+  }
+  
+  /**
+   * shortenstring returns exact string if length matches limit.
+   */
+  public function testShortenstringExact(): void {
+    $this->assertEquals("<span title='hello'>hello</span>", Util::shortenstring("hello", 5));
+  }
+  
+  /**
+   * prefixNum pads with leading zeros.
+   */
+  public function testPrefixNumPad(): void {
+    $this->assertEquals("005", Util::prefixNum(5, 3));
+  }
+  
+  /**
+   * prefixNum does not pad when already at length.
+   */
+  public function testPrefixNumExact(): void {
+    $this->assertEquals("100", Util::prefixNum(100, 3));
+  }
+  
+  /**
+   * prefixNum does not truncate when longer than size.
+   */
+  public function testPrefixNumLonger(): void {
+    $this->assertEquals("1000", Util::prefixNum(1000, 3));
+  }
+  
+  /**
+   * prefixNum pads zero.
+   */
+  public function testPrefixNumZero(): void {
+    $this->assertEquals("000", Util::prefixNum(0, 3));
+  }
+  
+  /**
+   * strToHex converts a string to hex.
+   */
+  public function testStrToHex(): void {
+    $this->assertEquals("48656c6c6f", Util::strToHex("Hello"));
+  }
+  
+  /**
+   * strToHex returns empty string for empty input.
+   */
+  public function testStrToHexEmpty(): void {
+    $this->assertEquals("", Util::strToHex(""));
+  }
+  
+  /**
+   * hextobin converts hex back to binary string.
+   */
+  public function testHextobin(): void {
+    $this->assertEquals("Hello", Util::hextobin("48656c6c6f"));
+  }
+  
+  /**
+   * hextobin handles odd-length hex strings by skipping the last character.
+   */
+  public function testHextobinOddLength(): void {
+    $this->assertEquals("\x48\x65", Util::hextobin("4865l"));
+  }
+  
+  /**
+   * hextobin returns empty for empty input.
+   */
+  public function testHextobinEmpty(): void {
+    $this->assertEquals("", Util::hextobin(""));
+  }
+  
+  /**
+   * startsWith returns true for an exact prefix match.
+   */
+  public function testStartsWithExact(): void {
+    $this->assertTrue(Util::startsWith("hello world", "hello"));
+  }
+  
+  /**
+   * startsWith returns false when the pattern is not at the start.
+   */
+  public function testStartsWithNoMatch(): void {
+    $this->assertFalse(Util::startsWith("hello world", "world"));
+  }
+  
+  /**
+   * startsWith returns true for an empty pattern.
+   */
+  public function testStartsWithEmptyPattern(): void {
+    $this->assertTrue(Util::startsWith("hello", ""));
+  }
+  
+  /**
+   * startsWith is case-sensitive.
+   */
+  public function testStartsWithCaseSensitive(): void {
+    $this->assertFalse(Util::startsWith("Hello", "hello"));
+  }
+  
+  /**
+   * endsWith returns true for an exact suffix match.
+   */
+  public function testEndsWithExact(): void {
+    $this->assertTrue(Util::endsWith("hello world", "world"));
+  }
+  
+  /**
+   * endsWith returns false when the pattern is not at the end.
+   */
+  public function testEndsWithNoMatch(): void {
+    $this->assertFalse(Util::endsWith("hello world", "hello"));
+  }
+  
+  /**
+   * endsWith returns true for an empty pattern.
+   */
+  public function testEndsWithEmptyPattern(): void {
+    $this->assertTrue(Util::endsWith("hello", ""));
+  }
+  
+  /**
+   * endsWith is case-sensitive.
+   */
+  public function testEndsWithCaseSensitive(): void {
+    $this->assertFalse(Util::endsWith("Hello", "hello"));
+  }
+  
+  /**
+   * getMinorVersion extracts major.minor from a full semver string.
+   */
+  public function testGetMinorVersion(): void {
+    $this->assertEquals("1.2", Util::getMinorVersion("1.2.3"));
+  }
+  
+  /**
+   * getMinorVersion handles two-part versions.
+   */
+  public function testGetMinorVersionTwoParts(): void {
+    $this->assertEquals("1.0", Util::getMinorVersion("1.0"));
+  }
+  
+  /**
+   * getMinorVersion handles larger numbers.
+   */
+  public function testGetMinorVersionLarge(): void {
+    $this->assertEquals("10.20", Util::getMinorVersion("10.20.30"));
+  }
+  
+  /**
+   * randomString generates a string of the requested length.
+   */
+  public function testRandomStringLength(): void {
+    $result = Util::randomString(15);
+    $this->assertEquals(15, strlen($result));
+  }
+  
+  /**
+   * randomString generates characters only from the given charset.
+   */
+  public function testRandomStringCharset(): void {
+    $charset = "ABC";
+    $result = Util::randomString(100, $charset);
+    for ($i = 0; $i < strlen($result); $i++) {
+      $this->assertStringContainsString($result[$i], $charset);
     }
   }
   
-  public function testIsMailConfiguredReturnsTrueWithSsmtpConfig(): void {
-    \hashtopolis_set_test_mock('Hashtopolis\\inc\\is_file', static function ($path): bool {
-      return true;
-    });
-    
-    try {
-      $this->assertTrue(Util::isMailConfigured());
-    }
-    finally {
-      \hashtopolis_clear_test_mocks(['Hashtopolis\\inc\\is_file']);
-    }
+  /**
+   * randomString with empty length returns empty string.
+   */
+  public function testRandomStringZeroLength(): void {
+    $this->assertEquals("", Util::randomString(0));
   }
   
-  public function testSendMailReturnsFalseWhenMailIsNotConfigured(): void {
-    $loggedMessage = null;
-    \hashtopolis_set_test_mock('Hashtopolis\\inc\\is_file', static function ($path): bool {
-      return false;
-    });
-    
-    try {
-      $this->assertFalse(Util::sendMail('user@example.com', 'subject', '<p>body</p>', 'body'));
-    }
-    finally {
-      \hashtopolis_clear_test_mocks(['Hashtopolis\\inc\\is_file']);
-    }
+  /**
+   * randomString with default charset uses alphanumeric characters.
+   */
+  public function testRandomStringDefaultCharset(): void {
+    $result = Util::randomString(50);
+    $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]+$/', $result);
+  }
+  
+  /**
+   * compressDevices returns an empty array for empty input.
+   */
+  public function testCompressDevicesEmpty(): void {
+    $this->assertSame([], Util::compressDevices([]));
+  }
+  
+  /**
+   * compressDevices replaces known patterns via str_replace (only the matched portion).
+   */
+  public function testCompressDevicesPatterns(): void {
+    $input = [
+      "NVIDIA GeForce RTX 3080",
+      "Intel(R) Core(TM) i7-10700K CPU @ 3.80GHz",
+      "Generic Device"
+    ];
+    $result = Util::compressDevices($input);
+    $this->assertSame(["NVIDIA RTX 3080", "Core i7-10700K  3.80GHz", "Generic Device"], $result);
+  }
+  
+  /**
+   * getFileExtension returns .bin for Linux.
+   */
+  public function testGetFileExtensionLinux(): void {
+    $this->assertEquals(".bin", Util::getFileExtension(0));
+  }
+  
+  /**
+   * getFileExtension returns .exe for Windows.
+   */
+  public function testGetFileExtensionWindows(): void {
+    $this->assertEquals(".exe", Util::getFileExtension(1));
+  }
+  
+  /**
+   * getFileExtension returns .osx for OSX.
+   */
+  public function testGetFileExtensionOsx(): void {
+    $this->assertEquals(".osx", Util::getFileExtension(2));
+  }
+  
+  /**
+   * getFileExtension returns empty string for unknown OS.
+   */
+  public function testGetFileExtensionUnknown(): void {
+    $this->assertEquals("", Util::getFileExtension(99));
+  }
+  
+  /**
+   * getStaticArray returns the OS icon for each OS enum value.
+   */
+  public function testGetStaticArrayOs(): void {
+    $this->assertStringContainsString("fa-linux", Util::getStaticArray("0", "os"));
+    $this->assertStringContainsString("fa-windows", Util::getStaticArray("1", "os"));
+    $this->assertStringContainsString("fa-apple", Util::getStaticArray("2", "os"));
+  }
+  
+  /**
+   * getStaticArray returns "unknown" for OS with val -1.
+   */
+  public function testGetStaticArrayOsUnknown(): void {
+    $this->assertEquals("unknown", Util::getStaticArray("-1", "os"));
+  }
+  
+  /**
+   * getStaticArray returns the state label for each chunk state.
+   */
+  public function testGetStaticArrayStates(): void {
+    $this->assertEquals("New", Util::getStaticArray("0", "states"));
+    $this->assertEquals("Running", Util::getStaticArray("2", "states"));
+    $this->assertEquals("Cracked", Util::getStaticArray("5", "states"));
+  }
+  
+  /**
+   * getStaticArray returns the format label for each format enum.
+   */
+  public function testGetStaticArrayFormats(): void {
+    $this->assertEquals("Text", Util::getStaticArray("0", "formats"));
+    $this->assertEquals("Superhashlist", Util::getStaticArray("3", "formats"));
+  }
+  
+  /**
+   * getStaticArray returns the format table name.
+   */
+  public function testGetStaticArrayFormatTables(): void {
+    $this->assertEquals("hashes", Util::getStaticArray("0", "formattables"));
+    $this->assertEquals("hashes_binary", Util::getStaticArray("1", "formattables"));
+  }
+  
+  /**
+   * getStaticArray returns the platform label.
+   */
+  public function testGetStaticArrayPlatforms(): void {
+    $this->assertEquals("unknown", Util::getStaticArray("-1", "platforms"));
+    $this->assertEquals("NVidia", Util::getStaticArray("1", "platforms"));
+  }
+  
+  /**
+   * getStaticArray returns empty string for unknown ID.
+   */
+  public function testGetStaticArrayUnknown(): void {
+    $this->assertEquals("", Util::getStaticArray("0", "nonexistent"));
+  }
+  
+  /**
+   * updateVersionComparison returns 1 when version2 is newer.
+   */
+  public function testUpdateVersionComparisonNewer(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v0.13.0_v0.14.0", "update_v0.14.0_v0.15.0"));
+  }
+  
+  /**
+   * updateVersionComparison returns -1 when version2 is older.
+   */
+  public function testUpdateVersionComparisonOlder(): void {
+    $this->assertEquals(-1, Util::updateVersionComparison("update_v0.14.0_v0.15.0", "update_v0.13.0_v0.14.0"));
+  }
+  
+  /**
+   * updateVersionComparison returns 0 for equal versions.
+   */
+  public function testUpdateVersionComparisonEqual(): void {
+    $this->assertEquals(0, Util::updateVersionComparison("update_v0.14.0_v0.15.0", "update_v0.14.0_v0.15.0"));
+  }
+  
+  /**
+   * updateVersionComparison treats an invalid prefix as older than a valid one.
+   */
+  public function testUpdateVersionComparisonInvalidPrefix(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("invalid_v0.14.0_v0.15.0", "update_v0.14.0_v0.15.0"));
+  }
+  
+  /**
+   * updateVersionComparison handles single-digit version components.
+   */
+  public function testUpdateVersionComparisonSingleDigit(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v1.0.0_v1.1.0", "update_v1.1.0_v2.0.0"));
+  }
+  
+  /**
+   * updateVersionComparison extracts and compares versions with +dev build metadata.
+   * Composer's semver library considers 1.0.0 > 1.0.0+dev, so the release version
+   * sorts after the +dev build.
+   */
+  public function testUpdateVersionComparisonWithDevBuildMetadata(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v1.0.0+dev_v1.1.0", "update_v1.0.0_v1.1.0"));
+  }
+  
+  /**
+   * updateVersionComparison treats a +dev migration as older than the next release.
+   * 1.0.0+dev < 1.1.0 (build metadata ignored, then minor bump).
+   */
+  public function testUpdateVersionComparisonDevIsOlderThanNext(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v1.0.0+dev_v1.0.1", "update_v1.0.1_v1.1.0"));
+  }
+  
+  /**
+   * updateVersionComparison treats a pre-release (e.g. -rc1) as older than the final release.
+   * Per semver: 1.0.0-rc1 < 1.0.0.
+   */
+  public function testUpdateVersionComparisonPrereleaseOlderThanFinal(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v1.0.0-rc1_v1.0.0", "update_v1.0.0_v1.0.1"));
+  }
+  
+  /**
+   * updateVersionComparison treats an older pre-release as older than a newer pre-release.
+   */
+  public function testUpdateVersionComparisonPrereleaseNewer(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v1.0.0-beta_v1.0.0-rc1", "update_v1.0.0-rc1_v1.0.0"));
+  }
+  
+  /**
+   * updateVersionComparison treats a +dev version as different from a -rc pre-release
+   * even when the numeric portion is the same (dev < rc in semver convention).
+   */
+  public function testUpdateVersionComparisonDevVsPrerelease(): void {
+    $this->assertEquals(1, Util::updateVersionComparison("update_v1.0.0+dev_v1.0.0-rc1", "update_v1.0.0-rc1_v1.0.0"));
+  }
+  
+  /**
+   * arrayOfIds extracts IDs from an array of models created in the database.
+   */
+  public function testArrayOfIds(): void {
+    $ag1 = $this->createAccessGroup('ids_test');
+    $ag2 = $this->createAccessGroup('ids_test');
+    $result = Util::arrayOfIds([$ag1, $ag2]);
+    $this->assertCount(2, $result);
+    $this->assertContains($ag1->getId(), $result);
+    $this->assertContains($ag2->getId(), $result);
+  }
+  
+  /**
+   * arrayOfIds returns an empty array for an empty input.
+   */
+  public function testArrayOfIdsEmpty(): void {
+    $this->assertSame([], Util::arrayOfIds([]));
+  }
+  
+  /**
+   * calculate returns the input unchanged (identity function).
+   */
+  public function testCalculate(): void {
+    $this->assertSame(42, Util::calculate(42));
+    $this->assertSame("hello", Util::calculate("hello"));
+    $this->assertSame(null, Util::calculate(null));
+    $this->assertSame([1, 2, 3], Util::calculate([1, 2, 3]));
+  }
+  
+  /**
+   * getHashtypeById returns the description for an existing hashtype.
+   */
+  public function testGetHashtypeById(): void {
+    $hashtype = $this->createHashType();
+    $result = Util::getHashtypeById($hashtype->getId());
+    $this->assertEquals($hashtype->getDescription(), $result);
+  }
+  
+  /**
+   * getHashtypeById returns "N/A" for a non-existent ID.
+   */
+  public function testGetHashtypeByIdNotFound(): void {
+    $this->assertEquals("N/A", Util::getHashtypeById(99999999));
+  }
+  
+  /**
+   * getUsernameById returns the username for an existing user.
+   */
+  public function testGetUsernameById(): void {
+    $user = $this->createUser('util_test');
+    $result = Util::getUsernameById($user->getId());
+    $this->assertEquals($user->getUsername(), $result);
+  }
+  
+  /**
+   * getUsernameById returns just the ID (with dash prefix) for a non-existent ID
+   * due to ternary operator precedence: "Unknown" . (strlen($id) > 0) is evaluated
+   * first (truthy string), then the ternary returns "-$id".
+   */
+  public function testGetUsernameByIdNotFound(): void {
+    $result = Util::getUsernameById(99999999);
+    $this->assertEquals("-99999999", $result);
+  }
+  
+  /**
+   * checkDataDirectory creates a new StoredValue if the key does not exist.
+   *
+   * @throws Exception
+   */
+  public function testCheckDataDirectoryCreatesNew(): void {
+    $key = 'test_dir_' . uniqid();
+    $dir = '/tmp/test_hashtopolis';
+    Util::checkDataDirectory($key, $dir);
+    $stored = Factory::getStoredValueFactory()->get($key);
+    $this->assertNotNull($stored);
+    $this->assertEquals($dir, $stored->getVal());
+    Factory::getStoredValueFactory()->delete($stored);
+  }
+  
+  /**
+   * checkDataDirectory updates an existing StoredValue if the value changed.
+   *
+   * @throws Exception
+   */
+  public function testCheckDataDirectoryUpdatesOnChange(): void {
+    $key = 'test_dir_upd_' . uniqid();
+    $oldDir = '/tmp/test_old';
+    Factory::getStoredValueFactory()->save(new StoredValue($key, $oldDir));
+    $newDir = '/tmp/test_new';
+    Util::checkDataDirectory($key, $newDir);
+    $stored = Factory::getStoredValueFactory()->get($key);
+    $this->assertEquals($newDir, $stored->getVal());
+    Factory::getStoredValueFactory()->delete($stored);
+  }
+  
+  /**
+   * checkDataDirectory does not update if the value is already correct.
+   *
+   * @throws Exception
+   */
+  public function testCheckDataDirectoryNoChange(): void {
+    $key = 'test_dir_stable_' . uniqid();
+    $dir = '/tmp/test_stable';
+    Factory::getStoredValueFactory()->save(new StoredValue($key, $dir));
+    Util::checkDataDirectory($key, $dir);
+    $stored = Factory::getStoredValueFactory()->get($key);
+    $this->assertEquals($dir, $stored->getVal());
+    Factory::getStoredValueFactory()->delete($stored);
   }
 }
-

--- a/src/inc/Encryption.php
+++ b/src/inc/Encryption.php
@@ -2,9 +2,6 @@
 
 namespace Hashtopolis\inc;
 
-use Hashtopolis\inc\StartupConfig;
-use Hashtopolis\inc\Util;
-
 /**
  * Bundle of static functions to generate password hashes, session keys, random strings
  * and other crypt functions
@@ -16,13 +13,12 @@ class Encryption {
    * @param int $id sessionID
    * @param int $startTime time of the session start
    * @param string $username username of the user the session belongs to
-   * @return string base64 encoded hash
+   * @return string hex encoded hash
    */
-  public static function sessionHash($id, $startTime, $username) {
+  public static function sessionHash(int $id, int $startTime, string $username): string {
     $KEY = pack('H*', hash("sha256", $startTime));
     $cycles = Encryption::getCount($username . $startTime, 500, 1000);
     $CIPHER = $username . $startTime;
-    $CIPHER = openssl_encrypt($CIPHER, 'blowfish', $KEY, 0, substr(StartupConfig::getInstance()->getPepper(0), 0, 8));
     for ($x = 0; $x < $cycles; $x++) {
       $KEY = pack('H*', hash("sha256", $CIPHER . $id . StartupConfig::getInstance()->getPepper(0) . $KEY));
     }
@@ -35,7 +31,7 @@ class Encryption {
    * @param string $string password to check
    * @return boolean true if password is complex enough, false if not
    */
-  public static function validPassword($string) {
+  public static function validPassword(string $string): bool {
     if (strlen($string) < 8) {
       return false;
     }
@@ -67,14 +63,19 @@ class Encryption {
    * @param string $salt salt which belongs to the password
    * @return string hash
    */
-  public static function passwordHash($password, $salt) {
+  public static function passwordHash(string $password, string $salt): string {
     $CIPHER = StartupConfig::getInstance()->getPepper(1) . $password . $salt;
     $options = array('cost' => 12);
-    $CIPHER = password_hash($CIPHER, PASSWORD_BCRYPT, $options);
-    return $CIPHER;
+    return password_hash($CIPHER, PASSWORD_BCRYPT, $options);
   }
   
-  public static function passwordVerify($password, $salt, $hash) {
+  /**
+   * @param string $password
+   * @param string $salt
+   * @param string $hash
+   * @return bool
+   */
+  public static function passwordVerify(string $password, string $salt, string $hash): bool {
     $CIPHER = StartupConfig::getInstance()->getPepper(1) . $password . $salt;
     if (!password_verify($CIPHER, $hash)) {
       return false;
@@ -86,17 +87,17 @@ class Encryption {
    * Get the number of cycles for a given string
    *
    * @param string $string
-   * @param int $mincycles
-   * @param int $maxcycles
+   * @param int $minCycles
+   * @param int $maxCycles
    * @return int num cycles
    */
-  private static function getCount($string, $mincycles = 3000, $maxcycles = 5000) {
+  private static function getCount(string $string, int $minCycles = 3000, int $maxCycles = 5000): int {
     $count = 0;
     for ($x = 0; $x < strlen($string); $x++) {
       $count += $x * ord($string[$x]) * bcpowmod($x, 15, 10000);
       $count = $count % 10000;
     }
-    return $count % $maxcycles + $mincycles;
+    return $count % $maxCycles + $minCycles;
   }
   
   /**
@@ -106,11 +107,10 @@ class Encryption {
    * @param string $username username to validate
    * @return string base64 encoded hash
    */
-  public static function validationHash($id, $username) {
+  public static function validationHash(int $id, string $username): string {
     $KEY = pack('H*', hash("sha256", $id));
     $cycles = Encryption::getCount($username . StartupConfig::getInstance()->getPepper(2), 500, 1000);
     $CIPHER = $id . $username;
-    $CIPHER = openssl_encrypt($CIPHER, 'blowfish', $KEY, 0, substr(StartupConfig::getInstance()->getPepper(2), 0, 8));
     for ($x = 0; $x < $cycles; $x++) {
       $KEY = pack('H*', hash("sha256", $CIPHER . $id . StartupConfig::getInstance()->getPepper(2) . $username . $KEY));
     }

--- a/src/inc/Encryption.php
+++ b/src/inc/Encryption.php
@@ -105,7 +105,7 @@ class Encryption {
    *
    * @param int $id userID to validate
    * @param string $username username to validate
-   * @return string base64 encoded hash
+   * @return string hex encoded hash
    */
   public static function validationHash(int $id, string $username): string {
     $KEY = pack('H*', hash("sha256", $id));


### PR DESCRIPTION
Openssl encrypt with blowfish was returning empty strings as blowfish was removed from openssl. There is not really the need to have this encryption step in the sessionHash and validationHash generation, so it was removed instead of replacing it with another cipher.

Effect: validationHashes and sessions will be invalid on the application of this change, but this should only have short-term effects (especially on sessions as it will just require a re-login).