### PR TITLE
Fixed LikeFilterInsensitive to cast integer columns to text before LIKE

### DIFF
--- a/ci/apiv2/test_filter_and_ordering.py
+++ b/ci/apiv2/test_filter_and_ordering.py
@@ -26,11 +26,12 @@ class FilterTest(BaseTest):
             objs.append(obj)
             self.delete_after_test(obj)
 
-        result = HashType.objects.filter(hashTypeId__icontains="9900")
-        self.assertEqual([99001, 99002, 99003], sorted([x.id for x in result]))
-
-        result_single = HashType.objects.filter(hashTypeId__icontains="99003")
-        self.assertEqual([99003], [x.id for x in result_single])
+        search = "9900"
+        result = HashType.objects.filter(hashTypeId__icontains=search)
+        all_objs = HashType.objects.all()
+        self.assertEqual(
+            [x.id for x in all_objs if search.lower() in str(x.id).lower()],
+            [x.id for x in result])
 
     def test_filter(self):
         model_objs = self.create_test_objects()

--- a/ci/apiv2/test_filter_and_ordering.py
+++ b/ci/apiv2/test_filter_and_ordering.py
@@ -16,6 +16,22 @@ class FilterTest(BaseTest):
             self.delete_after_test(obj)
         return objs
 
+    def test_filter__icontains_int(self):
+        objs = []
+        for i in [99001, 99002, 99003]:
+            obj = HashType(hashTypeId=i,
+                           description=f"icontains-int {i}",
+                           isSalted=False,
+                           isSlowHash=False).save()
+            objs.append(obj)
+            self.delete_after_test(obj)
+
+        result = HashType.objects.filter(hashTypeId__icontains="9900")
+        self.assertEqual([99001, 99002, 99003], sorted([x.id for x in result]))
+
+        result_single = HashType.objects.filter(hashTypeId__icontains="99003")
+        self.assertEqual([99003], [x.id for x in result_single])
+
     def test_filter(self):
         model_objs = self.create_test_objects()
         objs = HashType.objects.filter(hashTypeId__gte=90000, hashTypeId__lte=91000)

--- a/ci/phpunit/dba/LikeFilterInsensitiveTest.php
+++ b/ci/phpunit/dba/LikeFilterInsensitiveTest.php
@@ -4,37 +4,67 @@ namespace Hashtopolis\dba;
 
 use Exception;
 use Hashtopolis\dba\models\Hashlist;
+use Hashtopolis\dba\models\HashType;
 use Hashtopolis\dba\models\HealthCheckAgent;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\defines\DHashlistFormat;
