### PR TITLE
Fix include in dba/init

### DIFF
--- a/src/dba/init.php
+++ b/src/dba/init.php
@@ -3,7 +3,7 @@
 require_once(dirname(__FILE__) . "/AbstractModel.php");
 require_once(dirname(__FILE__) . "/AbstractModelFactory.php");
 require_once(dirname(__FILE__) . "/Aggregation.php");
-require_once(dirname(__FILE__) . "/ExistFilter.php");
+require_once(dirname(__FILE__) . "/ExistsFilter.php");
 require_once(dirname(__FILE__) . "/Filter.php");
 require_once(dirname(__FILE__) . "/Order.php");
 require_once(dirname(__FILE__) . "/ConcatColumn.php");


### PR DESCRIPTION
There was a typo in the include and it only happens when you upgrade from non-migrations versions to migrations ones.