+use Hashtopolis\inc\StartupConfig;
 use Hashtopolis\TestBase;
 
 require_once(dirname(__FILE__) . '/../TestBase.php');
 
 final class LikeFilterInsensitiveTest extends TestBase {
-  /** Verify query string without table prefix uses 'LOWER(key) LIKE LOWER(?)'. */
+  /** Verify PostgreSQL: `col::text LIKE LOWER(?)` for int column. */
   public function testQueryStringBasic(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=postgres');
+    StartupConfig::getInstance(true);
     $filter = new LikeFilterInsensitive(Hashlist::HASHLIST_ID, '%test%');
     $this->assertEquals(
-      'LOWER(hashlistId) LIKE LOWER(?)',
+      'hashlistId::text LIKE LOWER(?)',
       $filter->getQueryString(Factory::getHashlistFactory())
     );
   }
   
-  /** Verify query string with includeTable=true prefixes the table name. */
-  public function testQueryStringWithTable(): void {
+  /** Verify MySQL: `CONVERT(col, CHAR) LIKE LOWER(?)` for int column. */
+  public function testQueryStringBasicMysql(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=mysql');
+    StartupConfig::getInstance(true);
     $filter = new LikeFilterInsensitive(Hashlist::HASHLIST_ID, '%test%');
     $this->assertEquals(
-      'LOWER(Hashlist.hashlistId) LIKE LOWER(?)',
+      'CONVERT(hashlistId, CHAR) LIKE LOWER(?)',
+      $filter->getQueryString(Factory::getHashlistFactory())
+    );
+  }
+  
+  /** Verify PostgreSQL: `Table.col::text LIKE LOWER(?)` with includeTable=true. */
+  public function testQueryStringWithTable(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=postgres');
+    StartupConfig::getInstance(true);
+    $filter = new LikeFilterInsensitive(Hashlist::HASHLIST_ID, '%test%');
+    $this->assertEquals(
+      'Hashlist.hashlistId::text LIKE LOWER(?)',
+      $filter->getQueryString(Factory::getHashlistFactory(), true)
+    );
+  }
+  
+  /** Verify MySQL: `CONVERT(Table.col, CHAR) LIKE LOWER(?)` with includeTable=true. */
+  public function testQueryStringWithTableMysql(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=mysql');
+    StartupConfig::getInstance(true);
+    $filter = new LikeFilterInsensitive(Hashlist::HASHLIST_ID, '%test%');
+    $this->assertEquals(
+      'CONVERT(Hashlist.hashlistId, CHAR) LIKE LOWER(?)',
       $filter->getQueryString(Factory::getHashlistFactory(), true)
     );
   }
   
   /** Verify overrideFactory forces column resolution from the override, ignoring the passed factory. */
   public function testQueryStringOverrideFactory(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=postgres');
+    StartupConfig::getInstance(true);
     $filter = new LikeFilterInsensitive(Hashlist::HASHLIST_ID, '%test%', Factory::getHashlistFactory());
     $this->assertEquals(
-      'LOWER(hashlistId) LIKE LOWER(?)',
+      'hashlistId::text LIKE LOWER(?)',
       $filter->getQueryString(Factory::getUserFactory())
     );
   }
@@ -48,7 +78,11 @@ final class LikeFilterInsensitiveTest extends TestBase {
     );
   }
   
-  /** Verify mapped column name (htp_end) is used when the column has dba_mapping = True. */
+  /**
+   * Verify mapped int64 column (htp_end) — the type check in the current
+   * implementation only covers 'int', not 'int64', so LOWER() is still
+   * applied to the mapped column name.
+   */
   public function testQueryStringMappedColumn(): void {
     $filter = new LikeFilterInsensitive(HealthCheckAgent::END, '%5%');
     $this->assertEquals(
@@ -77,7 +111,6 @@ final class LikeFilterInsensitiveTest extends TestBase {
   
   /**
    * Create 3 hashlists and filter on hashlistName with a matching prefix.
-   * Only the 2 hashlists whose name contains the prefix should be returned.
    *
    * @throws Exception
    */
@@ -99,9 +132,8 @@ final class LikeFilterInsensitiveTest extends TestBase {
   }
   
   /**
-   * Create 2 hashlists with names that have the same content but different
-   * casing (e.g. "FindMe_xxx" and "findme_yyy") and filter with a case-
-   * insensitive LIKE — both should match.
+   * Verify case-insensitive matching — both uppercase and lowercase names
+   * are found.
    *
    * @throws Exception
    */
@@ -126,8 +158,8 @@ final class LikeFilterInsensitiveTest extends TestBase {
   }
   
   /**
-   * Filter on hashlistName with a pattern that matches none of the existing
-   * hashlists — the result array should be empty.
+   * Filter with a pattern that matches none of the existing hashlists —
+   * result should be empty.
    *
    * @throws Exception
    */
@@ -160,5 +192,97 @@ final class LikeFilterInsensitiveTest extends TestBase {
     $this->assertCount(1, $results);
     $this->assertInstanceOf(User::class, $results[0]);
     $this->assertEquals($user->getId(), $results[0]->getId());
+  }
+  
+  /**
+   * Verify PostgreSQL query string for integer column hashTypeId on
+   * HashType — casts with ::text and omits LOWER().
+   *
+   * @throws Exception
+   */
+  public function testQueryStringIntegerColumn(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=postgres');
+    StartupConfig::getInstance(true);
+    $filter = new LikeFilterInsensitive(HashType::HASH_TYPE_ID, '%1%');
+    $this->assertEquals(
+      'hashTypeId::text LIKE LOWER(?)',
+      $filter->getQueryString(Factory::getHashTypeFactory())
+    );
+  }
+  
+  /**
+   * Verify MySQL query string for integer column hashTypeId on
+   * HashType — wraps with CONVERT(col, CHAR) and omits LOWER().
+   *
+   * @throws Exception
+   */
+  public function testQueryStringIntegerColumnMysql(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=mysql');
+    StartupConfig::getInstance(true);
+    $filter = new LikeFilterInsensitive(HashType::HASH_TYPE_ID, '%1%');
+    $this->assertEquals(
+      'CONVERT(hashTypeId, CHAR) LIKE LOWER(?)',
+      $filter->getQueryString(Factory::getHashTypeFactory())
+    );
+  }
+  
+  /**
+   * Verify query string for the string column description on HashType —
+   * LOWER() is preserved for text-based columns regardless of DB type.
+   *
+   * @throws Exception
+   */
+  public function testQueryStringStringColumn(): void {
+    $filter = new LikeFilterInsensitive(HashType::DESCRIPTION, '%test%');
+    $this->assertEquals(
+      'LOWER(description) LIKE LOWER(?)',
+      $filter->getQueryString(Factory::getHashTypeFactory())
+    );
+  }
+  
+  /**
+   * Integration test: create 2 HashType objects and filter on hashTypeId
+   * (integer primary key) with LikeFilterInsensitive. Verifies the int
+   * cast works end-to-end on the current database backend.
+   *
+   * @throws Exception
+   */
+  public function testFilterLikeIntegerColumn(): void {
+    $hashType1 = $this->createHashType();
+    $this->createHashType();
+    
+    $id1 = $hashType1->getId();
+    
+    $filter = new LikeFilterInsensitive(HashType::HASH_TYPE_ID, '%' . $id1 . '%');
+    $results = Factory::getHashTypeFactory()->filter([Factory::FILTER => $filter]);
+    
+    $this->assertCount(1, $results);
+    $this->assertInstanceOf(HashType::class, $results[0]);
+    $this->assertEquals($id1, $results[0]->getId());
+  }
+  
+  /**
+   * Integration test: create a HealthCheckAgent with a specific status
+   * and filter on HealthCheckAgent::STATUS (int column) with
+   * LikeFilterInsensitive. Verifies the int cast works end-to-end on the
+   * current database backend.
+   *
+   * @throws Exception
+   */
+  public function testFilterLikeIntegerColumnHealthCheckAgent(): void {
+    $crackerBinaryType = $this->createCrackerBinaryType();
+    $crackerBinary = $this->createCrackerBinary($crackerBinaryType);
+    $healthCheck = $this->createHealthCheck($crackerBinary);
+    $agent = $this->createAgent('inttest');
+    
+    $statusValue = 1;
+    $this->createHealthCheckAgent($healthCheck, $agent, $statusValue);
+    
+    $filter = new LikeFilterInsensitive(HealthCheckAgent::STATUS, '%' . $statusValue . '%');
+    $results = Factory::getHealthCheckAgentFactory()->filter([Factory::FILTER => $filter]);
+    
+    $this->assertCount(1, $results);
+    $this->assertInstanceOf(HealthCheckAgent::class, $results[0]);
+    $this->assertEquals($statusValue, $results[0]->getStatus());
   }
 }

--- a/ci/phpunit/dba/LikeFilterInsensitiveTest.php
+++ b/ci/phpunit/dba/LikeFilterInsensitiveTest.php
@@ -78,15 +78,24 @@ final class LikeFilterInsensitiveTest extends TestBase {
     );
   }
   
-  /**
-   * Verify mapped int64 column (htp_end) — the type check in the current
-   * implementation only covers 'int', not 'int64', so LOWER() is still
-   * applied to the mapped column name.
-   */
+  /** Verify PostgreSQL: mapped int64 column casts with ::text and preserves the htp_ prefix. */
   public function testQueryStringMappedColumn(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=postgres');
+    StartupConfig::getInstance(true);
     $filter = new LikeFilterInsensitive(HealthCheckAgent::END, '%5%');
     $this->assertEquals(
-      'LOWER(HealthCheckAgent.htp_end) LIKE LOWER(?)',
+      'HealthCheckAgent.htp_end::text LIKE LOWER(?)',
+      $filter->getQueryString(Factory::getHealthCheckAgentFactory(), true)
+    );
+  }
+  
+  /** Verify MySQL: mapped int64 column uses CONVERT() and preserves the htp_ prefix. */
+  public function testQueryStringMappedColumnMysql(): void {
+    putenv('HASHTOPOLIS_DB_TYPE=mysql');
+    StartupConfig::getInstance(true);
+    $filter = new LikeFilterInsensitive(HealthCheckAgent::END, '%5%');
+    $this->assertEquals(
+      'CONVERT(HealthCheckAgent.htp_end, CHAR) LIKE LOWER(?)',
       $filter->getQueryString(Factory::getHealthCheckAgentFactory(), true)
     );
   }
@@ -284,5 +293,30 @@ final class LikeFilterInsensitiveTest extends TestBase {
     $this->assertCount(1, $results);
     $this->assertInstanceOf(HealthCheckAgent::class, $results[0]);
     $this->assertEquals($statusValue, $results[0]->getStatus());
+  }
+  
+  /**
+   * Integration test: create a HealthCheckAgent with a specific end value
+   * and filter on HealthCheckAgent::END (mapped int64 column) with
+   * LikeFilterInsensitive. Verifies the mapped int64 cast works end-to-end
+   * on the current database backend.
+   *
+   * @throws Exception
+   */
+  public function testFilterLikeMappedInt64Column(): void {
+    $crackerBinaryType = $this->createCrackerBinaryType();
+    $crackerBinary = $this->createCrackerBinary($crackerBinaryType);
+    $healthCheck = $this->createHealthCheck($crackerBinary);
+    $agent = $this->createAgent('mapped64');
+    
+    $endValue = 42;
+    $this->createHealthCheckAgent($healthCheck, $agent, 0, 0, 0, 0, $endValue);
+    
+    $filter = new LikeFilterInsensitive(HealthCheckAgent::END, '%' . $endValue . '%');
+    $results = Factory::getHealthCheckAgentFactory()->filter([Factory::FILTER => $filter]);
+    
+    $this->assertCount(1, $results);
+    $this->assertInstanceOf(HealthCheckAgent::class, $results[0]);
+    $this->assertEquals($endValue, $results[0]->getEnd());
   }
 }

--- a/src/dba/LikeFilterInsensitive.php
+++ b/src/dba/LikeFilterInsensitive.php
@@ -28,7 +28,7 @@ class LikeFilterInsensitive extends Filter {
     $column = $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->key);
     
     // test if we do this on an integer column, if yes, we do not apply LOWER() and need to cast it
-    if ($factory->getNullObject()->getFeatures()[$this->key]['type'] == 'int') {
+    if (str_starts_with($factory->getNullObject()->getFeatures()[$this->key]['type'], 'int')) {
       if (StartupConfig::getInstance()->getDatabaseType() == 'postgres') {
         return $column . "::text LIKE LOWER(?)";
       }

--- a/src/dba/LikeFilterInsensitive.php
+++ b/src/dba/LikeFilterInsensitive.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\dba;
 
+use Hashtopolis\inc\StartupConfig;
+
 class LikeFilterInsensitive extends Filter {
   private string $key;
   private string $value;
@@ -23,7 +25,17 @@ class LikeFilterInsensitive extends Filter {
       $table = $factory->getMappedModelTable() . ".";
     }
     
-    return "LOWER(" . $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(),$this->key) . ") LIKE LOWER(?)";
+    $column = $table . AbstractModelFactory::getMappedModelKey($factory->getNullObject(), $this->key);
+    
+    // test if we do this on an integer column, if yes, we do not apply LOWER() and need to cast it
+    if ($factory->getNullObject()->getFeatures()[$this->key]['type'] == 'int') {
+      if (StartupConfig::getInstance()->getDatabaseType() == 'postgres') {
+        return $column . "::text LIKE LOWER(?)";
+      }
+      return "CONVERT(" . $column . ", CHAR) LIKE LOWER(?)";
+    }
+    
+    return "LOWER(" . $column . ") LIKE LOWER(?)";
   }
   
   function getValue(): string {
@@ -33,7 +45,7 @@ class LikeFilterInsensitive extends Filter {
   function getHasValue(): bool {
     return true;
   }
-
+  
   function getKey() {
     return $this->key;
   }


### PR DESCRIPTION
closes #2277

NOTE: We are now always casting integer to string before like. MySQL was silently casting it before, Postgres does not.