### PR TITLE
Typing rework and warning fixes

### DIFF
--- a/ci/phpunit/TestBase.php
+++ b/ci/phpunit/TestBase.php
@@ -319,9 +319,10 @@ class TestBase extends TestCase {
   /**
    * used to create an object in the database and then register it directly for deletion to be cleaned up after the test
    *
+   * @template TModel of AbstractModel
    * @param AbstractModelFactory $factory
-   * @param AbstractModel $obj
-   * @return AbstractModel
+   * @param TModel $obj
+   * @return TModel
    * @throws Exception
    */
   public function createDatabaseObject(AbstractModelFactory $factory, AbstractModel $obj): AbstractModel {

--- a/ci/phpunit/dba/AbstractModelFactoryTest.php
+++ b/ci/phpunit/dba/AbstractModelFactoryTest.php
@@ -105,6 +105,7 @@ final class AbstractModelFactoryTest extends TestBase {
    *
    * @return void
    * @throws RandomException
+   * @throws Exception
    */
   public function testSaveModelSuccessStaticId(): void {
     $id = 100000 + random_int(10, 999);
@@ -118,6 +119,7 @@ final class AbstractModelFactoryTest extends TestBase {
    * Test creating a hash type object without providing an id and let it auto increment.
    *
    * @return void
+   * @throws Exception
    */
   public function testSaveModelSuccessNoId(): void {
     $hashType = new HashType(null, 'placeholder', 0, 0);
@@ -367,13 +369,11 @@ final class AbstractModelFactoryTest extends TestBase {
     
     Factory::getHashTypeFactory()->inc($hashType1, HashType::IS_SALTED, 2);
     
-    $this->assertTrue($hashType1 instanceof HashType);
     $this->assertEquals(3, $hashType1->getIsSalted());
     $this->assertEquals(1, $hashType2->getIsSalted());
     
     Factory::getHashTypeFactory()->inc($hashType2, HashType::IS_SALTED, 20);
     
-    $this->assertTrue($hashType2 instanceof HashType);
     $this->assertEquals(23, $hashType2->getIsSalted());
     
     $hashTypeUpdated = Factory::getHashTypeFactory()->get($hashType1->getId());
@@ -443,13 +443,11 @@ final class AbstractModelFactoryTest extends TestBase {
     
     Factory::getHashTypeFactory()->dec($hashType1, HashType::IS_SALTED, 2);
     
-    $this->assertTrue($hashType1 instanceof HashType);
     $this->assertEquals(48, $hashType1->getIsSalted());
     $this->assertEquals(50, $hashType2->getIsSalted());
     
     Factory::getHashTypeFactory()->dec($hashType2, HashType::IS_SALTED, 20);
     
-    $this->assertTrue($hashType2 instanceof HashType);
     $this->assertEquals(28, $hashType2->getIsSalted());
     
     $hashTypeUpdated = Factory::getHashTypeFactory()->get($hashType1->getId());

--- a/ci/phpunit/dba/ConcatColumnTest.php
+++ b/ci/phpunit/dba/ConcatColumnTest.php
@@ -22,12 +22,6 @@ final class ConcatColumnTest extends TestBase {
     $this->assertSame($factory, $col->getFactory());
   }
 
-  /** Verify getValue returns null when null is passed as the column key. */
-  public function testNullValue(): void {
-    $col = new ConcatColumn(null, Factory::getHashlistFactory());
-    $this->assertNull($col->getValue());
-  }
-
   /** Verify getValue returns the correct column key for a mapped-table factory (User). */
   public function testUserColumn(): void {
     $col = new ConcatColumn(User::USERNAME, Factory::getUserFactory());

--- a/ci/phpunit/dba/ConcatLikeFilterInsensitiveTest.php
+++ b/ci/phpunit/dba/ConcatLikeFilterInsensitiveTest.php
@@ -3,9 +3,11 @@
 namespace Hashtopolis\dba;
 
 use Exception;
+use Hashtopolis\dba\models\AccessGroup;
 use Hashtopolis\dba\models\HashType;
 use Hashtopolis\dba\models\Hashlist;
 use Hashtopolis\dba\models\User;
+use Hashtopolis\inc\defines\DHashlistFormat;
 use Hashtopolis\TestBase;
 
 require_once(dirname(__FILE__) . '/../TestBase.php');
@@ -91,5 +93,58 @@ final class ConcatLikeFilterInsensitiveTest extends TestBase {
     $result = Factory::getHashTypeFactory()->filter([Factory::FILTER => $filter]);
     
     $this->assertCount(0, $result);
+  }
+  
+  /**
+   * Create two hashlist + hashtype pairs and filter with a CONCAT LIKE
+   * across columns from both joined tables. Only the pair whose
+   * concatenated hashlistName + hashtype description matches the pattern
+   * should be returned.
+   *
+   * @throws Exception
+   */
+  public function testFilterCrossTableConcatLike(): void {
+    $testId = uniqid();
+    
+    $hashType = $this->createDatabaseObject(
+      Factory::getHashTypeFactory(),
+      new HashType(null, 'crypto' . $testId, 0, 0)
+    );
+    
+    $group = $this->createDatabaseObject(
+      Factory::getAccessGroupFactory(),
+      new AccessGroup(null, 'clf_cross_' . $testId)
+    );
+    
+    $hashlist = $this->createDatabaseObject(
+      Factory::getHashlistFactory(),
+      new Hashlist(null, 'bitcoin' . $testId, DHashlistFormat::PLAIN, $hashType->getId(), 1, ':', 0, 0, 0, 0, $group->getId(), '', 0, 0, 0)
+    );
+    
+    // second — non-matching — pair
+    $hashType2 = $this->createDatabaseObject(
+      Factory::getHashTypeFactory(),
+      new HashType(null, 'other' . $testId, 0, 0)
+    );
+    $this->createDatabaseObject(
+      Factory::getHashlistFactory(),
+      new Hashlist(null, 'something' . $testId, DHashlistFormat::PLAIN, $hashType2->getId(), 1, ':', 0, 0, 0, 0, $group->getId(), '', 0, 0, 0)
+    );
+    
+    $jF = new JoinFilter(Factory::getHashTypeFactory(), Hashlist::HASH_TYPE_ID, HashType::HASH_TYPE_ID);
+    
+    $col1 = new ConcatColumn(Hashlist::HASHLIST_NAME, Factory::getHashlistFactory());
+    $col2 = new ConcatColumn(HashType::DESCRIPTION, Factory::getHashTypeFactory());
+    $filter = new ConcatLikeFilterInsensitive([$col1, $col2], '%bitcoin%crypto%' . $testId);
+    
+    $joined = Factory::getHashlistFactory()->filter([Factory::JOIN => $jF, Factory::FILTER => $filter]);
+    
+    $hashlists = $joined[Factory::getHashlistFactory()->getModelName()];
+    $hashTypes = $joined[Factory::getHashTypeFactory()->getModelName()];
+    
+    $this->assertCount(1, $hashlists);
+    $this->assertCount(1, $hashTypes);
+    $this->assertEquals($hashlist->getId(), $hashlists[0]->getId());
+    $this->assertEquals($hashType->getId(), $hashTypes[0]->getId());
   }
 }

--- a/ci/phpunit/inc/SConfigTest.php
+++ b/ci/phpunit/inc/SConfigTest.php
@@ -20,7 +20,7 @@ final class SConfigTest extends TestBase {
     $p->setValue(null, null);
     parent::tearDown();
   }
-
+  
   /**
    * getInstance returns a DataSet object when called for the first time.
    */
@@ -33,7 +33,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * Consecutive calls to getInstance return the same DataSet object (singleton).
    */
@@ -47,7 +47,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * getInstance(true) discards the cached singleton and loads fresh data from the database.
    */
@@ -55,7 +55,7 @@ final class SConfigTest extends TestBase {
     try {
       $p = (new ReflectionClass(SConfig::class))->getProperty('instance');
       $p->setValue(null, new DataSet(['test' => 'value']));
-
+      
       $fresh = SConfig::getInstance(true);
       $this->assertInstanceOf(DataSet::class, $fresh);
     }
@@ -63,7 +63,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * reload() forces a fresh load from the database, replacing the current singleton.
    */
@@ -78,7 +78,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * A Config row saved to the database is accessible via SConfig after a reload.
    */
@@ -86,9 +86,9 @@ final class SConfigTest extends TestBase {
     try {
       $key = 'test_config_' . uniqid();
       $value = 'test_value_' . uniqid();
-
+      
       Factory::getConfigFactory()->save(new Config(null, 1, $key, $value));
-
+      
       SConfig::reload();
       $result = SConfig::getInstance()->getVal($key);
       $this->assertSame($value, $result);
@@ -97,7 +97,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * Multiple Config rows saved to the database are all loaded into the DataSet.
    */
@@ -105,10 +105,10 @@ final class SConfigTest extends TestBase {
     try {
       $key1 = 'multi_test_1_' . uniqid();
       $key2 = 'multi_test_2_' . uniqid();
-
+      
       Factory::getConfigFactory()->save(new Config(null, 1, $key1, 'val1'));
       Factory::getConfigFactory()->save(new Config(null, 1, $key2, 'val2'));
-
+      
       SConfig::reload();
       $ds = SConfig::getInstance();
       $this->assertSame('val1', $ds->getVal($key1));
@@ -118,7 +118,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * getVal returns false for a key that does not exist in the loaded config.
    */
@@ -131,7 +131,7 @@ final class SConfigTest extends TestBase {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());
     }
   }
-
+  
   /**
    * getKeys returns an array of all config keys loaded from the database.
    */
@@ -139,7 +139,7 @@ final class SConfigTest extends TestBase {
     try {
       $ds = SConfig::getInstance();
       $keys = $ds->getKeys();
-      $this->assertIsArray($keys);
+      $this->assertTrue(sizeof($keys) > 0);
     }
     catch (Exception $e) {
       $this->markTestSkipped('DB not available: ' . $e->getMessage());

--- a/src/agentStatus.php
+++ b/src/agentStatus.php
@@ -63,7 +63,7 @@ $qF3 = new QueryFilter(AgentStat::TIME, time() - SConfig::getInstance()->getVal(
 $stats = Factory::getAgentStatFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3], Factory::ORDER => [$oF1, $oF2]]);
 $agentStats = new DataSet();
 foreach ($stats as $stat) {
-  if ($agentStats->getVal($stat->getAgentId()) === false) {
+  if ($agentStats->getVal($stat->getAgentId()) === null) {
     $agentStats->addValue($stat->getAgentId(), $stat);
   }
 }
@@ -77,7 +77,7 @@ $qF3 = new QueryFilter(AgentStat::TIME, time() - SConfig::getInstance()->getVal(
 $stats = Factory::getAgentStatFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3], Factory::ORDER => [$oF1, $oF2]]);
 $agentStats = new DataSet();
 foreach ($stats as $stat) {
-  if ($agentStats->getVal($stat->getAgentId()) === false) {
+  if ($agentStats->getVal($stat->getAgentId()) === null) {
     $agentStats->addValue($stat->getAgentId(), $stat);
   }
 }
@@ -91,7 +91,7 @@ $qF3 = new QueryFilter(AgentStat::TIME, time() - SConfig::getInstance()->getVal(
 $stats = Factory::getAgentStatFactory()->filter([Factory::FILTER => [$qF1, $qF2, $qF3], Factory::ORDER => [$oF1, $oF2]]);
 $agentStats = new DataSet();
 foreach ($stats as $stat) {
-  if ($agentStats->getVal($stat->getAgentId()) === false) {
+  if ($agentStats->getVal($stat->getAgentId()) === null) {
     $agentStats->addValue($stat->getAgentId(), $stat);
   }
 }

--- a/src/dba/AbstractModelFactory.php
+++ b/src/dba/AbstractModelFactory.php
@@ -10,6 +10,8 @@ use Hashtopolis\inc\StartupConfig;
  * Abstraction of all ModelFactories.
  * A ModelFactory is used to get all
  * models from Database. It handles the DB calling and caching of objects.
+ *
+ * @template TModel of AbstractModel
  */
 abstract class AbstractModelFactory {
   private const MAPPING_PREFIX = "htp_";
@@ -65,7 +67,7 @@ abstract class AbstractModelFactory {
    * different queries such as the get queries, where no actual object
    * is given
    *
-   * @return AbstractModel
+   * @return TModel
    */
   abstract function getNullObject(): AbstractModel;
   
@@ -76,7 +78,7 @@ abstract class AbstractModelFactory {
    *
    * @param $pk string primary key
    * @param $dict array dict of values and keys
-   * @return AbstractModel An object of the factories type
+   * @return TModel An object of the factories type
    */
   abstract function createObjectFromDict(string $pk, array $dict): AbstractModel;
   
@@ -163,8 +165,8 @@ abstract class AbstractModelFactory {
    *
    * The Function returns null if the object could not be placed into the
    * database
-   * @param $model AbstractModel model to save
-   * @return AbstractModel|null
+   * @param TModel $model model to save
+   * @return TModel|null
    * @throws Exception
    */
   public function save(AbstractModel $model): ?AbstractModel {
@@ -245,7 +247,7 @@ abstract class AbstractModelFactory {
    * This function updates the database entry for the given model
    * based on it's primary key.
    * Returns the return of PDO::execute()
-   * @param $model AbstractModel model to update
+   * @param TModel $model model to update
    * @return PDOStatement
    * @throws Exception
    */
@@ -277,9 +279,9 @@ abstract class AbstractModelFactory {
    * Atomically sets the given keys of this model to the given values without setting all other values (like ->update() does)
    *
    * Returns the return of PDO::execute() or null if nothing was executed
-   * @param AbstractModel $model AbstractModel primary key of model
+   * @param TModel $model primary key of model
    * @param array $arr key-value associations for update
-   * @return AbstractModel updated model
+   * @return TModel updated model
    * @throws Exception
    */
   public function mset(AbstractModel $model, array $arr): AbstractModel {
@@ -307,10 +309,10 @@ abstract class AbstractModelFactory {
    * Atomically sets the given key of this model to the given value without altering other values
    *
    * Returns the return of PDO::execute()
-   * @param AbstractModel $model primary key of model
+   * @param TModel $model primary key of model
    * @param string $key key of the column to update
    * @param $value
-   * @return AbstractModel
+   * @return TModel
    * @throws Exception
    */
   public function set(AbstractModel $model, string $key, $value): AbstractModel {
@@ -333,7 +335,7 @@ abstract class AbstractModelFactory {
    * Increments the given key of this model by the given value atomically
    *
    * Returns the return of PDO::execute()
-   * @param $model AbstractModel primary key of model
+   * @param TModel &$model primary key of model
    * @param $key string key of the column to update
    * @param $value int amount of increment
    * @return PDOStatement
@@ -356,7 +358,7 @@ abstract class AbstractModelFactory {
     $stmt->execute($values);
     
     $refreshed = $this->get($model->getPrimaryKeyValue());
-    assert($refreshed instanceof AbstractModel);
+    assert($refreshed !== null);
     $model = $refreshed;
     return $stmt;
   }
@@ -365,7 +367,7 @@ abstract class AbstractModelFactory {
    * Decrements the given key of this model by the given value
    *
    * Returns the return of PDO::execute()
-   * @param $model AbstractModel primary key of model
+   * @param TModel &$model primary key of model
    * @param $key string key of the column to update
    * @param $value int amount of increment
    * @return PDOStatement
@@ -388,13 +390,13 @@ abstract class AbstractModelFactory {
     $stmt->execute($values);
     
     $refreshed = $this->get($model->getPrimaryKeyValue());
-    assert($refreshed instanceof AbstractModel);
+    assert($refreshed !== null);
     $model = $refreshed;
     return $stmt;
   }
   
   /**
-   * @param $models AbstractModel[]
+   * @param TModel[] $models
    * @return bool|PDOStatement
    * @throws Exception
    */
@@ -643,7 +645,7 @@ abstract class AbstractModelFactory {
    * to use this function
    *
    * @param $pk string primary key
-   * @return AbstractModel|null the with pk associated model or Null
+   * @return TModel|null the with pk associated model or Null
    * @throws Exception
    */
   public function get($pk): ?AbstractModel {
@@ -658,7 +660,7 @@ abstract class AbstractModelFactory {
    * If the model is set to be cachable, the cache will also be updated
    *
    * @param $pk string primary key
-   * @return AbstractModel|null the with pk associated model or Null
+   * @return TModel|null the with pk associated model or Null
    * @throws Exception
    */
   public function getFromDB($pk): ?AbstractModel {
@@ -692,7 +694,7 @@ abstract class AbstractModelFactory {
    * $options[Factory::JOIN] is an array of JoinFilter options
    *
    * @param $options array containing option settings
-   * @return array Returns an array of matching objects
+   * @return array<TModel>|TModel|null Returns an array of matching objects
    * @throws Exception
    */
   private function filterWithJoin(array $options): array {
@@ -773,7 +775,7 @@ abstract class AbstractModelFactory {
   /**
    * @param array $options
    * @param bool $single
-   * @return array|AbstractModel|null
+   * @return array<TModel>|TModel|null
    * @throws Exception
    */
   public function filter(array $options, bool $single = false): array|AbstractModel|null {
@@ -929,7 +931,7 @@ abstract class AbstractModelFactory {
    *
    * This function deletes the given and also cleans the cache from it.
    * It returns the return of the execute query.
-   * @param $model AbstractModel
+   * @param TModel $model
    * @return bool
    * @throws Exception
    */

--- a/src/dba/AbstractModelFactory.php
+++ b/src/dba/AbstractModelFactory.php
@@ -76,11 +76,10 @@ abstract class AbstractModelFactory {
    *
    * This function is used to get objects from a certain type from db resourcebundle_get_error_message
    *
-   * @param $pk string primary key
    * @param $dict array dict of values and keys
    * @return TModel An object of the factories type
    */
-  abstract function createObjectFromDict(string $pk, array $dict): AbstractModel;
+  abstract function createObjectFromDict(array $dict): AbstractModel;
   
   /**
    * Return the model name in the table, which is the same normally, unless mapping is required. In a mapping case,
@@ -673,7 +672,7 @@ abstract class AbstractModelFactory {
     $stmt->execute(array($pk));
     if ($stmt->rowCount() != 0) {
       $row = $stmt->fetch(PDO::FETCH_ASSOC);
-      return $this->createObjectFromDict($pk, $row);
+      return $this->createObjectFromDict($row);
     }
     else {
       return null;
@@ -764,7 +763,7 @@ abstract class AbstractModelFactory {
       }
       
       foreach ($factories as $factory) {
-        $model = $factory->createObjectFromDict($values[$factory->getModelTable()][strtolower($factory->getNullObject()->getPrimaryKey())], $values[$factory->getModelTable()]);
+        $model = $factory->createObjectFromDict($values[$factory->getModelTable()]);
         $res[$factory->getModelTable()][] = $model;
       }
     }
@@ -812,16 +811,7 @@ abstract class AbstractModelFactory {
     
     // Loop over all entries and create an object from dict for each
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-      $pkName = $this->getNullObject()->getPrimaryKey();
-      
-      if (isset($row[strtolower($pkName)])) {
-        $pk = $row[strtolower($pkName)];
-      }
-      else {
-        $pk = $row[$pkName];
-      }
-      $model = $this->createObjectFromDict($pk, $row);
-      $objects[] = $model;
+      $objects[] = $this->createObjectFromDict($row);
     }
     
     if ($single) {

--- a/src/dba/AbstractModelFactory.php
+++ b/src/dba/AbstractModelFactory.php
@@ -643,11 +643,11 @@ abstract class AbstractModelFactory {
    * the getFromDB() function and return it's result. It's therefor recommended
    * to use this function
    *
-   * @param $pk string primary key
+   * @param string|int $pk primary key
    * @return ?TModel the with pk associated model or Null
    * @throws Exception
    */
-  public function get($pk): ?AbstractModel {
+  public function get(string|int $pk): ?AbstractModel {
     return $this->getFromDB($pk);
   }
   
@@ -658,11 +658,11 @@ abstract class AbstractModelFactory {
    * This function will go to the database directly neglecting the cache.
    * If the model is set to be cachable, the cache will also be updated
    *
-   * @param $pk string primary key
+   * @param string|int $pk primary key
    * @return ?TModel the with pk associated model or Null
    * @throws Exception
    */
-  public function getFromDB($pk): ?AbstractModel {
+  public function getFromDB(string|int $pk): ?AbstractModel {
     $keys = self::getMappedModelKeys($this->getNullObject());
     $query = "SELECT " . implode(", ", $keys);
     $query .= " FROM " . $this->getMappedModelTable();
@@ -921,11 +921,11 @@ abstract class AbstractModelFactory {
    *
    * This function deletes the given and also cleans the cache from it.
    * It returns the return of the execute query.
-   * @param TModel $model
+   * @param ?TModel $model
    * @return bool
    * @throws Exception
    */
-  public function delete($model): bool {
+  public function delete(?AbstractModel $model): bool {
     if ($model != null) {
       $query = "DELETE FROM " . $this->getMappedModelTable() . " WHERE " . $model->getPrimaryKey() . " = ?";
       $stmt = $this->getDB()->prepare($query);
@@ -1007,7 +1007,7 @@ abstract class AbstractModelFactory {
   public function massUpdate($options): bool {
     $query = "UPDATE " . $this->getMappedModelTable();
     
-    $vals = array();
+    $vals = [];
     
     if (array_key_exists(Factory::UPDATE, $options)) {
       $query = $query . " SET ";
@@ -1017,7 +1017,6 @@ abstract class AbstractModelFactory {
       if (!is_array($updateOptions)) {
         $updateOptions = array($updateOptions);
       }
-      $vals = array();
       
       for ($i = 0; $i < count($updateOptions); $i++) {
         $option = $updateOptions[$i];

--- a/src/dba/AbstractModelFactory.php
+++ b/src/dba/AbstractModelFactory.php
@@ -166,7 +166,7 @@ abstract class AbstractModelFactory {
    * The Function returns null if the object could not be placed into the
    * database
    * @param TModel $model model to save
-   * @return TModel|null
+   * @return ?TModel
    * @throws Exception
    */
   public function save(AbstractModel $model): ?AbstractModel {
@@ -645,7 +645,7 @@ abstract class AbstractModelFactory {
    * to use this function
    *
    * @param $pk string primary key
-   * @return TModel|null the with pk associated model or Null
+   * @return ?TModel the with pk associated model or Null
    * @throws Exception
    */
   public function get($pk): ?AbstractModel {
@@ -660,7 +660,7 @@ abstract class AbstractModelFactory {
    * If the model is set to be cachable, the cache will also be updated
    *
    * @param $pk string primary key
-   * @return TModel|null the with pk associated model or Null
+   * @return ?TModel the with pk associated model or Null
    * @throws Exception
    */
   public function getFromDB($pk): ?AbstractModel {
@@ -694,7 +694,7 @@ abstract class AbstractModelFactory {
    * $options[Factory::JOIN] is an array of JoinFilter options
    *
    * @param $options array containing option settings
-   * @return array<TModel>|TModel|null Returns an array of matching objects
+   * @return array<string,array<TModel>> Returns an array of matching objects
    * @throws Exception
    */
   private function filterWithJoin(array $options): array {
@@ -775,7 +775,7 @@ abstract class AbstractModelFactory {
   /**
    * @param array $options
    * @param bool $single
-   * @return array<TModel>|TModel|null
+   * @return array|TModel|null
    * @throws Exception
    */
   public function filter(array $options, bool $single = false): array|AbstractModel|null {

--- a/src/dba/ConcatColumn.php
+++ b/src/dba/ConcatColumn.php
@@ -3,11 +3,8 @@
 namespace Hashtopolis\dba;
 
 class ConcatColumn {
-  private $value;
-  /**
-   * @var AbstractModelFactory
-   */
-  private $factory;
+  private string $value;
+  private AbstractModelFactory $factory;
 
   function __construct($value, $factory)
   {
@@ -15,11 +12,11 @@ class ConcatColumn {
     $this->factory = $factory;
   }
 
-  function getValue() {
+  function getValue(): string {
     return $this->value;
   }
 
-  function getFactory() {
+  function getFactory(): AbstractModelFactory {
     return $this->factory;
   }
 }

--- a/src/dba/ConcatLikeFilterInsensitive.php
+++ b/src/dba/ConcatLikeFilterInsensitive.php
@@ -3,27 +3,19 @@
 namespace Hashtopolis\dba;
 
 class ConcatLikeFilterInsensitive extends Filter {
-  private $value;
-  /**
-   * @var AbstractModelFactory
-   */
-  private $overrideFactory;
+  private string $value;
 
   /**
    * @var ConcatColumn[] $columns
    */
   private array $columns;
   
-  function __construct($columns, $value, $overrideFactory = null) {
+  function __construct($columns, $value) {
     $this->columns = $columns;
     $this->value = $value;
-    $this->overrideFactory = $overrideFactory;
   }
   
   function getQueryString(AbstractModelFactory $factory, bool $includeTable = false): string {
-    if ($this->overrideFactory != null) {
-      $factory = $this->overrideFactory;
-    }
     $mapped_columns = [];
     foreach($this->columns as $column) {
       $columnFactory = $column->getFactory();
@@ -32,7 +24,7 @@ class ConcatLikeFilterInsensitive extends Filter {
     return "LOWER(" . "CONCAT(" . implode(", ", $mapped_columns) . ")" . ") LIKE LOWER(?)";
   }
   
-  function getValue() {
+  function getValue(): string {
     return $this->value;
   }
   

--- a/src/dba/LikeFilterInsensitive.php
+++ b/src/dba/LikeFilterInsensitive.php
@@ -46,7 +46,7 @@ class LikeFilterInsensitive extends Filter {
     return true;
   }
   
-  function getKey() {
+  function getKey(): string {
     return $this->key;
   }
 }

--- a/src/dba/PaginationFilter.php
+++ b/src/dba/PaginationFilter.php
@@ -3,12 +3,13 @@
 namespace Hashtopolis\dba;
 
 class PaginationFilter extends Filter {
-  private $key;
-  private $value;
-  private $operator;
-  private $tieBreakerKey;
-  private $tieBreakerValue;
-  private $filters;
+  private string $key;
+  private mixed $value;
+  private string $operator;
+  private string $tieBreakerKey;
+  private mixed $tieBreakerValue;
+  /** @var Filter[] $filters */
+  private array $filters;
   
   private ?AbstractModelFactory $overrideFactory;
   
@@ -47,7 +48,7 @@ class PaginationFilter extends Filter {
     return $queryString;
   }
   
-  function getValue() {
+  function getValue(): array {
     $values = [$this->value, $this->value, $this->tieBreakerValue];
     return array_merge($values, array_map(fn($filter) => $filter->getValue(), $this->filters));
   }

--- a/src/dba/models/AbstractModelFactory.template.txt
+++ b/src/dba/models/AbstractModelFactory.template.txt
@@ -36,11 +36,10 @@ class __MODEL_NAME__Factory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return __MODEL_NAME__
    */
-  function createObjectFromDict($pk, $dict): __MODEL_NAME__ {
+  function createObjectFromDict(array $dict): __MODEL_NAME__ {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AbstractModelFactory.template.txt
+++ b/src/dba/models/AbstractModelFactory.template.txt
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<__MODEL_NAME__>
+ */
 class __MODEL_NAME__Factory extends AbstractModelFactory {
   function getModelName(): string {
     return "__MODEL_NAME__";
@@ -48,72 +47,5 @@ class __MODEL_NAME__Factory extends AbstractModelFactory {
     }
     $dict = $conv;__MODEL_MAPPING_DICT____MODEL_STREAMING_DICT__
     return new __MODEL_NAME__(__MODEL__DICT2__);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return __MODEL_NAME__|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): __MODEL_NAME__|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), __MODEL_NAME__::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, __MODEL_NAME__::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?__MODEL_NAME__
-   * @throws Exception
-   */
-  function get($pk): ?__MODEL_NAME__ {
-    return Util::cast(parent::get($pk), __MODEL_NAME__::class);
-  }
-  
-  /**
-   * @param __MODEL_NAME__ $model
-   * @return ?__MODEL_NAME__
-   * @throws Exception
-   */
-  function save($model): ?__MODEL_NAME__ {
-    return Util::cast(parent::save($model), __MODEL_NAME__::class);
-  }
-
-  /**
-   * @param __MODEL_NAME__ $model
-   * @param array $arr key-value associations for update
-   * @return __MODEL_NAME__
-   * @throws Exception
-   */
-  function mset($model, array $arr): __MODEL_NAME__ {
-    return Util::cast(parent::mset($model, $arr), __MODEL_NAME__::class);
-  }
-
-  /**
-   * @param __MODEL_NAME__ $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return __MODEL_NAME__
-   * @throws Exception
-   */
-  function set($model, string $key, $value): __MODEL_NAME__ {
-    return Util::cast(parent::set($model, $key, $value), __MODEL_NAME__::class);
   }
 }

--- a/src/dba/models/AccessGroupAgentFactory.php
+++ b/src/dba/models/AccessGroupAgentFactory.php
@@ -36,11 +36,10 @@ class AccessGroupAgentFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AccessGroupAgent
    */
-  function createObjectFromDict($pk, $dict): AccessGroupAgent {
+  function createObjectFromDict(array $dict): AccessGroupAgent {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AccessGroupAgentFactory.php
+++ b/src/dba/models/AccessGroupAgentFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AccessGroupAgent>
+ */
 class AccessGroupAgentFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AccessGroupAgent";
@@ -48,72 +47,5 @@ class AccessGroupAgentFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AccessGroupAgent($dict['accessgroupagentid'], $dict['accessgroupid'], $dict['agentid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AccessGroupAgent|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AccessGroupAgent|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AccessGroupAgent::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AccessGroupAgent::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AccessGroupAgent
-   * @throws Exception
-   */
-  function get($pk): ?AccessGroupAgent {
-    return Util::cast(parent::get($pk), AccessGroupAgent::class);
-  }
-  
-  /**
-   * @param AccessGroupAgent $model
-   * @return ?AccessGroupAgent
-   * @throws Exception
-   */
-  function save($model): ?AccessGroupAgent {
-    return Util::cast(parent::save($model), AccessGroupAgent::class);
-  }
-
-  /**
-   * @param AccessGroupAgent $model
-   * @param array $arr key-value associations for update
-   * @return AccessGroupAgent
-   * @throws Exception
-   */
-  function mset($model, array $arr): AccessGroupAgent {
-    return Util::cast(parent::mset($model, $arr), AccessGroupAgent::class);
-  }
-
-  /**
-   * @param AccessGroupAgent $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AccessGroupAgent
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AccessGroupAgent {
-    return Util::cast(parent::set($model, $key, $value), AccessGroupAgent::class);
   }
 }

--- a/src/dba/models/AccessGroupFactory.php
+++ b/src/dba/models/AccessGroupFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AccessGroup>
+ */
 class AccessGroupFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AccessGroup";
@@ -48,72 +47,5 @@ class AccessGroupFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AccessGroup($dict['accessgroupid'], $dict['groupname']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AccessGroup|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AccessGroup|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AccessGroup::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AccessGroup::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AccessGroup
-   * @throws Exception
-   */
-  function get($pk): ?AccessGroup {
-    return Util::cast(parent::get($pk), AccessGroup::class);
-  }
-  
-  /**
-   * @param AccessGroup $model
-   * @return ?AccessGroup
-   * @throws Exception
-   */
-  function save($model): ?AccessGroup {
-    return Util::cast(parent::save($model), AccessGroup::class);
-  }
-
-  /**
-   * @param AccessGroup $model
-   * @param array $arr key-value associations for update
-   * @return AccessGroup
-   * @throws Exception
-   */
-  function mset($model, array $arr): AccessGroup {
-    return Util::cast(parent::mset($model, $arr), AccessGroup::class);
-  }
-
-  /**
-   * @param AccessGroup $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AccessGroup
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AccessGroup {
-    return Util::cast(parent::set($model, $key, $value), AccessGroup::class);
   }
 }

--- a/src/dba/models/AccessGroupFactory.php
+++ b/src/dba/models/AccessGroupFactory.php
@@ -36,11 +36,10 @@ class AccessGroupFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AccessGroup
    */
-  function createObjectFromDict($pk, $dict): AccessGroup {
+  function createObjectFromDict(array $dict): AccessGroup {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AccessGroupUserFactory.php
+++ b/src/dba/models/AccessGroupUserFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AccessGroupUser>
+ */
 class AccessGroupUserFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AccessGroupUser";
@@ -48,72 +47,5 @@ class AccessGroupUserFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AccessGroupUser($dict['accessgroupuserid'], $dict['accessgroupid'], $dict['userid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AccessGroupUser|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AccessGroupUser|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AccessGroupUser::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AccessGroupUser::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AccessGroupUser
-   * @throws Exception
-   */
-  function get($pk): ?AccessGroupUser {
-    return Util::cast(parent::get($pk), AccessGroupUser::class);
-  }
-  
-  /**
-   * @param AccessGroupUser $model
-   * @return ?AccessGroupUser
-   * @throws Exception
-   */
-  function save($model): ?AccessGroupUser {
-    return Util::cast(parent::save($model), AccessGroupUser::class);
-  }
-
-  /**
-   * @param AccessGroupUser $model
-   * @param array $arr key-value associations for update
-   * @return AccessGroupUser
-   * @throws Exception
-   */
-  function mset($model, array $arr): AccessGroupUser {
-    return Util::cast(parent::mset($model, $arr), AccessGroupUser::class);
-  }
-
-  /**
-   * @param AccessGroupUser $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AccessGroupUser
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AccessGroupUser {
-    return Util::cast(parent::set($model, $key, $value), AccessGroupUser::class);
   }
 }

--- a/src/dba/models/AccessGroupUserFactory.php
+++ b/src/dba/models/AccessGroupUserFactory.php
@@ -36,11 +36,10 @@ class AccessGroupUserFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AccessGroupUser
    */
-  function createObjectFromDict($pk, $dict): AccessGroupUser {
+  function createObjectFromDict(array $dict): AccessGroupUser {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AgentBinaryFactory.php
+++ b/src/dba/models/AgentBinaryFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AgentBinary>
+ */
 class AgentBinaryFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AgentBinary";
@@ -48,72 +47,5 @@ class AgentBinaryFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AgentBinary($dict['agentbinaryid'], $dict['binarytype'], $dict['version'], $dict['operatingsystems'], $dict['filename'], $dict['updatetrack'], $dict['updateavailable']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AgentBinary|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AgentBinary|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AgentBinary::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AgentBinary::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AgentBinary
-   * @throws Exception
-   */
-  function get($pk): ?AgentBinary {
-    return Util::cast(parent::get($pk), AgentBinary::class);
-  }
-  
-  /**
-   * @param AgentBinary $model
-   * @return ?AgentBinary
-   * @throws Exception
-   */
-  function save($model): ?AgentBinary {
-    return Util::cast(parent::save($model), AgentBinary::class);
-  }
-
-  /**
-   * @param AgentBinary $model
-   * @param array $arr key-value associations for update
-   * @return AgentBinary
-   * @throws Exception
-   */
-  function mset($model, array $arr): AgentBinary {
-    return Util::cast(parent::mset($model, $arr), AgentBinary::class);
-  }
-
-  /**
-   * @param AgentBinary $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AgentBinary
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AgentBinary {
-    return Util::cast(parent::set($model, $key, $value), AgentBinary::class);
   }
 }

--- a/src/dba/models/AgentBinaryFactory.php
+++ b/src/dba/models/AgentBinaryFactory.php
@@ -36,11 +36,10 @@ class AgentBinaryFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AgentBinary
    */
-  function createObjectFromDict($pk, $dict): AgentBinary {
+  function createObjectFromDict(array $dict): AgentBinary {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AgentErrorFactory.php
+++ b/src/dba/models/AgentErrorFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AgentError>
+ */
 class AgentErrorFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AgentError";
@@ -48,72 +47,5 @@ class AgentErrorFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AgentError($dict['agenterrorid'], $dict['agentid'], $dict['taskid'], $dict['chunkid'], $dict['time'], $dict['error']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AgentError|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AgentError|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AgentError::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AgentError::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AgentError
-   * @throws Exception
-   */
-  function get($pk): ?AgentError {
-    return Util::cast(parent::get($pk), AgentError::class);
-  }
-  
-  /**
-   * @param AgentError $model
-   * @return ?AgentError
-   * @throws Exception
-   */
-  function save($model): ?AgentError {
-    return Util::cast(parent::save($model), AgentError::class);
-  }
-
-  /**
-   * @param AgentError $model
-   * @param array $arr key-value associations for update
-   * @return AgentError
-   * @throws Exception
-   */
-  function mset($model, array $arr): AgentError {
-    return Util::cast(parent::mset($model, $arr), AgentError::class);
-  }
-
-  /**
-   * @param AgentError $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AgentError
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AgentError {
-    return Util::cast(parent::set($model, $key, $value), AgentError::class);
   }
 }

--- a/src/dba/models/AgentErrorFactory.php
+++ b/src/dba/models/AgentErrorFactory.php
@@ -36,11 +36,10 @@ class AgentErrorFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AgentError
    */
-  function createObjectFromDict($pk, $dict): AgentError {
+  function createObjectFromDict(array $dict): AgentError {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AgentFactory.php
+++ b/src/dba/models/AgentFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Agent>
+ */
 class AgentFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Agent";
@@ -48,72 +47,5 @@ class AgentFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Agent($dict['agentid'], $dict['agentname'], $dict['uid'], $dict['os'], $dict['devices'], $dict['cmdpars'], $dict['ignoreerrors'], $dict['isactive'], $dict['istrusted'], $dict['token'], $dict['lastact'], $dict['lasttime'], $dict['lastip'], $dict['userid'], $dict['cpuonly'], $dict['clientsignature']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Agent|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Agent|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Agent::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Agent::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Agent
-   * @throws Exception
-   */
-  function get($pk): ?Agent {
-    return Util::cast(parent::get($pk), Agent::class);
-  }
-  
-  /**
-   * @param Agent $model
-   * @return ?Agent
-   * @throws Exception
-   */
-  function save($model): ?Agent {
-    return Util::cast(parent::save($model), Agent::class);
-  }
-
-  /**
-   * @param Agent $model
-   * @param array $arr key-value associations for update
-   * @return Agent
-   * @throws Exception
-   */
-  function mset($model, array $arr): Agent {
-    return Util::cast(parent::mset($model, $arr), Agent::class);
-  }
-
-  /**
-   * @param Agent $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Agent
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Agent {
-    return Util::cast(parent::set($model, $key, $value), Agent::class);
   }
 }

--- a/src/dba/models/AgentFactory.php
+++ b/src/dba/models/AgentFactory.php
@@ -36,11 +36,10 @@ class AgentFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Agent
    */
-  function createObjectFromDict($pk, $dict): Agent {
+  function createObjectFromDict(array $dict): Agent {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AgentStatFactory.php
+++ b/src/dba/models/AgentStatFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AgentStat>
+ */
 class AgentStatFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AgentStat";
@@ -48,72 +47,5 @@ class AgentStatFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AgentStat($dict['agentstatid'], $dict['agentid'], $dict['stattype'], $dict['time'], $dict['value']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AgentStat|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AgentStat|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AgentStat::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AgentStat::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AgentStat
-   * @throws Exception
-   */
-  function get($pk): ?AgentStat {
-    return Util::cast(parent::get($pk), AgentStat::class);
-  }
-  
-  /**
-   * @param AgentStat $model
-   * @return ?AgentStat
-   * @throws Exception
-   */
-  function save($model): ?AgentStat {
-    return Util::cast(parent::save($model), AgentStat::class);
-  }
-
-  /**
-   * @param AgentStat $model
-   * @param array $arr key-value associations for update
-   * @return AgentStat
-   * @throws Exception
-   */
-  function mset($model, array $arr): AgentStat {
-    return Util::cast(parent::mset($model, $arr), AgentStat::class);
-  }
-
-  /**
-   * @param AgentStat $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AgentStat
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AgentStat {
-    return Util::cast(parent::set($model, $key, $value), AgentStat::class);
   }
 }

--- a/src/dba/models/AgentStatFactory.php
+++ b/src/dba/models/AgentStatFactory.php
@@ -36,11 +36,10 @@ class AgentStatFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AgentStat
    */
-  function createObjectFromDict($pk, $dict): AgentStat {
+  function createObjectFromDict(array $dict): AgentStat {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AgentZapFactory.php
+++ b/src/dba/models/AgentZapFactory.php
@@ -36,11 +36,10 @@ class AgentZapFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return AgentZap
    */
-  function createObjectFromDict($pk, $dict): AgentZap {
+  function createObjectFromDict(array $dict): AgentZap {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AgentZapFactory.php
+++ b/src/dba/models/AgentZapFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<AgentZap>
+ */
 class AgentZapFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "AgentZap";
@@ -48,72 +47,5 @@ class AgentZapFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new AgentZap($dict['agentzapid'], $dict['agentid'], $dict['lastzapid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return AgentZap|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): AgentZap|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), AgentZap::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, AgentZap::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?AgentZap
-   * @throws Exception
-   */
-  function get($pk): ?AgentZap {
-    return Util::cast(parent::get($pk), AgentZap::class);
-  }
-  
-  /**
-   * @param AgentZap $model
-   * @return ?AgentZap
-   * @throws Exception
-   */
-  function save($model): ?AgentZap {
-    return Util::cast(parent::save($model), AgentZap::class);
-  }
-
-  /**
-   * @param AgentZap $model
-   * @param array $arr key-value associations for update
-   * @return AgentZap
-   * @throws Exception
-   */
-  function mset($model, array $arr): AgentZap {
-    return Util::cast(parent::mset($model, $arr), AgentZap::class);
-  }
-
-  /**
-   * @param AgentZap $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return AgentZap
-   * @throws Exception
-   */
-  function set($model, string $key, $value): AgentZap {
-    return Util::cast(parent::set($model, $key, $value), AgentZap::class);
   }
 }

--- a/src/dba/models/ApiGroupFactory.php
+++ b/src/dba/models/ApiGroupFactory.php
@@ -36,11 +36,10 @@ class ApiGroupFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return ApiGroup
    */
-  function createObjectFromDict($pk, $dict): ApiGroup {
+  function createObjectFromDict(array $dict): ApiGroup {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/ApiGroupFactory.php
+++ b/src/dba/models/ApiGroupFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<ApiGroup>
+ */
 class ApiGroupFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "ApiGroup";
@@ -48,72 +47,5 @@ class ApiGroupFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new ApiGroup($dict['apigroupid'], $dict['permissions'], $dict['name']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return ApiGroup|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): ApiGroup|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), ApiGroup::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, ApiGroup::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?ApiGroup
-   * @throws Exception
-   */
-  function get($pk): ?ApiGroup {
-    return Util::cast(parent::get($pk), ApiGroup::class);
-  }
-  
-  /**
-   * @param ApiGroup $model
-   * @return ?ApiGroup
-   * @throws Exception
-   */
-  function save($model): ?ApiGroup {
-    return Util::cast(parent::save($model), ApiGroup::class);
-  }
-
-  /**
-   * @param ApiGroup $model
-   * @param array $arr key-value associations for update
-   * @return ApiGroup
-   * @throws Exception
-   */
-  function mset($model, array $arr): ApiGroup {
-    return Util::cast(parent::mset($model, $arr), ApiGroup::class);
-  }
-
-  /**
-   * @param ApiGroup $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return ApiGroup
-   * @throws Exception
-   */
-  function set($model, string $key, $value): ApiGroup {
-    return Util::cast(parent::set($model, $key, $value), ApiGroup::class);
   }
 }

--- a/src/dba/models/ApiKeyFactory.php
+++ b/src/dba/models/ApiKeyFactory.php
@@ -36,11 +36,10 @@ class ApiKeyFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return ApiKey
    */
-  function createObjectFromDict($pk, $dict): ApiKey {
+  function createObjectFromDict(array $dict): ApiKey {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/ApiKeyFactory.php
+++ b/src/dba/models/ApiKeyFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<ApiKey>
+ */
 class ApiKeyFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "ApiKey";
@@ -48,72 +47,5 @@ class ApiKeyFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new ApiKey($dict['apikeyid'], $dict['startvalid'], $dict['endvalid'], $dict['accesskey'], $dict['accesscount'], $dict['userid'], $dict['apigroupid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return ApiKey|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): ApiKey|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), ApiKey::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, ApiKey::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?ApiKey
-   * @throws Exception
-   */
-  function get($pk): ?ApiKey {
-    return Util::cast(parent::get($pk), ApiKey::class);
-  }
-  
-  /**
-   * @param ApiKey $model
-   * @return ?ApiKey
-   * @throws Exception
-   */
-  function save($model): ?ApiKey {
-    return Util::cast(parent::save($model), ApiKey::class);
-  }
-
-  /**
-   * @param ApiKey $model
-   * @param array $arr key-value associations for update
-   * @return ApiKey
-   * @throws Exception
-   */
-  function mset($model, array $arr): ApiKey {
-    return Util::cast(parent::mset($model, $arr), ApiKey::class);
-  }
-
-  /**
-   * @param ApiKey $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return ApiKey
-   * @throws Exception
-   */
-  function set($model, string $key, $value): ApiKey {
-    return Util::cast(parent::set($model, $key, $value), ApiKey::class);
   }
 }

--- a/src/dba/models/AssignmentFactory.php
+++ b/src/dba/models/AssignmentFactory.php
@@ -36,11 +36,10 @@ class AssignmentFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Assignment
    */
-  function createObjectFromDict($pk, $dict): Assignment {
+  function createObjectFromDict(array $dict): Assignment {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/AssignmentFactory.php
+++ b/src/dba/models/AssignmentFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Assignment>
+ */
 class AssignmentFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Assignment";
@@ -48,72 +47,5 @@ class AssignmentFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Assignment($dict['assignmentid'], $dict['taskid'], $dict['agentid'], $dict['benchmark']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Assignment|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Assignment|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Assignment::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Assignment::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Assignment
-   * @throws Exception
-   */
-  function get($pk): ?Assignment {
-    return Util::cast(parent::get($pk), Assignment::class);
-  }
-  
-  /**
-   * @param Assignment $model
-   * @return ?Assignment
-   * @throws Exception
-   */
-  function save($model): ?Assignment {
-    return Util::cast(parent::save($model), Assignment::class);
-  }
-
-  /**
-   * @param Assignment $model
-   * @param array $arr key-value associations for update
-   * @return Assignment
-   * @throws Exception
-   */
-  function mset($model, array $arr): Assignment {
-    return Util::cast(parent::mset($model, $arr), Assignment::class);
-  }
-
-  /**
-   * @param Assignment $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Assignment
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Assignment {
-    return Util::cast(parent::set($model, $key, $value), Assignment::class);
   }
 }

--- a/src/dba/models/ChunkFactory.php
+++ b/src/dba/models/ChunkFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Chunk>
+ */
 class ChunkFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Chunk";
@@ -48,72 +47,5 @@ class ChunkFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Chunk($dict['chunkid'], $dict['taskid'], $dict['skip'], $dict['length'], $dict['agentid'], $dict['dispatchtime'], $dict['solvetime'], $dict['checkpoint'], $dict['progress'], $dict['state'], $dict['cracked'], $dict['speed']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Chunk|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Chunk|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Chunk::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Chunk::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Chunk
-   * @throws Exception
-   */
-  function get($pk): ?Chunk {
-    return Util::cast(parent::get($pk), Chunk::class);
-  }
-  
-  /**
-   * @param Chunk $model
-   * @return ?Chunk
-   * @throws Exception
-   */
-  function save($model): ?Chunk {
-    return Util::cast(parent::save($model), Chunk::class);
-  }
-
-  /**
-   * @param Chunk $model
-   * @param array $arr key-value associations for update
-   * @return Chunk
-   * @throws Exception
-   */
-  function mset($model, array $arr): Chunk {
-    return Util::cast(parent::mset($model, $arr), Chunk::class);
-  }
-
-  /**
-   * @param Chunk $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Chunk
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Chunk {
-    return Util::cast(parent::set($model, $key, $value), Chunk::class);
   }
 }

--- a/src/dba/models/ChunkFactory.php
+++ b/src/dba/models/ChunkFactory.php
@@ -36,11 +36,10 @@ class ChunkFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Chunk
    */
-  function createObjectFromDict($pk, $dict): Chunk {
+  function createObjectFromDict(array $dict): Chunk {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/ConfigFactory.php
+++ b/src/dba/models/ConfigFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Config>
+ */
 class ConfigFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Config";
@@ -48,72 +47,5 @@ class ConfigFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Config($dict['configid'], $dict['configsectionid'], $dict['item'], $dict['value']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Config|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Config|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Config::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Config::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Config
-   * @throws Exception
-   */
-  function get($pk): ?Config {
-    return Util::cast(parent::get($pk), Config::class);
-  }
-  
-  /**
-   * @param Config $model
-   * @return ?Config
-   * @throws Exception
-   */
-  function save($model): ?Config {
-    return Util::cast(parent::save($model), Config::class);
-  }
-
-  /**
-   * @param Config $model
-   * @param array $arr key-value associations for update
-   * @return Config
-   * @throws Exception
-   */
-  function mset($model, array $arr): Config {
-    return Util::cast(parent::mset($model, $arr), Config::class);
-  }
-
-  /**
-   * @param Config $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Config
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Config {
-    return Util::cast(parent::set($model, $key, $value), Config::class);
   }
 }

--- a/src/dba/models/ConfigFactory.php
+++ b/src/dba/models/ConfigFactory.php
@@ -36,11 +36,10 @@ class ConfigFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Config
    */
-  function createObjectFromDict($pk, $dict): Config {
+  function createObjectFromDict(array $dict): Config {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/ConfigSectionFactory.php
+++ b/src/dba/models/ConfigSectionFactory.php
@@ -36,11 +36,10 @@ class ConfigSectionFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return ConfigSection
    */
-  function createObjectFromDict($pk, $dict): ConfigSection {
+  function createObjectFromDict(array $dict): ConfigSection {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/ConfigSectionFactory.php
+++ b/src/dba/models/ConfigSectionFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<ConfigSection>
+ */
 class ConfigSectionFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "ConfigSection";
@@ -48,72 +47,5 @@ class ConfigSectionFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new ConfigSection($dict['configsectionid'], $dict['sectionname']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return ConfigSection|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): ConfigSection|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), ConfigSection::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, ConfigSection::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?ConfigSection
-   * @throws Exception
-   */
-  function get($pk): ?ConfigSection {
-    return Util::cast(parent::get($pk), ConfigSection::class);
-  }
-  
-  /**
-   * @param ConfigSection $model
-   * @return ?ConfigSection
-   * @throws Exception
-   */
-  function save($model): ?ConfigSection {
-    return Util::cast(parent::save($model), ConfigSection::class);
-  }
-
-  /**
-   * @param ConfigSection $model
-   * @param array $arr key-value associations for update
-   * @return ConfigSection
-   * @throws Exception
-   */
-  function mset($model, array $arr): ConfigSection {
-    return Util::cast(parent::mset($model, $arr), ConfigSection::class);
-  }
-
-  /**
-   * @param ConfigSection $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return ConfigSection
-   * @throws Exception
-   */
-  function set($model, string $key, $value): ConfigSection {
-    return Util::cast(parent::set($model, $key, $value), ConfigSection::class);
   }
 }

--- a/src/dba/models/CrackerBinaryFactory.php
+++ b/src/dba/models/CrackerBinaryFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<CrackerBinary>
+ */
 class CrackerBinaryFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "CrackerBinary";
@@ -48,72 +47,5 @@ class CrackerBinaryFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new CrackerBinary($dict['crackerbinaryid'], $dict['crackerbinarytypeid'], $dict['version'], $dict['downloadurl'], $dict['binaryname']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return CrackerBinary|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): CrackerBinary|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), CrackerBinary::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, CrackerBinary::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?CrackerBinary
-   * @throws Exception
-   */
-  function get($pk): ?CrackerBinary {
-    return Util::cast(parent::get($pk), CrackerBinary::class);
-  }
-  
-  /**
-   * @param CrackerBinary $model
-   * @return ?CrackerBinary
-   * @throws Exception
-   */
-  function save($model): ?CrackerBinary {
-    return Util::cast(parent::save($model), CrackerBinary::class);
-  }
-
-  /**
-   * @param CrackerBinary $model
-   * @param array $arr key-value associations for update
-   * @return CrackerBinary
-   * @throws Exception
-   */
-  function mset($model, array $arr): CrackerBinary {
-    return Util::cast(parent::mset($model, $arr), CrackerBinary::class);
-  }
-
-  /**
-   * @param CrackerBinary $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return CrackerBinary
-   * @throws Exception
-   */
-  function set($model, string $key, $value): CrackerBinary {
-    return Util::cast(parent::set($model, $key, $value), CrackerBinary::class);
   }
 }

--- a/src/dba/models/CrackerBinaryFactory.php
+++ b/src/dba/models/CrackerBinaryFactory.php
@@ -36,11 +36,10 @@ class CrackerBinaryFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return CrackerBinary
    */
-  function createObjectFromDict($pk, $dict): CrackerBinary {
+  function createObjectFromDict(array $dict): CrackerBinary {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/CrackerBinaryTypeFactory.php
+++ b/src/dba/models/CrackerBinaryTypeFactory.php
@@ -36,11 +36,10 @@ class CrackerBinaryTypeFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return CrackerBinaryType
    */
-  function createObjectFromDict($pk, $dict): CrackerBinaryType {
+  function createObjectFromDict(array $dict): CrackerBinaryType {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/CrackerBinaryTypeFactory.php
+++ b/src/dba/models/CrackerBinaryTypeFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<CrackerBinaryType>
+ */
 class CrackerBinaryTypeFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "CrackerBinaryType";
@@ -48,72 +47,5 @@ class CrackerBinaryTypeFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new CrackerBinaryType($dict['crackerbinarytypeid'], $dict['typename'], $dict['ischunkingavailable']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return CrackerBinaryType|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): CrackerBinaryType|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), CrackerBinaryType::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, CrackerBinaryType::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?CrackerBinaryType
-   * @throws Exception
-   */
-  function get($pk): ?CrackerBinaryType {
-    return Util::cast(parent::get($pk), CrackerBinaryType::class);
-  }
-  
-  /**
-   * @param CrackerBinaryType $model
-   * @return ?CrackerBinaryType
-   * @throws Exception
-   */
-  function save($model): ?CrackerBinaryType {
-    return Util::cast(parent::save($model), CrackerBinaryType::class);
-  }
-
-  /**
-   * @param CrackerBinaryType $model
-   * @param array $arr key-value associations for update
-   * @return CrackerBinaryType
-   * @throws Exception
-   */
-  function mset($model, array $arr): CrackerBinaryType {
-    return Util::cast(parent::mset($model, $arr), CrackerBinaryType::class);
-  }
-
-  /**
-   * @param CrackerBinaryType $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return CrackerBinaryType
-   * @throws Exception
-   */
-  function set($model, string $key, $value): CrackerBinaryType {
-    return Util::cast(parent::set($model, $key, $value), CrackerBinaryType::class);
   }
 }

--- a/src/dba/models/FileDeleteFactory.php
+++ b/src/dba/models/FileDeleteFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<FileDelete>
+ */
 class FileDeleteFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "FileDelete";
@@ -48,72 +47,5 @@ class FileDeleteFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new FileDelete($dict['filedeleteid'], $dict['filename'], $dict['time']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return FileDelete|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): FileDelete|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), FileDelete::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, FileDelete::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?FileDelete
-   * @throws Exception
-   */
-  function get($pk): ?FileDelete {
-    return Util::cast(parent::get($pk), FileDelete::class);
-  }
-  
-  /**
-   * @param FileDelete $model
-   * @return ?FileDelete
-   * @throws Exception
-   */
-  function save($model): ?FileDelete {
-    return Util::cast(parent::save($model), FileDelete::class);
-  }
-
-  /**
-   * @param FileDelete $model
-   * @param array $arr key-value associations for update
-   * @return FileDelete
-   * @throws Exception
-   */
-  function mset($model, array $arr): FileDelete {
-    return Util::cast(parent::mset($model, $arr), FileDelete::class);
-  }
-
-  /**
-   * @param FileDelete $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return FileDelete
-   * @throws Exception
-   */
-  function set($model, string $key, $value): FileDelete {
-    return Util::cast(parent::set($model, $key, $value), FileDelete::class);
   }
 }

--- a/src/dba/models/FileDeleteFactory.php
+++ b/src/dba/models/FileDeleteFactory.php
@@ -36,11 +36,10 @@ class FileDeleteFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return FileDelete
    */
-  function createObjectFromDict($pk, $dict): FileDelete {
+  function createObjectFromDict(array $dict): FileDelete {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/FileDownloadFactory.php
+++ b/src/dba/models/FileDownloadFactory.php
@@ -36,11 +36,10 @@ class FileDownloadFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return FileDownload
    */
-  function createObjectFromDict($pk, $dict): FileDownload {
+  function createObjectFromDict(array $dict): FileDownload {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/FileDownloadFactory.php
+++ b/src/dba/models/FileDownloadFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<FileDownload>
+ */
 class FileDownloadFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "FileDownload";
@@ -48,72 +47,5 @@ class FileDownloadFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new FileDownload($dict['filedownloadid'], $dict['time'], $dict['fileid'], $dict['status']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return FileDownload|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): FileDownload|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), FileDownload::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, FileDownload::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?FileDownload
-   * @throws Exception
-   */
-  function get($pk): ?FileDownload {
-    return Util::cast(parent::get($pk), FileDownload::class);
-  }
-  
-  /**
-   * @param FileDownload $model
-   * @return ?FileDownload
-   * @throws Exception
-   */
-  function save($model): ?FileDownload {
-    return Util::cast(parent::save($model), FileDownload::class);
-  }
-
-  /**
-   * @param FileDownload $model
-   * @param array $arr key-value associations for update
-   * @return FileDownload
-   * @throws Exception
-   */
-  function mset($model, array $arr): FileDownload {
-    return Util::cast(parent::mset($model, $arr), FileDownload::class);
-  }
-
-  /**
-   * @param FileDownload $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return FileDownload
-   * @throws Exception
-   */
-  function set($model, string $key, $value): FileDownload {
-    return Util::cast(parent::set($model, $key, $value), FileDownload::class);
   }
 }

--- a/src/dba/models/FileFactory.php
+++ b/src/dba/models/FileFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<File>
+ */
 class FileFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "File";
@@ -48,72 +47,5 @@ class FileFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new File($dict['fileid'], $dict['filename'], $dict['size'], $dict['issecret'], $dict['filetype'], $dict['accessgroupid'], $dict['linecount']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return File|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): File|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), File::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, File::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?File
-   * @throws Exception
-   */
-  function get($pk): ?File {
-    return Util::cast(parent::get($pk), File::class);
-  }
-  
-  /**
-   * @param File $model
-   * @return ?File
-   * @throws Exception
-   */
-  function save($model): ?File {
-    return Util::cast(parent::save($model), File::class);
-  }
-
-  /**
-   * @param File $model
-   * @param array $arr key-value associations for update
-   * @return File
-   * @throws Exception
-   */
-  function mset($model, array $arr): File {
-    return Util::cast(parent::mset($model, $arr), File::class);
-  }
-
-  /**
-   * @param File $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return File
-   * @throws Exception
-   */
-  function set($model, string $key, $value): File {
-    return Util::cast(parent::set($model, $key, $value), File::class);
   }
 }

--- a/src/dba/models/FileFactory.php
+++ b/src/dba/models/FileFactory.php
@@ -36,11 +36,10 @@ class FileFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return File
    */
-  function createObjectFromDict($pk, $dict): File {
+  function createObjectFromDict(array $dict): File {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/FilePretaskFactory.php
+++ b/src/dba/models/FilePretaskFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<FilePretask>
+ */
 class FilePretaskFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "FilePretask";
@@ -48,72 +47,5 @@ class FilePretaskFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new FilePretask($dict['filepretaskid'], $dict['fileid'], $dict['pretaskid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return FilePretask|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): FilePretask|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), FilePretask::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, FilePretask::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?FilePretask
-   * @throws Exception
-   */
-  function get($pk): ?FilePretask {
-    return Util::cast(parent::get($pk), FilePretask::class);
-  }
-  
-  /**
-   * @param FilePretask $model
-   * @return ?FilePretask
-   * @throws Exception
-   */
-  function save($model): ?FilePretask {
-    return Util::cast(parent::save($model), FilePretask::class);
-  }
-
-  /**
-   * @param FilePretask $model
-   * @param array $arr key-value associations for update
-   * @return FilePretask
-   * @throws Exception
-   */
-  function mset($model, array $arr): FilePretask {
-    return Util::cast(parent::mset($model, $arr), FilePretask::class);
-  }
-
-  /**
-   * @param FilePretask $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return FilePretask
-   * @throws Exception
-   */
-  function set($model, string $key, $value): FilePretask {
-    return Util::cast(parent::set($model, $key, $value), FilePretask::class);
   }
 }

--- a/src/dba/models/FilePretaskFactory.php
+++ b/src/dba/models/FilePretaskFactory.php
@@ -36,11 +36,10 @@ class FilePretaskFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return FilePretask
    */
-  function createObjectFromDict($pk, $dict): FilePretask {
+  function createObjectFromDict(array $dict): FilePretask {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/FileTaskFactory.php
+++ b/src/dba/models/FileTaskFactory.php
@@ -36,11 +36,10 @@ class FileTaskFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return FileTask
    */
-  function createObjectFromDict($pk, $dict): FileTask {
+  function createObjectFromDict(array $dict): FileTask {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/FileTaskFactory.php
+++ b/src/dba/models/FileTaskFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<FileTask>
+ */
 class FileTaskFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "FileTask";
@@ -48,72 +47,5 @@ class FileTaskFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new FileTask($dict['filetaskid'], $dict['fileid'], $dict['taskid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return FileTask|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): FileTask|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), FileTask::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, FileTask::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?FileTask
-   * @throws Exception
-   */
-  function get($pk): ?FileTask {
-    return Util::cast(parent::get($pk), FileTask::class);
-  }
-  
-  /**
-   * @param FileTask $model
-   * @return ?FileTask
-   * @throws Exception
-   */
-  function save($model): ?FileTask {
-    return Util::cast(parent::save($model), FileTask::class);
-  }
-
-  /**
-   * @param FileTask $model
-   * @param array $arr key-value associations for update
-   * @return FileTask
-   * @throws Exception
-   */
-  function mset($model, array $arr): FileTask {
-    return Util::cast(parent::mset($model, $arr), FileTask::class);
-  }
-
-  /**
-   * @param FileTask $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return FileTask
-   * @throws Exception
-   */
-  function set($model, string $key, $value): FileTask {
-    return Util::cast(parent::set($model, $key, $value), FileTask::class);
   }
 }

--- a/src/dba/models/HashBinaryFactory.php
+++ b/src/dba/models/HashBinaryFactory.php
@@ -36,11 +36,10 @@ class HashBinaryFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return HashBinary
    */
-  function createObjectFromDict($pk, $dict): HashBinary {
+  function createObjectFromDict(array $dict): HashBinary {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HashBinaryFactory.php
+++ b/src/dba/models/HashBinaryFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<HashBinary>
+ */
 class HashBinaryFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "HashBinary";
@@ -48,72 +47,5 @@ class HashBinaryFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new HashBinary($dict['hashbinaryid'], $dict['hashlistid'], $dict['essid'], $dict['hash'], $dict['plaintext'], $dict['timecracked'], $dict['chunkid'], $dict['iscracked'], $dict['crackpos']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return HashBinary|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): HashBinary|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), HashBinary::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, HashBinary::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?HashBinary
-   * @throws Exception
-   */
-  function get($pk): ?HashBinary {
-    return Util::cast(parent::get($pk), HashBinary::class);
-  }
-  
-  /**
-   * @param HashBinary $model
-   * @return ?HashBinary
-   * @throws Exception
-   */
-  function save($model): ?HashBinary {
-    return Util::cast(parent::save($model), HashBinary::class);
-  }
-
-  /**
-   * @param HashBinary $model
-   * @param array $arr key-value associations for update
-   * @return HashBinary
-   * @throws Exception
-   */
-  function mset($model, array $arr): HashBinary {
-    return Util::cast(parent::mset($model, $arr), HashBinary::class);
-  }
-
-  /**
-   * @param HashBinary $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return HashBinary
-   * @throws Exception
-   */
-  function set($model, string $key, $value): HashBinary {
-    return Util::cast(parent::set($model, $key, $value), HashBinary::class);
   }
 }

--- a/src/dba/models/HashFactory.php
+++ b/src/dba/models/HashFactory.php
@@ -36,11 +36,10 @@ class HashFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Hash
    */
-  function createObjectFromDict($pk, $dict): Hash {
+  function createObjectFromDict(array $dict): Hash {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HashFactory.php
+++ b/src/dba/models/HashFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Hash>
+ */
 class HashFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Hash";
@@ -48,72 +47,5 @@ class HashFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Hash($dict['hashid'], $dict['hashlistid'], $dict['hash'], $dict['salt'], $dict['plaintext'], $dict['timecracked'], $dict['chunkid'], $dict['iscracked'], $dict['crackpos']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Hash|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Hash|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Hash::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Hash::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Hash
-   * @throws Exception
-   */
-  function get($pk): ?Hash {
-    return Util::cast(parent::get($pk), Hash::class);
-  }
-  
-  /**
-   * @param Hash $model
-   * @return ?Hash
-   * @throws Exception
-   */
-  function save($model): ?Hash {
-    return Util::cast(parent::save($model), Hash::class);
-  }
-
-  /**
-   * @param Hash $model
-   * @param array $arr key-value associations for update
-   * @return Hash
-   * @throws Exception
-   */
-  function mset($model, array $arr): Hash {
-    return Util::cast(parent::mset($model, $arr), Hash::class);
-  }
-
-  /**
-   * @param Hash $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Hash
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Hash {
-    return Util::cast(parent::set($model, $key, $value), Hash::class);
   }
 }

--- a/src/dba/models/HashTypeFactory.php
+++ b/src/dba/models/HashTypeFactory.php
@@ -2,12 +2,12 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
 use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<HashType>
+ */
 class HashTypeFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "HashType";
@@ -48,72 +48,5 @@ class HashTypeFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new HashType($dict['hashtypeid'], $dict['description'], $dict['issalted'], $dict['isslowhash']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return HashType|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): HashType|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), HashType::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, HashType::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?HashType
-   * @throws Exception
-   */
-  function get($pk): ?HashType {
-    return Util::cast(parent::get($pk), HashType::class);
-  }
-  
-  /**
-   * @param HashType $model
-   * @return ?HashType
-   * @throws Exception
-   */
-  function save($model): ?HashType {
-    return Util::cast(parent::save($model), HashType::class);
-  }
-
-  /**
-   * @param HashType $model
-   * @param array $arr key-value associations for update
-   * @return HashType
-   * @throws Exception
-   */
-  function mset($model, array $arr): HashType {
-    return Util::cast(parent::mset($model, $arr), HashType::class);
-  }
-
-  /**
-   * @param HashType $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return HashType
-   * @throws Exception
-   */
-  function set($model, string $key, $value): HashType {
-    return Util::cast(parent::set($model, $key, $value), HashType::class);
   }
 }

--- a/src/dba/models/HashTypeFactory.php
+++ b/src/dba/models/HashTypeFactory.php
@@ -3,7 +3,6 @@
 namespace Hashtopolis\dba\models;
 
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
 
 /**
  * @extends AbstractModelFactory<HashType>

--- a/src/dba/models/HashTypeFactory.php
+++ b/src/dba/models/HashTypeFactory.php
@@ -36,11 +36,10 @@ class HashTypeFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return HashType
    */
-  function createObjectFromDict($pk, $dict): HashType {
+  function createObjectFromDict(array $dict): HashType {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HashlistFactory.php
+++ b/src/dba/models/HashlistFactory.php
@@ -2,12 +2,12 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
 use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Hashlist>
+ */
 class HashlistFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Hashlist";
@@ -48,72 +48,5 @@ class HashlistFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Hashlist($dict['hashlistid'], $dict['hashlistname'], $dict['format'], $dict['hashtypeid'], $dict['hashcount'], $dict['saltseparator'], $dict['cracked'], $dict['issecret'], $dict['hexsalt'], $dict['issalted'], $dict['accessgroupid'], $dict['notes'], $dict['brainid'], $dict['brainfeatures'], $dict['isarchived']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Hashlist|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Hashlist|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Hashlist::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Hashlist::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Hashlist
-   * @throws Exception
-   */
-  function get($pk): ?Hashlist {
-    return Util::cast(parent::get($pk), Hashlist::class);
-  }
-  
-  /**
-   * @param Hashlist $model
-   * @return ?Hashlist
-   * @throws Exception
-   */
-  function save($model): ?Hashlist {
-    return Util::cast(parent::save($model), Hashlist::class);
-  }
-
-  /**
-   * @param Hashlist $model
-   * @param array $arr key-value associations for update
-   * @return Hashlist
-   * @throws Exception
-   */
-  function mset($model, array $arr): Hashlist {
-    return Util::cast(parent::mset($model, $arr), Hashlist::class);
-  }
-
-  /**
-   * @param Hashlist $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Hashlist
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Hashlist {
-    return Util::cast(parent::set($model, $key, $value), Hashlist::class);
   }
 }

--- a/src/dba/models/HashlistFactory.php
+++ b/src/dba/models/HashlistFactory.php
@@ -3,7 +3,6 @@
 namespace Hashtopolis\dba\models;
 
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
 
 /**
  * @extends AbstractModelFactory<Hashlist>

--- a/src/dba/models/HashlistFactory.php
+++ b/src/dba/models/HashlistFactory.php
@@ -36,11 +36,10 @@ class HashlistFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Hashlist
    */
-  function createObjectFromDict($pk, $dict): Hashlist {
+  function createObjectFromDict(array $dict): Hashlist {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HashlistHashlistFactory.php
+++ b/src/dba/models/HashlistHashlistFactory.php
@@ -36,11 +36,10 @@ class HashlistHashlistFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return HashlistHashlist
    */
-  function createObjectFromDict($pk, $dict): HashlistHashlist {
+  function createObjectFromDict(array $dict): HashlistHashlist {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HashlistHashlistFactory.php
+++ b/src/dba/models/HashlistHashlistFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<HashlistHashlist>
+ */
 class HashlistHashlistFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "HashlistHashlist";
@@ -48,72 +47,5 @@ class HashlistHashlistFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new HashlistHashlist($dict['hashlisthashlistid'], $dict['parenthashlistid'], $dict['hashlistid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return HashlistHashlist|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): HashlistHashlist|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), HashlistHashlist::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, HashlistHashlist::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?HashlistHashlist
-   * @throws Exception
-   */
-  function get($pk): ?HashlistHashlist {
-    return Util::cast(parent::get($pk), HashlistHashlist::class);
-  }
-  
-  /**
-   * @param HashlistHashlist $model
-   * @return ?HashlistHashlist
-   * @throws Exception
-   */
-  function save($model): ?HashlistHashlist {
-    return Util::cast(parent::save($model), HashlistHashlist::class);
-  }
-
-  /**
-   * @param HashlistHashlist $model
-   * @param array $arr key-value associations for update
-   * @return HashlistHashlist
-   * @throws Exception
-   */
-  function mset($model, array $arr): HashlistHashlist {
-    return Util::cast(parent::mset($model, $arr), HashlistHashlist::class);
-  }
-
-  /**
-   * @param HashlistHashlist $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return HashlistHashlist
-   * @throws Exception
-   */
-  function set($model, string $key, $value): HashlistHashlist {
-    return Util::cast(parent::set($model, $key, $value), HashlistHashlist::class);
   }
 }

--- a/src/dba/models/HealthCheckAgentFactory.php
+++ b/src/dba/models/HealthCheckAgentFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<HealthCheckAgent>
+ */
 class HealthCheckAgentFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "HealthCheckAgent";
@@ -49,72 +48,5 @@ class HealthCheckAgentFactory extends AbstractModelFactory {
     $dict = $conv;
     $dict['end'] = $dict['htp_end'];
     return new HealthCheckAgent($dict['healthcheckagentid'], $dict['healthcheckid'], $dict['agentid'], $dict['status'], $dict['cracked'], $dict['numgpus'], $dict['start'], $dict['end'], $dict['errors']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return HealthCheckAgent|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): HealthCheckAgent|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), HealthCheckAgent::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, HealthCheckAgent::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?HealthCheckAgent
-   * @throws Exception
-   */
-  function get($pk): ?HealthCheckAgent {
-    return Util::cast(parent::get($pk), HealthCheckAgent::class);
-  }
-  
-  /**
-   * @param HealthCheckAgent $model
-   * @return ?HealthCheckAgent
-   * @throws Exception
-   */
-  function save($model): ?HealthCheckAgent {
-    return Util::cast(parent::save($model), HealthCheckAgent::class);
-  }
-
-  /**
-   * @param HealthCheckAgent $model
-   * @param array $arr key-value associations for update
-   * @return HealthCheckAgent
-   * @throws Exception
-   */
-  function mset($model, array $arr): HealthCheckAgent {
-    return Util::cast(parent::mset($model, $arr), HealthCheckAgent::class);
-  }
-
-  /**
-   * @param HealthCheckAgent $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return HealthCheckAgent
-   * @throws Exception
-   */
-  function set($model, string $key, $value): HealthCheckAgent {
-    return Util::cast(parent::set($model, $key, $value), HealthCheckAgent::class);
   }
 }

--- a/src/dba/models/HealthCheckAgentFactory.php
+++ b/src/dba/models/HealthCheckAgentFactory.php
@@ -36,11 +36,10 @@ class HealthCheckAgentFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return HealthCheckAgent
    */
-  function createObjectFromDict($pk, $dict): HealthCheckAgent {
+  function createObjectFromDict(array $dict): HealthCheckAgent {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HealthCheckFactory.php
+++ b/src/dba/models/HealthCheckFactory.php
@@ -36,11 +36,10 @@ class HealthCheckFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return HealthCheck
    */
-  function createObjectFromDict($pk, $dict): HealthCheck {
+  function createObjectFromDict(array $dict): HealthCheck {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/HealthCheckFactory.php
+++ b/src/dba/models/HealthCheckFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<HealthCheck>
+ */
 class HealthCheckFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "HealthCheck";
@@ -48,72 +47,5 @@ class HealthCheckFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new HealthCheck($dict['healthcheckid'], $dict['time'], $dict['status'], $dict['checktype'], $dict['hashtypeid'], $dict['crackerbinaryid'], $dict['expectedcracks'], $dict['attackcmd']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return HealthCheck|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): HealthCheck|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), HealthCheck::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, HealthCheck::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?HealthCheck
-   * @throws Exception
-   */
-  function get($pk): ?HealthCheck {
-    return Util::cast(parent::get($pk), HealthCheck::class);
-  }
-  
-  /**
-   * @param HealthCheck $model
-   * @return ?HealthCheck
-   * @throws Exception
-   */
-  function save($model): ?HealthCheck {
-    return Util::cast(parent::save($model), HealthCheck::class);
-  }
-
-  /**
-   * @param HealthCheck $model
-   * @param array $arr key-value associations for update
-   * @return HealthCheck
-   * @throws Exception
-   */
-  function mset($model, array $arr): HealthCheck {
-    return Util::cast(parent::mset($model, $arr), HealthCheck::class);
-  }
-
-  /**
-   * @param HealthCheck $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return HealthCheck
-   * @throws Exception
-   */
-  function set($model, string $key, $value): HealthCheck {
-    return Util::cast(parent::set($model, $key, $value), HealthCheck::class);
   }
 }

--- a/src/dba/models/JwtApiKeyFactory.php
+++ b/src/dba/models/JwtApiKeyFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<JwtApiKey>
+ */
 class JwtApiKeyFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "JwtApiKey";
@@ -48,72 +47,5 @@ class JwtApiKeyFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new JwtApiKey($dict['jwtapikeyid'], $dict['startvalid'], $dict['endvalid'], $dict['userid'], $dict['isrevoked']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return JwtApiKey|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): JwtApiKey|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), JwtApiKey::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, JwtApiKey::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?JwtApiKey
-   * @throws Exception
-   */
-  function get($pk): ?JwtApiKey {
-    return Util::cast(parent::get($pk), JwtApiKey::class);
-  }
-  
-  /**
-   * @param JwtApiKey $model
-   * @return ?JwtApiKey
-   * @throws Exception
-   */
-  function save($model): ?JwtApiKey {
-    return Util::cast(parent::save($model), JwtApiKey::class);
-  }
-
-  /**
-   * @param JwtApiKey $model
-   * @param array $arr key-value associations for update
-   * @return JwtApiKey
-   * @throws Exception
-   */
-  function mset($model, array $arr): JwtApiKey {
-    return Util::cast(parent::mset($model, $arr), JwtApiKey::class);
-  }
-
-  /**
-   * @param JwtApiKey $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return JwtApiKey
-   * @throws Exception
-   */
-  function set($model, string $key, $value): JwtApiKey {
-    return Util::cast(parent::set($model, $key, $value), JwtApiKey::class);
   }
 }

--- a/src/dba/models/JwtApiKeyFactory.php
+++ b/src/dba/models/JwtApiKeyFactory.php
@@ -36,11 +36,10 @@ class JwtApiKeyFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return JwtApiKey
    */
-  function createObjectFromDict($pk, $dict): JwtApiKey {
+  function createObjectFromDict(array $dict): JwtApiKey {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/LogEntryFactory.php
+++ b/src/dba/models/LogEntryFactory.php
@@ -36,11 +36,10 @@ class LogEntryFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return LogEntry
    */
-  function createObjectFromDict($pk, $dict): LogEntry {
+  function createObjectFromDict(array $dict): LogEntry {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/LogEntryFactory.php
+++ b/src/dba/models/LogEntryFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<LogEntry>
+ */
 class LogEntryFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "LogEntry";
@@ -48,72 +47,5 @@ class LogEntryFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new LogEntry($dict['logentryid'], $dict['issuer'], $dict['issuerid'], $dict['level'], $dict['message'], $dict['time']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return LogEntry|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): LogEntry|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), LogEntry::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, LogEntry::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?LogEntry
-   * @throws Exception
-   */
-  function get($pk): ?LogEntry {
-    return Util::cast(parent::get($pk), LogEntry::class);
-  }
-  
-  /**
-   * @param LogEntry $model
-   * @return ?LogEntry
-   * @throws Exception
-   */
-  function save($model): ?LogEntry {
-    return Util::cast(parent::save($model), LogEntry::class);
-  }
-
-  /**
-   * @param LogEntry $model
-   * @param array $arr key-value associations for update
-   * @return LogEntry
-   * @throws Exception
-   */
-  function mset($model, array $arr): LogEntry {
-    return Util::cast(parent::mset($model, $arr), LogEntry::class);
-  }
-
-  /**
-   * @param LogEntry $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return LogEntry
-   * @throws Exception
-   */
-  function set($model, string $key, $value): LogEntry {
-    return Util::cast(parent::set($model, $key, $value), LogEntry::class);
   }
 }

--- a/src/dba/models/NotificationSettingFactory.php
+++ b/src/dba/models/NotificationSettingFactory.php
@@ -36,11 +36,10 @@ class NotificationSettingFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return NotificationSetting
    */
-  function createObjectFromDict($pk, $dict): NotificationSetting {
+  function createObjectFromDict(array $dict): NotificationSetting {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/NotificationSettingFactory.php
+++ b/src/dba/models/NotificationSettingFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<NotificationSetting>
+ */
 class NotificationSettingFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "NotificationSetting";
@@ -48,72 +47,5 @@ class NotificationSettingFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new NotificationSetting($dict['notificationsettingid'], $dict['action'], $dict['objectid'], $dict['notification'], $dict['userid'], $dict['receiver'], $dict['isactive']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return NotificationSetting|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): NotificationSetting|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), NotificationSetting::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, NotificationSetting::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?NotificationSetting
-   * @throws Exception
-   */
-  function get($pk): ?NotificationSetting {
-    return Util::cast(parent::get($pk), NotificationSetting::class);
-  }
-  
-  /**
-   * @param NotificationSetting $model
-   * @return ?NotificationSetting
-   * @throws Exception
-   */
-  function save($model): ?NotificationSetting {
-    return Util::cast(parent::save($model), NotificationSetting::class);
-  }
-
-  /**
-   * @param NotificationSetting $model
-   * @param array $arr key-value associations for update
-   * @return NotificationSetting
-   * @throws Exception
-   */
-  function mset($model, array $arr): NotificationSetting {
-    return Util::cast(parent::mset($model, $arr), NotificationSetting::class);
-  }
-
-  /**
-   * @param NotificationSetting $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return NotificationSetting
-   * @throws Exception
-   */
-  function set($model, string $key, $value): NotificationSetting {
-    return Util::cast(parent::set($model, $key, $value), NotificationSetting::class);
   }
 }

--- a/src/dba/models/PreprocessorFactory.php
+++ b/src/dba/models/PreprocessorFactory.php
@@ -36,11 +36,10 @@ class PreprocessorFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Preprocessor
    */
-  function createObjectFromDict($pk, $dict): Preprocessor {
+  function createObjectFromDict(array $dict): Preprocessor {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/PreprocessorFactory.php
+++ b/src/dba/models/PreprocessorFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Preprocessor>
+ */
 class PreprocessorFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Preprocessor";
@@ -48,72 +47,5 @@ class PreprocessorFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Preprocessor($dict['preprocessorid'], $dict['name'], $dict['url'], $dict['binaryname'], $dict['keyspacecommand'], $dict['skipcommand'], $dict['limitcommand']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Preprocessor|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Preprocessor|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Preprocessor::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Preprocessor::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Preprocessor
-   * @throws Exception
-   */
-  function get($pk): ?Preprocessor {
-    return Util::cast(parent::get($pk), Preprocessor::class);
-  }
-  
-  /**
-   * @param Preprocessor $model
-   * @return ?Preprocessor
-   * @throws Exception
-   */
-  function save($model): ?Preprocessor {
-    return Util::cast(parent::save($model), Preprocessor::class);
-  }
-
-  /**
-   * @param Preprocessor $model
-   * @param array $arr key-value associations for update
-   * @return Preprocessor
-   * @throws Exception
-   */
-  function mset($model, array $arr): Preprocessor {
-    return Util::cast(parent::mset($model, $arr), Preprocessor::class);
-  }
-
-  /**
-   * @param Preprocessor $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Preprocessor
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Preprocessor {
-    return Util::cast(parent::set($model, $key, $value), Preprocessor::class);
   }
 }

--- a/src/dba/models/PretaskFactory.php
+++ b/src/dba/models/PretaskFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Pretask>
+ */
 class PretaskFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Pretask";
@@ -48,72 +47,5 @@ class PretaskFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Pretask($dict['pretaskid'], $dict['taskname'], $dict['attackcmd'], $dict['chunktime'], $dict['statustimer'], $dict['color'], $dict['issmall'], $dict['iscputask'], $dict['usenewbench'], $dict['priority'], $dict['maxagents'], $dict['ismaskimport'], $dict['crackerbinarytypeid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Pretask|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Pretask|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Pretask::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Pretask::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Pretask
-   * @throws Exception
-   */
-  function get($pk): ?Pretask {
-    return Util::cast(parent::get($pk), Pretask::class);
-  }
-  
-  /**
-   * @param Pretask $model
-   * @return ?Pretask
-   * @throws Exception
-   */
-  function save($model): ?Pretask {
-    return Util::cast(parent::save($model), Pretask::class);
-  }
-
-  /**
-   * @param Pretask $model
-   * @param array $arr key-value associations for update
-   * @return Pretask
-   * @throws Exception
-   */
-  function mset($model, array $arr): Pretask {
-    return Util::cast(parent::mset($model, $arr), Pretask::class);
-  }
-
-  /**
-   * @param Pretask $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Pretask
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Pretask {
-    return Util::cast(parent::set($model, $key, $value), Pretask::class);
   }
 }

--- a/src/dba/models/PretaskFactory.php
+++ b/src/dba/models/PretaskFactory.php
@@ -36,11 +36,10 @@ class PretaskFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Pretask
    */
-  function createObjectFromDict($pk, $dict): Pretask {
+  function createObjectFromDict(array $dict): Pretask {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/RegVoucherFactory.php
+++ b/src/dba/models/RegVoucherFactory.php
@@ -36,11 +36,10 @@ class RegVoucherFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return RegVoucher
    */
-  function createObjectFromDict($pk, $dict): RegVoucher {
+  function createObjectFromDict(array $dict): RegVoucher {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/RegVoucherFactory.php
+++ b/src/dba/models/RegVoucherFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<RegVoucher>
+ */
 class RegVoucherFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "RegVoucher";
@@ -48,72 +47,5 @@ class RegVoucherFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new RegVoucher($dict['regvoucherid'], $dict['voucher'], $dict['time']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return RegVoucher|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): RegVoucher|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), RegVoucher::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, RegVoucher::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?RegVoucher
-   * @throws Exception
-   */
-  function get($pk): ?RegVoucher {
-    return Util::cast(parent::get($pk), RegVoucher::class);
-  }
-  
-  /**
-   * @param RegVoucher $model
-   * @return ?RegVoucher
-   * @throws Exception
-   */
-  function save($model): ?RegVoucher {
-    return Util::cast(parent::save($model), RegVoucher::class);
-  }
-
-  /**
-   * @param RegVoucher $model
-   * @param array $arr key-value associations for update
-   * @return RegVoucher
-   * @throws Exception
-   */
-  function mset($model, array $arr): RegVoucher {
-    return Util::cast(parent::mset($model, $arr), RegVoucher::class);
-  }
-
-  /**
-   * @param RegVoucher $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return RegVoucher
-   * @throws Exception
-   */
-  function set($model, string $key, $value): RegVoucher {
-    return Util::cast(parent::set($model, $key, $value), RegVoucher::class);
   }
 }

--- a/src/dba/models/RightGroupFactory.php
+++ b/src/dba/models/RightGroupFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<RightGroup>
+ */
 class RightGroupFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "RightGroup";
@@ -48,72 +47,5 @@ class RightGroupFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new RightGroup($dict['rightgroupid'], $dict['groupname'], $dict['permissions']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return RightGroup|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): RightGroup|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), RightGroup::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, RightGroup::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?RightGroup
-   * @throws Exception
-   */
-  function get($pk): ?RightGroup {
-    return Util::cast(parent::get($pk), RightGroup::class);
-  }
-  
-  /**
-   * @param RightGroup $model
-   * @return ?RightGroup
-   * @throws Exception
-   */
-  function save($model): ?RightGroup {
-    return Util::cast(parent::save($model), RightGroup::class);
-  }
-
-  /**
-   * @param RightGroup $model
-   * @param array $arr key-value associations for update
-   * @return RightGroup
-   * @throws Exception
-   */
-  function mset($model, array $arr): RightGroup {
-    return Util::cast(parent::mset($model, $arr), RightGroup::class);
-  }
-
-  /**
-   * @param RightGroup $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return RightGroup
-   * @throws Exception
-   */
-  function set($model, string $key, $value): RightGroup {
-    return Util::cast(parent::set($model, $key, $value), RightGroup::class);
   }
 }

--- a/src/dba/models/RightGroupFactory.php
+++ b/src/dba/models/RightGroupFactory.php
@@ -36,11 +36,10 @@ class RightGroupFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return RightGroup
    */
-  function createObjectFromDict($pk, $dict): RightGroup {
+  function createObjectFromDict(array $dict): RightGroup {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/SessionFactory.php
+++ b/src/dba/models/SessionFactory.php
@@ -36,11 +36,10 @@ class SessionFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Session
    */
-  function createObjectFromDict($pk, $dict): Session {
+  function createObjectFromDict(array $dict): Session {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/SessionFactory.php
+++ b/src/dba/models/SessionFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Session>
+ */
 class SessionFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Session";
@@ -48,72 +47,5 @@ class SessionFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Session($dict['sessionid'], $dict['userid'], $dict['sessionstartdate'], $dict['lastactiondate'], $dict['isopen'], $dict['sessionlifetime'], $dict['sessionkey']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Session|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Session|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Session::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Session::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Session
-   * @throws Exception
-   */
-  function get($pk): ?Session {
-    return Util::cast(parent::get($pk), Session::class);
-  }
-  
-  /**
-   * @param Session $model
-   * @return ?Session
-   * @throws Exception
-   */
-  function save($model): ?Session {
-    return Util::cast(parent::save($model), Session::class);
-  }
-
-  /**
-   * @param Session $model
-   * @param array $arr key-value associations for update
-   * @return Session
-   * @throws Exception
-   */
-  function mset($model, array $arr): Session {
-    return Util::cast(parent::mset($model, $arr), Session::class);
-  }
-
-  /**
-   * @param Session $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Session
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Session {
-    return Util::cast(parent::set($model, $key, $value), Session::class);
   }
 }

--- a/src/dba/models/SpeedFactory.php
+++ b/src/dba/models/SpeedFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Speed>
+ */
 class SpeedFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Speed";
@@ -48,72 +47,5 @@ class SpeedFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Speed($dict['speedid'], $dict['agentid'], $dict['taskid'], $dict['speed'], $dict['time']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Speed|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Speed|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Speed::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Speed::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Speed
-   * @throws Exception
-   */
-  function get($pk): ?Speed {
-    return Util::cast(parent::get($pk), Speed::class);
-  }
-  
-  /**
-   * @param Speed $model
-   * @return ?Speed
-   * @throws Exception
-   */
-  function save($model): ?Speed {
-    return Util::cast(parent::save($model), Speed::class);
-  }
-
-  /**
-   * @param Speed $model
-   * @param array $arr key-value associations for update
-   * @return Speed
-   * @throws Exception
-   */
-  function mset($model, array $arr): Speed {
-    return Util::cast(parent::mset($model, $arr), Speed::class);
-  }
-
-  /**
-   * @param Speed $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Speed
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Speed {
-    return Util::cast(parent::set($model, $key, $value), Speed::class);
   }
 }

--- a/src/dba/models/SpeedFactory.php
+++ b/src/dba/models/SpeedFactory.php
@@ -36,11 +36,10 @@ class SpeedFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Speed
    */
-  function createObjectFromDict($pk, $dict): Speed {
+  function createObjectFromDict(array $dict): Speed {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/StoredValueFactory.php
+++ b/src/dba/models/StoredValueFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<StoredValue>
+ */
 class StoredValueFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "StoredValue";
@@ -48,72 +47,5 @@ class StoredValueFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new StoredValue($dict['storedvalueid'], $dict['val']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return StoredValue|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): StoredValue|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), StoredValue::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, StoredValue::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?StoredValue
-   * @throws Exception
-   */
-  function get($pk): ?StoredValue {
-    return Util::cast(parent::get($pk), StoredValue::class);
-  }
-  
-  /**
-   * @param StoredValue $model
-   * @return ?StoredValue
-   * @throws Exception
-   */
-  function save($model): ?StoredValue {
-    return Util::cast(parent::save($model), StoredValue::class);
-  }
-
-  /**
-   * @param StoredValue $model
-   * @param array $arr key-value associations for update
-   * @return StoredValue
-   * @throws Exception
-   */
-  function mset($model, array $arr): StoredValue {
-    return Util::cast(parent::mset($model, $arr), StoredValue::class);
-  }
-
-  /**
-   * @param StoredValue $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return StoredValue
-   * @throws Exception
-   */
-  function set($model, string $key, $value): StoredValue {
-    return Util::cast(parent::set($model, $key, $value), StoredValue::class);
   }
 }

--- a/src/dba/models/StoredValueFactory.php
+++ b/src/dba/models/StoredValueFactory.php
@@ -36,11 +36,10 @@ class StoredValueFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return StoredValue
    */
-  function createObjectFromDict($pk, $dict): StoredValue {
+  function createObjectFromDict(array $dict): StoredValue {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/SupertaskFactory.php
+++ b/src/dba/models/SupertaskFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Supertask>
+ */
 class SupertaskFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Supertask";
@@ -48,72 +47,5 @@ class SupertaskFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Supertask($dict['supertaskid'], $dict['supertaskname']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Supertask|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Supertask|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Supertask::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Supertask::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Supertask
-   * @throws Exception
-   */
-  function get($pk): ?Supertask {
-    return Util::cast(parent::get($pk), Supertask::class);
-  }
-  
-  /**
-   * @param Supertask $model
-   * @return ?Supertask
-   * @throws Exception
-   */
-  function save($model): ?Supertask {
-    return Util::cast(parent::save($model), Supertask::class);
-  }
-
-  /**
-   * @param Supertask $model
-   * @param array $arr key-value associations for update
-   * @return Supertask
-   * @throws Exception
-   */
-  function mset($model, array $arr): Supertask {
-    return Util::cast(parent::mset($model, $arr), Supertask::class);
-  }
-
-  /**
-   * @param Supertask $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Supertask
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Supertask {
-    return Util::cast(parent::set($model, $key, $value), Supertask::class);
   }
 }

--- a/src/dba/models/SupertaskFactory.php
+++ b/src/dba/models/SupertaskFactory.php
@@ -36,11 +36,10 @@ class SupertaskFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Supertask
    */
-  function createObjectFromDict($pk, $dict): Supertask {
+  function createObjectFromDict(array $dict): Supertask {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/SupertaskPretaskFactory.php
+++ b/src/dba/models/SupertaskPretaskFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<SupertaskPretask>
+ */
 class SupertaskPretaskFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "SupertaskPretask";
@@ -48,72 +47,5 @@ class SupertaskPretaskFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new SupertaskPretask($dict['supertaskpretaskid'], $dict['supertaskid'], $dict['pretaskid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return SupertaskPretask|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): SupertaskPretask|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), SupertaskPretask::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, SupertaskPretask::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?SupertaskPretask
-   * @throws Exception
-   */
-  function get($pk): ?SupertaskPretask {
-    return Util::cast(parent::get($pk), SupertaskPretask::class);
-  }
-  
-  /**
-   * @param SupertaskPretask $model
-   * @return ?SupertaskPretask
-   * @throws Exception
-   */
-  function save($model): ?SupertaskPretask {
-    return Util::cast(parent::save($model), SupertaskPretask::class);
-  }
-
-  /**
-   * @param SupertaskPretask $model
-   * @param array $arr key-value associations for update
-   * @return SupertaskPretask
-   * @throws Exception
-   */
-  function mset($model, array $arr): SupertaskPretask {
-    return Util::cast(parent::mset($model, $arr), SupertaskPretask::class);
-  }
-
-  /**
-   * @param SupertaskPretask $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return SupertaskPretask
-   * @throws Exception
-   */
-  function set($model, string $key, $value): SupertaskPretask {
-    return Util::cast(parent::set($model, $key, $value), SupertaskPretask::class);
   }
 }

--- a/src/dba/models/SupertaskPretaskFactory.php
+++ b/src/dba/models/SupertaskPretaskFactory.php
@@ -36,11 +36,10 @@ class SupertaskPretaskFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return SupertaskPretask
    */
-  function createObjectFromDict($pk, $dict): SupertaskPretask {
+  function createObjectFromDict(array $dict): SupertaskPretask {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/TaskDebugOutputFactory.php
+++ b/src/dba/models/TaskDebugOutputFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<TaskDebugOutput>
+ */
 class TaskDebugOutputFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "TaskDebugOutput";
@@ -48,72 +47,5 @@ class TaskDebugOutputFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new TaskDebugOutput($dict['taskdebugoutputid'], $dict['taskid'], $dict['output']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return TaskDebugOutput|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): TaskDebugOutput|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), TaskDebugOutput::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, TaskDebugOutput::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?TaskDebugOutput
-   * @throws Exception
-   */
-  function get($pk): ?TaskDebugOutput {
-    return Util::cast(parent::get($pk), TaskDebugOutput::class);
-  }
-  
-  /**
-   * @param TaskDebugOutput $model
-   * @return ?TaskDebugOutput
-   * @throws Exception
-   */
-  function save($model): ?TaskDebugOutput {
-    return Util::cast(parent::save($model), TaskDebugOutput::class);
-  }
-
-  /**
-   * @param TaskDebugOutput $model
-   * @param array $arr key-value associations for update
-   * @return TaskDebugOutput
-   * @throws Exception
-   */
-  function mset($model, array $arr): TaskDebugOutput {
-    return Util::cast(parent::mset($model, $arr), TaskDebugOutput::class);
-  }
-
-  /**
-   * @param TaskDebugOutput $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return TaskDebugOutput
-   * @throws Exception
-   */
-  function set($model, string $key, $value): TaskDebugOutput {
-    return Util::cast(parent::set($model, $key, $value), TaskDebugOutput::class);
   }
 }

--- a/src/dba/models/TaskDebugOutputFactory.php
+++ b/src/dba/models/TaskDebugOutputFactory.php
@@ -36,11 +36,10 @@ class TaskDebugOutputFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return TaskDebugOutput
    */
-  function createObjectFromDict($pk, $dict): TaskDebugOutput {
+  function createObjectFromDict(array $dict): TaskDebugOutput {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/TaskFactory.php
+++ b/src/dba/models/TaskFactory.php
@@ -36,11 +36,10 @@ class TaskFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Task
    */
-  function createObjectFromDict($pk, $dict): Task {
+  function createObjectFromDict(array $dict): Task {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/TaskFactory.php
+++ b/src/dba/models/TaskFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Task>
+ */
 class TaskFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Task";
@@ -48,72 +47,5 @@ class TaskFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Task($dict['taskid'], $dict['taskname'], $dict['attackcmd'], $dict['chunktime'], $dict['statustimer'], $dict['keyspace'], $dict['keyspaceprogress'], $dict['priority'], $dict['maxagents'], $dict['color'], $dict['issmall'], $dict['iscputask'], $dict['usenewbench'], $dict['skipkeyspace'], $dict['crackerbinaryid'], $dict['crackerbinarytypeid'], $dict['taskwrapperid'], $dict['isarchived'], $dict['notes'], $dict['staticchunks'], $dict['chunksize'], $dict['forcepipe'], $dict['usepreprocessor'], $dict['preprocessorcommand']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Task|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Task|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Task::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Task::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Task
-   * @throws Exception
-   */
-  function get($pk): ?Task {
-    return Util::cast(parent::get($pk), Task::class);
-  }
-  
-  /**
-   * @param Task $model
-   * @return ?Task
-   * @throws Exception
-   */
-  function save($model): ?Task {
-    return Util::cast(parent::save($model), Task::class);
-  }
-
-  /**
-   * @param Task $model
-   * @param array $arr key-value associations for update
-   * @return Task
-   * @throws Exception
-   */
-  function mset($model, array $arr): Task {
-    return Util::cast(parent::mset($model, $arr), Task::class);
-  }
-
-  /**
-   * @param Task $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Task
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Task {
-    return Util::cast(parent::set($model, $key, $value), Task::class);
   }
 }

--- a/src/dba/models/TaskWrapperDisplayFactory.php
+++ b/src/dba/models/TaskWrapperDisplayFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<TaskWrapperDisplay>
+ */
 class TaskWrapperDisplayFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "TaskWrapperDisplay";
@@ -48,72 +47,5 @@ class TaskWrapperDisplayFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new TaskWrapperDisplay($dict['taskwrapperid'], $dict['taskwrapperpriority'], $dict['taskwrappermaxagents'], $dict['tasktype'], $dict['hashlistid'], $dict['accessgroupid'], $dict['taskwrappername'], $dict['displayname'], $dict['taskwrapperisarchived'], $dict['cracked'], $dict['taskid'], $dict['taskname'], $dict['color'], $dict['attackcmd'], $dict['chunktime'], $dict['statustimer'], $dict['keyspace'], $dict['keyspaceprogress'], $dict['taskpriority'], $dict['taskmaxagents'], $dict['issmall'], $dict['iscputask'], $dict['taskisarchived'], $dict['taskusepreprocessor'], $dict['hashlistname'], $dict['hashcount'], $dict['hashlistcracked'], $dict['hashtypeid'], $dict['hashtypedescription'], $dict['groupname']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return TaskWrapperDisplay|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): TaskWrapperDisplay|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), TaskWrapperDisplay::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, TaskWrapperDisplay::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?TaskWrapperDisplay
-   * @throws Exception
-   */
-  function get($pk): ?TaskWrapperDisplay {
-    return Util::cast(parent::get($pk), TaskWrapperDisplay::class);
-  }
-  
-  /**
-   * @param TaskWrapperDisplay $model
-   * @return ?TaskWrapperDisplay
-   * @throws Exception
-   */
-  function save($model): ?TaskWrapperDisplay {
-    return Util::cast(parent::save($model), TaskWrapperDisplay::class);
-  }
-
-  /**
-   * @param TaskWrapperDisplay $model
-   * @param array $arr key-value associations for update
-   * @return TaskWrapperDisplay
-   * @throws Exception
-   */
-  function mset($model, array $arr): TaskWrapperDisplay {
-    return Util::cast(parent::mset($model, $arr), TaskWrapperDisplay::class);
-  }
-
-  /**
-   * @param TaskWrapperDisplay $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return TaskWrapperDisplay
-   * @throws Exception
-   */
-  function set($model, string $key, $value): TaskWrapperDisplay {
-    return Util::cast(parent::set($model, $key, $value), TaskWrapperDisplay::class);
   }
 }

--- a/src/dba/models/TaskWrapperDisplayFactory.php
+++ b/src/dba/models/TaskWrapperDisplayFactory.php
@@ -36,11 +36,10 @@ class TaskWrapperDisplayFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return TaskWrapperDisplay
    */
-  function createObjectFromDict($pk, $dict): TaskWrapperDisplay {
+  function createObjectFromDict(array $dict): TaskWrapperDisplay {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/TaskWrapperFactory.php
+++ b/src/dba/models/TaskWrapperFactory.php
@@ -36,11 +36,10 @@ class TaskWrapperFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return TaskWrapper
    */
-  function createObjectFromDict($pk, $dict): TaskWrapper {
+  function createObjectFromDict(array $dict): TaskWrapper {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/TaskWrapperFactory.php
+++ b/src/dba/models/TaskWrapperFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<TaskWrapper>
+ */
 class TaskWrapperFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "TaskWrapper";
@@ -48,72 +47,5 @@ class TaskWrapperFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new TaskWrapper($dict['taskwrapperid'], $dict['priority'], $dict['maxagents'], $dict['tasktype'], $dict['hashlistid'], $dict['accessgroupid'], $dict['taskwrappername'], $dict['isarchived'], $dict['cracked']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return TaskWrapper|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): TaskWrapper|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), TaskWrapper::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, TaskWrapper::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?TaskWrapper
-   * @throws Exception
-   */
-  function get($pk): ?TaskWrapper {
-    return Util::cast(parent::get($pk), TaskWrapper::class);
-  }
-  
-  /**
-   * @param TaskWrapper $model
-   * @return ?TaskWrapper
-   * @throws Exception
-   */
-  function save($model): ?TaskWrapper {
-    return Util::cast(parent::save($model), TaskWrapper::class);
-  }
-
-  /**
-   * @param TaskWrapper $model
-   * @param array $arr key-value associations for update
-   * @return TaskWrapper
-   * @throws Exception
-   */
-  function mset($model, array $arr): TaskWrapper {
-    return Util::cast(parent::mset($model, $arr), TaskWrapper::class);
-  }
-
-  /**
-   * @param TaskWrapper $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return TaskWrapper
-   * @throws Exception
-   */
-  function set($model, string $key, $value): TaskWrapper {
-    return Util::cast(parent::set($model, $key, $value), TaskWrapper::class);
   }
 }

--- a/src/dba/models/UserFactory.php
+++ b/src/dba/models/UserFactory.php
@@ -36,11 +36,10 @@ class UserFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return User
    */
-  function createObjectFromDict($pk, $dict): User {
+  function createObjectFromDict(array $dict): User {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/UserFactory.php
+++ b/src/dba/models/UserFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<User>
+ */
 class UserFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "User";
@@ -48,72 +47,5 @@ class UserFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new User($dict['userid'], $dict['username'], $dict['email'], $dict['passwordhash'], $dict['passwordsalt'], $dict['isvalid'], $dict['iscomputedpassword'], $dict['lastlogindate'], $dict['registeredsince'], $dict['sessionlifetime'], $dict['rightgroupid'], $dict['yubikey'], $dict['otp1'], $dict['otp2'], $dict['otp3'], $dict['otp4']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return User|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): User|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), User::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, User::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?User
-   * @throws Exception
-   */
-  function get($pk): ?User {
-    return Util::cast(parent::get($pk), User::class);
-  }
-  
-  /**
-   * @param User $model
-   * @return ?User
-   * @throws Exception
-   */
-  function save($model): ?User {
-    return Util::cast(parent::save($model), User::class);
-  }
-
-  /**
-   * @param User $model
-   * @param array $arr key-value associations for update
-   * @return User
-   * @throws Exception
-   */
-  function mset($model, array $arr): User {
-    return Util::cast(parent::mset($model, $arr), User::class);
-  }
-
-  /**
-   * @param User $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return User
-   * @throws Exception
-   */
-  function set($model, string $key, $value): User {
-    return Util::cast(parent::set($model, $key, $value), User::class);
   }
 }

--- a/src/dba/models/ZapFactory.php
+++ b/src/dba/models/ZapFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<Zap>
+ */
 class ZapFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "Zap";
@@ -48,72 +47,5 @@ class ZapFactory extends AbstractModelFactory {
     }
     $dict = $conv;
     return new Zap($dict['zapid'], $dict['hash'], $dict['solvetime'], $dict['agentid'], $dict['hashlistid']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return Zap|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): Zap|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), Zap::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, Zap::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?Zap
-   * @throws Exception
-   */
-  function get($pk): ?Zap {
-    return Util::cast(parent::get($pk), Zap::class);
-  }
-  
-  /**
-   * @param Zap $model
-   * @return ?Zap
-   * @throws Exception
-   */
-  function save($model): ?Zap {
-    return Util::cast(parent::save($model), Zap::class);
-  }
-
-  /**
-   * @param Zap $model
-   * @param array $arr key-value associations for update
-   * @return Zap
-   * @throws Exception
-   */
-  function mset($model, array $arr): Zap {
-    return Util::cast(parent::mset($model, $arr), Zap::class);
-  }
-
-  /**
-   * @param Zap $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return Zap
-   * @throws Exception
-   */
-  function set($model, string $key, $value): Zap {
-    return Util::cast(parent::set($model, $key, $value), Zap::class);
   }
 }

--- a/src/dba/models/ZapFactory.php
+++ b/src/dba/models/ZapFactory.php
@@ -36,11 +36,10 @@ class ZapFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return Zap
    */
-  function createObjectFromDict($pk, $dict): Zap {
+  function createObjectFromDict(array $dict): Zap {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/_sqlx_migrationsFactory.php
+++ b/src/dba/models/_sqlx_migrationsFactory.php
@@ -36,11 +36,10 @@ class _sqlx_migrationsFactory extends AbstractModelFactory {
   }
   
   /**
-   * @param string $pk
    * @param array $dict
    * @return _sqlx_migrations
    */
-  function createObjectFromDict($pk, $dict): _sqlx_migrations {
+  function createObjectFromDict(array $dict): _sqlx_migrations {
     $conv = [];
     foreach ($dict as $key => $val) {
       $conv[strtolower($key)] = $val;

--- a/src/dba/models/_sqlx_migrationsFactory.php
+++ b/src/dba/models/_sqlx_migrationsFactory.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\dba\models;
 
-use Exception;
-use PDOStatement;
 use Hashtopolis\dba\AbstractModelFactory;
-use Hashtopolis\dba\AbstractModel;
-use Hashtopolis\dba\Util;
 
+/**
+ * @extends AbstractModelFactory<_sqlx_migrations>
+ */
 class _sqlx_migrationsFactory extends AbstractModelFactory {
   function getModelName(): string {
     return "_sqlx_migrations";
@@ -53,72 +52,5 @@ class _sqlx_migrationsFactory extends AbstractModelFactory {
       $dict['checksum'] = bin2hex($t);
     }
     return new _sqlx_migrations($dict['version'], $dict['description'], $dict['installed_on'], $dict['success'], $dict['checksum'], $dict['execution_time']);
-  }
-  
-  /**
-   * @param array $options
-   * @param bool $single
-   * @return _sqlx_migrations|array|null
-   * @throws Exception
-   */
-  function filter(array $options, bool $single = false): _sqlx_migrations|array|null {
-    $join = false;
-    if (array_key_exists('join', $options)) {
-      $join = true;
-    }
-    if ($single) {
-      if ($join) {
-        return parent::filter($options, $single);
-      }
-      return Util::cast(parent::filter($options, $single), _sqlx_migrations::class);
-    }
-    $objects = parent::filter($options, $single);
-    if ($join) {
-      return $objects;
-    }
-    $models = array();
-    foreach ($objects as $object) {
-      $models[] = Util::cast($object, _sqlx_migrations::class);
-    }
-    return $models;
-  }
-  
-  /**
-   * @param string $pk
-   * @return ?_sqlx_migrations
-   * @throws Exception
-   */
-  function get($pk): ?_sqlx_migrations {
-    return Util::cast(parent::get($pk), _sqlx_migrations::class);
-  }
-  
-  /**
-   * @param _sqlx_migrations $model
-   * @return ?_sqlx_migrations
-   * @throws Exception
-   */
-  function save($model): ?_sqlx_migrations {
-    return Util::cast(parent::save($model), _sqlx_migrations::class);
-  }
-
-  /**
-   * @param _sqlx_migrations $model
-   * @param array $arr key-value associations for update
-   * @return _sqlx_migrations
-   * @throws Exception
-   */
-  function mset($model, array $arr): _sqlx_migrations {
-    return Util::cast(parent::mset($model, $arr), _sqlx_migrations::class);
-  }
-
-  /**
-   * @param _sqlx_migrations $model
-   * @param string $key key of the column to update
-   * @param $value
-   * @return _sqlx_migrations
-   * @throws Exception
-   */
-  function set($model, string $key, $value): _sqlx_migrations {
-    return Util::cast(parent::set($model, $key, $value), _sqlx_migrations::class);
   }
 }

--- a/src/groups.php
+++ b/src/groups.php
@@ -94,10 +94,10 @@ else {
   UI::add('groups', Factory::getAccessGroupFactory()->filter([]));
   foreach (UI::get('groups') as $group) {
     /** @var AccessGroup $group */
-    if ($users->getVal($group->getId()) === false) {
+    if ($users->getVal($group->getId()) === null) {
       $users->addValue($group->getId(), 0);
     }
-    if ($agents->getVal($group->getId()) === false) {
+    if ($agents->getVal($group->getId()) === null) {
       $agents->addValue($group->getId(), 0);
     }
   }

--- a/src/inc/DataSet.php
+++ b/src/inc/DataSet.php
@@ -21,7 +21,7 @@ class DataSet {
     if (isset($this->values[$key])) {
       return $this->values[$key];
     }
-    return false;
+    return null;
   }
   
   public function getKeys(): array {

--- a/src/inc/DataSet.php
+++ b/src/inc/DataSet.php
@@ -3,17 +3,17 @@
 namespace Hashtopolis\inc;
 
 class DataSet {
-  private $values;
+  private mixed $values;
   
   public function __construct($arr = array()) {
     $this->values = $arr;
   }
   
-  public function setValues($arr) {
+  public function setValues($arr): void {
     $this->values = $arr;
   }
   
-  public function addValue($key, $val) {
+  public function addValue(string $key, $val): void {
     $this->values[$key] = $val;
   }
   
@@ -24,7 +24,7 @@ class DataSet {
     return false;
   }
   
-  public function getKeys() {
+  public function getKeys(): array {
     $keys = [];
     foreach ($this->values as $key => $val) {
       $keys[] = $key;

--- a/src/inc/HTMessages.php
+++ b/src/inc/HTMessages.php
@@ -6,14 +6,14 @@ use Exception;
 use Throwable;
 
 class HTMessages extends Exception {
-  private $arr = [];
+  private mixed $arr = [];
   
   public function __construct($message = "", $code = 0, ?Throwable $previous = NULL) {
     $this->arr = $message;
     parent::__construct(implode("\n", $this->arr), $code, $previous);
   }
   
-  public function getHTMLMessage() {
+  public function getHTMLMessage(): string {
     return implode("<br>", $this->arr);
   }
 }

--- a/src/inc/Login.php
+++ b/src/inc/Login.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc;
 
-use Hashtopolis\inc\Auth_Yubico;
+use Exception;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\models\Session;
 use Hashtopolis\dba\models\User;
@@ -13,8 +13,6 @@ use Hashtopolis\inc\defines\DLogEntryIssuer;
 use Hashtopolis\inc\defines\DNotificationType;
 use Hashtopolis\inc\defines\DPayloadKeys;
 use Hashtopolis\inc\handlers\NotificationHandler;
-use Hashtopolis\inc\SConfig;
-use Hashtopolis\inc\Util;
 use function PHPUnit\Framework\assertNotNull;
 
 /**
@@ -23,21 +21,21 @@ use function PHPUnit\Framework\assertNotNull;
  * @author Sein
  */
 class Login {
-  private $user  = null;
-  private $valid = false;
+  private ?User    $user    = null;
+  private bool     $valid   = false;
   private ?Session $session = null;
   
-  private static $instance = null;
+  private static ?Login $instance = null;
   
-  public function setUser($user) {
+  public function setUser(User $user): void {
     $this->user = $user;
   }
   
   /**
    * Get an instance of the Login class
-   * @return Login
+   * @return ?Login
    */
-  public static function getInstance() {
+  public static function getInstance(): ?Login {
     if (self::$instance == null) {
       self::$instance = new Login();
     }
@@ -47,6 +45,7 @@ class Login {
   /**
    * Creates a Login-Instance and checks automatically if there is a session
    * running. It updates the session lifetime again up to the session limit.
+   * @throws Exception
    */
   private function __construct() {
     if (isset($_COOKIE['session'])) {
@@ -77,14 +76,15 @@ class Login {
   /**
    * Returns true if the user currently is loggedin with a valid session
    */
-  public function isLoggedin() {
+  public function isLoggedin(): bool {
     return $this->valid;
   }
   
   /**
    * Logs the current user out and closes his session
+   * @throws Exception
    */
-  public function logout() {
+  public function logout(): void {
     assertNotNull($this->session);
     Factory::getSessionFactory()->set($this->session, Session::IS_OPEN, 0);
     $this->session = null;
@@ -97,14 +97,14 @@ class Login {
    * Returns the uID of the currently logged in user, if the user is not logged
    * in, the uID will be -1
    */
-  public function getUserID() {
+  public function getUserID(): ?int {
     if (!$this->valid) {
       return -1;
     }
     return $this->user->getId();
   }
   
-  public function getUser() {
+  public function getUser(): ?User {
     if (!$this->valid) {
       return null;
     }
@@ -116,10 +116,11 @@ class Login {
    *
    * @param string $username username of the user to be logged in
    * @param string $password password which was entered on login form
-   * @param string $otp OTP login field
+   * @param ?string $otp OTP login field
    * @return bool true on success and false on failure
+   * @throws Exception
    */
-  public function login(string $username, string $password, $otp = NULL): bool {
+  public function login(string $username, string $password, ?string $otp = NULL): bool {
     /****** Check password ******/
     if ($this->valid) {
       return false;
@@ -146,7 +147,7 @@ class Login {
     /****** End check password ******/
     
     /***** Check Yubikey *****/
-    if ($user->getYubikey() == true && Util::isYubikeyEnabled() && sizeof(SConfig::getInstance()->getVal(DConfig::YUBIKEY_ID)) != 0 && sizeof(SConfig::getInstance()->getVal(DConfig::YUBIKEY_KEY) != 0)) {
+    if ($user->getYubikey() && Util::isYubikeyEnabled() && sizeof(SConfig::getInstance()->getVal(DConfig::YUBIKEY_ID)) != 0 && sizeof(SConfig::getInstance()->getVal(DConfig::YUBIKEY_KEY) != 0)) {
       $keyId = substr($otp, 0, 12);
       
       if (strtoupper($user->getOtp1()) != strtoupper($keyId) && strtoupper($user->getOtp2()) != strtoupper($keyId) && strtoupper($user->getOtp3()) != strtoupper($keyId) && strtoupper($user->getOtp4()) != strtoupper($keyId)) {
@@ -179,7 +180,7 @@ class Login {
         return false;
       }
     }
-    else if ($user->getYubikey() == true && Util::isYubikeyEnabled()) {
+    else if ($user->getYubikey() && Util::isYubikeyEnabled()) {
       return false;
     }
     /****** End check Yubikey ******/

--- a/src/inc/SConfig.php
+++ b/src/inc/SConfig.php
@@ -2,16 +2,18 @@
 
 namespace Hashtopolis\inc;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 
 class SConfig {
-  private static $instance = null;
+  private static ?DataSet $instance = null;
   
   /**
    * @param bool $force
-   * @return DataSet
+   * @return ?DataSet
+   * @throws Exception
    */
-  public static function getInstance($force = false) {
+  public static function getInstance(bool $force = false): ?DataSet {
     if (self::$instance == null || $force) {
       $res = Factory::getConfigFactory()->filter([]);
       self::$instance = new DataSet();
@@ -24,8 +26,9 @@ class SConfig {
   
   /**
    * Force reloading the config from the database
+   * @throws Exception
    */
-  public static function reload() {
+  public static function reload(): void {
     SConfig::getInstance(true);
   }
 }

--- a/src/inc/StartupConfig.php
+++ b/src/inc/StartupConfig.php
@@ -5,9 +5,9 @@ namespace Hashtopolis\inc;
 class StartupConfig {
   private static ?StartupConfig $instance = null;
   
-  private array $directories   = [];
-  private array $db_properties = [];
-  private array $peppers       = [];
+  private array $directories;
+  private array $db_properties;
+  private array $peppers;
   
   /**
    * The choice here is to define the possible keys for config settings only private and only allow to

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -364,9 +364,9 @@ class Util {
   /**
    * Escapes special chars before they can be entered into the report template to avoid mess-up with latex
    *
-   * @deprecated
    * @param string $string
    * @return string
+   * @deprecated
    */
   public static function texEscape(string $string): string {
     $output = "";
@@ -936,11 +936,14 @@ class Util {
   
   /**
    * Checks if the task is completed and returns the html tick image if this is the case.
-   * @param $prog int progress so far
-   * @param $total int total to be done
+   * @param int|null $prog int progress so far
+   * @param int|null $total int total to be done
    * @return string either the check.png with Finished or an empty string
    */
-  public static function tickdone(int $prog, int $total): string {
+  public static function tickdone(int|null $prog, int|null $total): string {
+    if ($prog === null || $total === null) {
+      return "";
+    }
     // show tick of progress is done
     if ($total > 0 && $prog >= $total) {
       return ' <span class="fas fa-check" aria-hidden="true"></span>';
@@ -1087,10 +1090,10 @@ class Util {
   }
   
   /**
-   * @deprecated semver should be used for version comparison
    * @param string $versionString1
    * @param string $versionString2
    * @return int 1 if version2 is newer, 0 if equal and -1 if version1 is newer
+   * @deprecated semver should be used for version comparison
    */
   public static function updateVersionComparison(string $versionString1, string $versionString2): int {
     if (!str_starts_with($versionString1, "update_v") || !str_starts_with($versionString2, "update_v")) {
@@ -1432,12 +1435,12 @@ class Util {
   }
   
   /**
-   * @deprecated php standard library now offers this
-   *
-   * Checks if $search starts with $pattern. Shortcut for strpos==0
    * @param $search
    * @param $pattern
    * @return bool
+   * @deprecated php standard library now offers this
+   *
+   * Checks if $search starts with $pattern. Shortcut for strpos==0
    */
   public static function startsWith($search, $pattern): bool {
     if (str_starts_with($search, $pattern)) {
@@ -1447,12 +1450,12 @@ class Util {
   }
   
   /**
-   * @deprecated php standard library now offers this
-   *
-   * if pattern is empty or if pattern is at the end of search
    * @param $search
    * @param $pattern
    * @return bool
+   * @deprecated php standard library now offers this
+   *
+   * if pattern is empty or if pattern is at the end of search
    */
   public static function endsWith($search, $pattern): bool {
     return str_ends_with($search, $pattern);
@@ -1546,7 +1549,7 @@ class Util {
   /**
    * @param string $tmpfile
    * @return int
-   *@deprecated fileLineCount() should be used
+   * @deprecated fileLineCount() should be used
    *
    */
   public static function countLines(string $tmpfile): int {
@@ -1579,10 +1582,10 @@ class Util {
   }
   
   /**
-   * @deprecated use semver functions
-   *
    * @param string $version
    * @return string
+   * @deprecated use semver functions
+   *
    */
   public static function getMinorVersion(string $version): string {
     $split = explode(".", $version);

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -584,7 +584,6 @@ class Util {
         $set->addValue('maxAgents', $taskWrapper->getMaxAgents());
         $set->addValue('cracked', $taskWrapper->getCracked());
         
-        $taskList[] = $set;
       }
       else {
         // normal task
@@ -629,8 +628,8 @@ class Util {
         $set->addValue('numChunks', $chunkInfo[0]);
         $set->addValue('performance', $taskInfo[4]);
         $set->addValue('speed', $taskInfo[5]);
-        $taskList[] = $set;
       }
+      $taskList[] = $set;
     }
     UI::add('taskList', $taskList);
   }

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -49,6 +49,8 @@ use Hashtopolis\inc\defines\DTaskTypes;
 use Hashtopolis\inc\handlers\NotificationHandler;
 use Hashtopolis\inc\utils\AccessUtils;
 use PDO;
+use Random\RandomException;
+use SplFileObject;
 
 /**
  *
@@ -64,7 +66,7 @@ class Util {
    * @param string $filename
    * @return string
    */
-  public static function extractFileExtension($filename) {
+  public static function extractFileExtension(string $filename): string {
     $split = explode(".", $filename);
     if (sizeof($split) == 1) {
       return "";
@@ -80,7 +82,7 @@ class Util {
    * @param string $dest
    * @throws HTException
    */
-  public static function downloadFromUrl($url, $dest) {
+  public static function downloadFromUrl(string $url, string $dest): void {
     $furl = fopen($url, "rb");
     if (!$furl) {
       throw new HTException("Failed to open URL!");
@@ -109,10 +111,11 @@ class Util {
    * @param int $agentId corresponding agent to show data from, 0 to sum up from all agents on this task
    * @param int $delta time distance between the data points
    * @return int[]
+   * @throws Exception
    */
-  public static function getSpeedDataSet($taskId, $limit = 50, $agentId = 0, $delta = 10) {
+  public static function getSpeedDataSet(int $taskId, int $limit = 50, int $agentId = 0, int $delta = 10): array {
     // if agentId is 0 we need to find out how many agents there are to find how many entries we would need max
-    $requestLimit = intval($limit) * $delta / 5;
+    $requestLimit = $limit * $delta / 5;
     if ($agentId == 0) { // This might be to rewritten, it's just an estimation how to calculate an ideal number of entries to be requested
       // we cannot request all entries here as this number might grow quite quickly over time
       $qF = new QueryFilter(Assignment::TASK_ID, $taskId, "=");
@@ -168,8 +171,9 @@ class Util {
    *
    * @param int $hashtypeId
    * @return string
+   * @throws Exception
    */
-  public static function getHashtypeById($hashtypeId) {
+  public static function getHashtypeById(int $hashtypeId): string {
     $hashtype = Factory::getHashTypeFactory()->get($hashtypeId);
     if ($hashtype == null) {
       return "N/A";
@@ -183,7 +187,7 @@ class Util {
    * @param bool $hashOnly
    * @return string
    */
-  public static function getGitCommit($hashOnly = false) {
+  public static function getGitCommit(bool $hashOnly = false): string {
     $gitcommit = "";
     $gitfolder = dirname(__FILE__) . "/../../.git";
     if (file_exists($gitfolder) && is_dir($gitfolder)) {
@@ -210,8 +214,9 @@ class Util {
   /**
    * function to check agent version for older update scripts, that still has
    * the 'type' field in AgentBinary instead of 'binaryType'
+   * @throws Exception
    */
-  public static function checkAgentVersionLegacy($type, $version, $silent = false) {
+  public static function checkAgentVersionLegacy($type, $version, $silent = false): void {
     $agentBinaryFactory = Factory::getAgentBinaryFactory();
     $dict = $agentBinaryFactory->getNullObject()->getKeyValueDict();
     unset($dict["binaryType"]);
@@ -255,8 +260,9 @@ class Util {
    * @param string $type
    * @param string $version
    * @param bool $silent
+   * @throws Exception
    */
-  public static function checkAgentVersion($type, $version, $silent = false) {
+  public static function checkAgentVersion(string $type, string $version, bool $silent = false): void {
     $qF = new QueryFilter(AgentBinary::BINARY_TYPE, $type, "=");
     $binary = Factory::getAgentBinaryFactory()->filter([Factory::FILTER => $qF], true);
     if ($binary != null) {
@@ -274,8 +280,10 @@ class Util {
   
   /**
    * @return boolean
+   * @throws Exception
+   * @deprecated
    */
-  public static function isYubikeyEnabled() {
+  public static function isYubikeyEnabled(): bool {
     $clientId = SConfig::getInstance()->getVal(DConfig::YUBIKEY_ID);
     if (!is_numeric($clientId) || $clientId <= 0) {
       return false;
@@ -296,8 +304,9 @@ class Util {
    * @param $issuerId string either the ID of the user or the token of the client
    * @param $level string
    * @param $message string
+   * @throws Exception
    */
-  public static function createLogEntry($issuer, $issuerId, $level, $message) {
+  public static function createLogEntry(string $issuer, string $issuerId, string $level, string $message): void {
     $count = Factory::getLogEntryFactory()->countFilter(array());
     if ($count > SConfig::getInstance()->getVal(DConfig::NUMBER_LOGENTRIES) * 1.2) {
       // if we have exceeded the log entry limit by 20%, delete the oldest ones
@@ -329,14 +338,14 @@ class Util {
    * @param bool $pretty
    * @return string[] found report template file names
    */
-  public static function scanReportDirectory($type = "", $pretty = false) {
+  public static function scanReportDirectory(string $type = "", bool $pretty = false): array {
     $directory = dirname(__FILE__) . "/../templates/report/";
     if (file_exists($directory) && is_dir($directory)) {
       $reportDir = opendir($directory);
       $reports = array();
       while ($file = readdir($reportDir)) {
-        if ($file[0] != '.' && $file != "." && $file != ".." && !is_dir($file) && strpos($file, ".tex") !== false) {
-          if (strlen($type) > 0 && strpos($file, $type . "-") !== 0) {
+        if ($file[0] != '.' && $file != "." && $file != ".." && !is_dir($file) && str_contains($file, ".tex")) {
+          if (strlen($type) > 0 && !str_starts_with($file, $type . "-")) {
             continue;
           }
           if ($pretty) {
@@ -355,10 +364,11 @@ class Util {
   /**
    * Escapes special chars before they can be entered into the report template to avoid mess-up with latex
    *
+   * @deprecated
    * @param string $string
    * @return string
    */
-  public static function texEscape($string) {
+  public static function texEscape(string $string): string {
     $output = "";
     for ($i = 0; $i < strlen($string); $i++) {
       if ($string[$i] == '#') {
@@ -380,8 +390,9 @@ class Util {
   /**
    * Scans the import-directory for files. Directories are ignored.
    * @return array of all files in the top-level directory /../import
+   * @throws Exception
    */
-  public static function scanImportDirectory() {
+  public static function scanImportDirectory(): array {
     $directory = Factory::getStoredValueFactory()->get(DDirectories::IMPORT)->getVal() . "/";
     if (file_exists($directory) && is_dir($directory)) {
       $importDirectory = opendir($directory);
@@ -402,7 +413,7 @@ class Util {
    * @param $in mixed calculation to be done
    * @return mixed
    */
-  public static function calculate($in) {
+  public static function calculate(mixed $in): mixed {
     return $in;
   }
   
@@ -413,8 +424,9 @@ class Util {
    * @param $type string
    * @param $accessGroupId int
    * @return bool true if the save of the file model succeeded
+   * @throws Exception
    */
-  public static function insertFile($path, $name, $type, $accessGroupId) {
+  public static function insertFile(string $path, string $name, string $type, int $accessGroupId): bool {
     $fileType = DFileType::OTHER;
     if ($type == 'rule') {
       $fileType = DFileType::RULE;
@@ -442,8 +454,9 @@ class Util {
   /**
    * @param $task Task
    * @return array
+   * @throws Exception
    */
-  public static function getTaskInfo($task) {
+  public static function getTaskInfo(Task $task): array {
     $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     
     $agg1 = new Aggregation(Chunk::CHECKPOINT, Aggregation::SUM);
@@ -477,8 +490,9 @@ class Util {
    * @param $task Task
    * @param $accessGroups AccessGroup[]
    * @return array
+   * @throws Exception
    */
-  public static function getFileInfo($task, $accessGroups) {
+  public static function getFileInfo(Task $task, array $accessGroups): array {
     $qF = new QueryFilter(FileTask::TASK_ID, $task->getId(), "=", Factory::getFileTaskFactory());
     $jF = new JoinFilter(Factory::getFileTaskFactory(), FileTask::FILE_ID, File::FILE_ID);
     $joinedFiles = Factory::getFileFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
@@ -502,8 +516,9 @@ class Util {
   /**
    * @param $task Task
    * @return array
+   * @throws Exception
    */
-  public static function getChunkInfo($task) {
+  public static function getChunkInfo(Task $task): array {
     $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     $agg1 = new Aggregation(Chunk::CRACKED, "SUM");
     $agg2 = new Aggregation(Chunk::CHUNK_ID, "COUNT");
@@ -521,8 +536,9 @@ class Util {
   /**
    * @param $userId int
    * @return array
+   * @throws Exception
    */
-  public static function getAccessGroupIds($userId) {
+  public static function getAccessGroupIds(int $userId): array {
     $qF = new QueryFilter(AccessGroupUser::USER_ID, $userId, "=", Factory::getAccessGroupUserFactory());
     $jF = new JoinFilter(Factory::getAccessGroupUserFactory(), AccessGroup::ACCESS_GROUP_ID, AccessGroupUser::ACCESS_GROUP_ID);
     $joined = Factory::getAccessGroupFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
@@ -531,7 +547,12 @@ class Util {
     return Util::arrayOfIds($accessGroups);
   }
   
-  public static function loadTasks($archived = false) {
+  /**
+   * @param bool $archived
+   * @return void
+   * @throws Exception
+   */
+  public static function loadTasks(bool $archived = false): void {
     $accessGroupIds = Util::getAccessGroupIds(Login::getInstance()->getUserID());
     $accessGroups = AccessUtils::getAccessGroupsOfUser(Login::getInstance()->getUser());
     
@@ -617,8 +638,9 @@ class Util {
   /**
    * @param $taskWrapper TaskWrapper
    * @return bool
+   * @throws Exception
    */
-  public static function checkTaskWrapperCompleted($taskWrapper) {
+  public static function checkTaskWrapperCompleted(TaskWrapper $taskWrapper): bool {
     $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $taskWrapper->getId(), "=");
     $tasks = Factory::getTaskFactory()->filter([Factory::FILTER => $qF]);
     foreach ($tasks as $task) {
@@ -640,7 +662,10 @@ class Util {
     return true;
   }
   
-  public static function cleaning() {
+  /**
+   * @throws Exception
+   */
+  public static function cleaning(): void {
     $entry = Factory::getStoredValueFactory()->get(DCleaning::LAST_CLEANING);
     if ($entry == null) {
       $entry = new StoredValue(DCleaning::LAST_CLEANING, 0);
@@ -659,8 +684,9 @@ class Util {
    * Checks if it is longer than 10 mins since the last time it was checked if there are
    * any old agent statistic entries which can be deleted. If necessary, check is executed
    * and old entries are deleted.
+   * @throws Exception
    */
-  public static function agentStatCleaning() {
+  public static function agentStatCleaning(): void {
     $lifetime = intval(SConfig::getInstance()->getVal(DConfig::AGENT_DATA_LIFETIME));
     if ($lifetime <= 0) {
       $lifetime = 3600;
@@ -675,8 +701,9 @@ class Util {
   
   /**
    * Used by the solver. Cleans the zap-queue
+   * @throws Exception
    */
-  public static function zapCleaning() {
+  public static function zapCleaning(): void {
     $zapFilter = new QueryFilter(Zap::SOLVE_TIME, time() - 600, "<=");
     
     // delete dependencies on AgentZap
@@ -696,8 +723,9 @@ class Util {
    * metadata to determine upload expiration, and removes expired metadata files
    * together with their corresponding upload (.part) files. It performs file
    * system operations and may delete files on disk.
+   * @throws Exception
    */
-  public static function tusFileCleaning() {
+  public static function tusFileCleaning(): void {
     $tusDirectory = Factory::getStoredValueFactory()->get(DDirectories::TUS);
     
     if ($tusDirectory !== null) {
@@ -737,7 +765,7 @@ class Util {
    * @param $file string Filepath you want to get the size from
    * @return int -1 if the file doesn't exist, else filesize
    */
-  public static function filesize($file) {
+  public static function filesize(string $file): int {
     if (!file_exists($file)) {
       return -1;
     }
@@ -747,7 +775,7 @@ class Util {
     }
     $pos = 0;
     $size = 1073741824;
-    fseek($fp, 0, SEEK_SET);
+    fseek($fp, 0);
     while ($size > 1) {
       fseek($fp, $size, SEEK_CUR);
       
@@ -773,13 +801,13 @@ class Util {
    * @param $file string Filepath you want to get the size from
    * @return int -1 if the file doesn't exist, else filesize
    */
-  public static function fileLineCount($file) {
+  public static function fileLineCount(string $file): int {
     if (!file_exists($file)) {
       return -1;
     }
     // find out what a prettier solution for this would be, as opposed to setting the max execution time to an arbitrary two hours
     ini_set('max_execution_time', '7200');
-    $file = new \SplFileObject($file, 'r');
+    $file = new SplFileObject($file, 'r');
     $file->seek(PHP_INT_MAX);
     
     return $file->key();
@@ -790,7 +818,7 @@ class Util {
    * @param $file string Filepath you want to get the size from
    * @return int -1 if the file doesn't exist, else filesize
    */
-  public static function rulefileLineCount($file) {
+  public static function rulefileLineCount(string $file): int {
     if (!file_exists($file)) {
       return -1;
     }
@@ -800,7 +828,7 @@ class Util {
     $handle = fopen($file, "r");
     while (!feof($handle)) {
       $line = fgets($handle);
-      if (!(Util::startsWith($line, '#') or trim($line) == "")) {
+      if (!(str_starts_with($line, '#') or trim($line) == "")) {
         $lineCount = $lineCount + 1;
       }
     }
@@ -812,7 +840,7 @@ class Util {
   /**
    * Refreshes the page with the current url, also includes the query string.
    */
-  public static function refresh() {
+  public static function refresh(): void {
     global $_SERVER;
     
     $url = $_SERVER['PHP_SELF'];
@@ -829,8 +857,9 @@ class Util {
    *
    * @param $hashlist Hashlist
    * @return Hashlist[] of all superhashlists belonging to the $list
+   * @throws Exception
    */
-  public static function checkSuperHashlist($hashlist) {
+  public static function checkSuperHashlist(Hashlist $hashlist): array {
     if ($hashlist->getFormat() == DHashlistFormat::SUPERHASHLIST) {
       $jF = new JoinFilter(Factory::getHashlistFactory(), HashlistHashlist::HASHLIST_ID, Hashlist::HASHLIST_ID);
       $qF = new QueryFilter(HashlistHashlist::PARENT_HASHLIST_ID, $hashlist->getId(), "=");
@@ -843,8 +872,9 @@ class Util {
   /**
    * @param $hashlist Hashlist
    * @return Hashlist[] all superhashlists which the hashlist is part of
+   * @throws Exception
    */
-  public static function getParentSuperHashlists($hashlist) {
+  public static function getParentSuperHashlists(Hashlist $hashlist): array {
     if ($hashlist->getFormat() == DHashlistFormat::SUPERHASHLIST) {
       return [];
     }
@@ -858,7 +888,7 @@ class Util {
    * Tries to determine the IP of the client.
    * @return string 0.0.0.0 or the client IP
    */
-  public static function getIP() {
+  public static function getIP(): string {
     if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
       $ip = $_SERVER['HTTP_CLIENT_IP'];
     }
@@ -879,7 +909,7 @@ class Util {
    * @param $arr array of files to check
    * @return bool
    */
-  public static function checkWriteFiles($arr) {
+  public static function checkWriteFiles(array $arr): bool {
     foreach ($arr as $path) {
       if (!is_writable($path)) {
         return false;
@@ -893,7 +923,7 @@ class Util {
    * @param $binString String you want to convert
    * @return string Hex-String
    */
-  public static function bintohex($binString) {
+  public static function bintohex(string $binString): string {
     $return = "";
     for ($i = 0; $i < strlen($binString); $i++) {
       $hex = dechex(ord($binString[$i]));
@@ -911,7 +941,7 @@ class Util {
    * @param $total int total to be done
    * @return string either the check.png with Finished or an empty string
    */
-  public static function tickdone($prog, $total) {
+  public static function tickdone(int $prog, int $total): string {
     // show tick of progress is done
     if ($total > 0 && $prog >= $total) {
       return ' <span class="fas fa-check" aria-hidden="true"></span>';
@@ -923,8 +953,9 @@ class Util {
    * Returns the username from the given userId
    * @param $id int ID for the user
    * @return string username or unknown-id
+   * @throws Exception
    */
-  public static function getUsernameById($id) {
+  public static function getUsernameById(int $id): string {
     $user = Factory::getUserFactory()->get($id);
     if ($user === null) {
       return "Unknown" . ((strlen("" . $id) > 0) ? "-$id" : "");
@@ -934,10 +965,10 @@ class Util {
   
   /**
    * Used in Template. Converts seconds to human readable format
-   * @param $seconds
+   * @param int $seconds
    * @return string
    */
-  public static function sectotime($seconds) {
+  public static function sectotime(int $seconds): string {
     $return = "";
     if ($seconds > 86400) {
       $days = floor($seconds / 86400);
@@ -954,18 +985,18 @@ class Util {
    * @param $string string to check
    * @return string escaped string
    */
-  public static function escapeSpecial($string) {
+  public static function escapeSpecial(string $string): string {
     $string = htmlentities($string, ENT_QUOTES, "UTF-8");
     $string = str_replace('"', '&#34;', $string);
     $string = str_replace("'", "&#39;", $string);
-    $string = str_replace('`', '&#96;', $string);
-    return $string;
+    return str_replace('`', '&#96;', $string);
   }
   
   /**
    * Checks if the given string contains characters which are blacklisted
    * @param $string string
    * @return bool true if at least one character is in the blacklist
+   * @throws Exception
    */
   public static function containsBlacklistedChars(string $string): bool {
     $blacklisted = SConfig::getInstance()->getVal(DConfig::BLACKLIST_CHARS);
@@ -980,11 +1011,11 @@ class Util {
   /**
    * Used in Template
    * TODO: this should be made a bit better
-   * @param $val string of the array
-   * @param $id int index of the array
+   * @param int $val index of the array
+   * @param string $id identifier of the array to request
    * @return string the element or empty string
    */
-  public static function getStaticArray($val, $id) {
+  public static function getStaticArray(int $val, string $id): string {
     $platforms = array(
       "unknown",
       "NVidia",
@@ -1022,7 +1053,7 @@ class Util {
     );
     switch ($id) {
       case 'os':
-        if ($val == '-1') {
+        if ($val == -1) {
           return $platforms[0];
         }
         return $oses[$val];
@@ -1033,7 +1064,7 @@ class Util {
       case 'formattables':
         return $formattables[$val];
       case 'platforms':
-        if ($val == '-1') {
+        if ($val == -1) {
           return $platforms[0];
         }
         return $platforms[$val];
@@ -1046,7 +1077,7 @@ class Util {
    * @param $binary2 CrackerBinary
    * @return int
    */
-  public static function versionComparisonBinary($binary1, $binary2) {
+  public static function versionComparisonBinary(CrackerBinary $binary1, CrackerBinary $binary2): int {
     if (Comparator::greaterThan($binary1->getVersion(), $binary2->getVersion())) {
       return 1;
     }
@@ -1057,13 +1088,14 @@ class Util {
   }
   
   /**
+   * @deprecated semver should be used for version comparison
    * @param string $versionString1
    * @param string $versionString2
    * @return int 1 if version2 is newer, 0 if equal and -1 if version1 is newer
    */
-  public static function updateVersionComparison($versionString1, $versionString2) {
-    if (!Util::startsWith($versionString1, "update_v") || !Util::startsWith($versionString2, "update_v")) {
-      return Util::startsWith($versionString1, "update_v") ? -1 : 1;
+  public static function updateVersionComparison(string $versionString1, string $versionString2): int {
+    if (!str_starts_with($versionString1, "update_v") || !str_starts_with($versionString2, "update_v")) {
+      return str_starts_with($versionString1, "update_v") ? -1 : 1;
     }
     $version1 = substr($versionString1, 8, strpos($versionString1, "_", 7) - 8);
     $version2 = substr($versionString2, 8, strpos($versionString2, "_", 7) - 8);
@@ -1084,7 +1116,7 @@ class Util {
    * @param int $divider default 1024
    * @return string Formatted Integer
    */
-  public static function nicenum($num, $threshold = 1024, $divider = 1024) {
+  public static function nicenum(int $num, int $threshold = 1024, int $divider = 1024): string {
     $r = 0;
     while ($num > $threshold) {
       $num /= $divider;
@@ -1106,7 +1138,7 @@ class Util {
    * @param int $decs decimals you want rounded
    * @return string formatted percentage
    */
-  public static function showperc($part, $total, $decs = 2) {
+  public static function showperc(int $part, int $total, int $decs = 2): string {
     if ($total > 0) {
       $percentage = round(($part / $total) * 100, $decs);
       if ($percentage == 100 && $part < $total) {
@@ -1127,10 +1159,11 @@ class Util {
    * TODO: this function can be improved, some else blocks can be removed when handling a bit differently
    * @param $target string File you want to write to
    * @param $type string paste, upload, import or url
-   * @param $sourcedata string|array
+   * @param $sourcedata array|string
    * @return array (boolean, string) success, msg detailing what happened
+   * @throws Exception
    */
-  public static function uploadFile($target, $type, $sourcedata) {
+  public static function uploadFile(string $target, string $type, array|string $sourcedata): array {
     $success = false;
     $msg = "ALL_OK";
     if (!file_exists($target)) {
@@ -1190,7 +1223,6 @@ class Util {
               $msg = "Could not open target file!";
             }
             else {
-              $downed = 0;
               $buffersize = 131072;
               $last_logged = time();
               while (!feof($furl)) {
@@ -1199,7 +1231,6 @@ class Util {
                   break;
                 }
                 fwrite($fileLocation, $data);
-                $downed += strlen($data);
                 if ($last_logged < time() - 10) {
                   $last_logged = time();
                 }
@@ -1222,28 +1253,21 @@ class Util {
     return array($success, $msg);
   }
   
-  public static function getFileExtension($os) {
-    switch ($os) {
-      case DOperatingSystem::LINUX:
-        $ext = ".bin";
-        break;
-      case DOperatingSystem::WINDOWS:
-        $ext = ".exe";
-        break;
-      case DOperatingSystem::OSX:
-        $ext = ".osx";
-        break;
-      default:
-        $ext = "";
-    }
-    return $ext;
+  public static function getFileExtension(int $os): string {
+    return match ($os) {
+      DOperatingSystem::LINUX => ".bin",
+      DOperatingSystem::WINDOWS => ".exe",
+      DOperatingSystem::OSX => ".osx",
+      default => "",
+    };
   }
   
   /**
    * This function determines the protocol, domain and port of the webserver and puts it together as baseurl.
    * @return string basic server url
+   * @throws Exception
    */
-  public static function buildServerUrl() {
+  public static function buildServerUrl(): string {
     // when the server hostname is set on the config, use this
     if (strlen(SConfig::getInstance()->getVal(DConfig::BASE_HOST)) > 0) {
       return SConfig::getInstance()->getVal(DConfig::BASE_HOST);
@@ -1269,15 +1293,13 @@ class Util {
    * @param $dec Number of decimals
    * @return string Rounded value
    */
-  public static function niceround($num, $dec) {
+  public static function niceround($num, $dec): string {
     $return = strval(round($num, $dec));
     if ($dec > 0) {
       $pointPosition = strpos($return, ".");
       if ($pointPosition === false) {
         $return .= ".";
-        for ($i = 0; $i < $dec; $i++) {
-          $return .= "0";
-        }
+        $return .= str_repeat("0", $dec);
       }
       else {
         while (strlen($return) - $pointPosition <= $dec) {
@@ -1290,11 +1312,11 @@ class Util {
   
   /**
    * Cut a string to a certain number of letters. If the string is too long, instead replaces the last three letters with ...
-   * @param $string String you want to short
-   * @param $length Number of Elements you want the string to have
+   * @param string $string String you want to short
+   * @param int $length Number of Elements you want the string to have
    * @return string Formatted string
    */
-  public static function shortenstring($string, $length) {
+  public static function shortenstring(string $string, int $length): string {
     // shorten string that would be too long
     $return = "<span title='$string'>";
     if (strlen($string) > $length) {
@@ -1309,11 +1331,11 @@ class Util {
   
   /**
    * Adds 0s to the beginning of a number until it reaches size.
-   * @param $number
-   * @param $size
+   * @param int $number
+   * @param int $size
    * @return string
    */
-  public static function prefixNum($number, $size) {
+  public static function prefixNum(int $number, int $size): string {
     $formatted = "" . $number;
     while (strlen($formatted) < $size) {
       $formatted = "0" . $formatted;
@@ -1328,7 +1350,7 @@ class Util {
    *          string to convert
    * @return string converted string into hex
    */
-  public static function strToHex($string) {
+  public static function strToHex(string $string): string {
     return implode(unpack("H*", $string));
   }
   
@@ -1337,7 +1359,7 @@ class Util {
    * @param $b Chunk
    * @return int
    */
-  public static function compareChunksTime($a, $b) {
+  public static function compareChunksTime(Chunk $a, Chunk $b): int {
     if ($a->getDispatchTime() == $b->getDispatchTime()) {
       return 0;
     }
@@ -1364,8 +1386,9 @@ class Util {
    *          html content of the email
    * @param string $plaintext plaintext version of the email content
    * @return bool true on success, false on failure
+   * @throws Exception
    */
-  public static function sendMail($address, $subject, $text, $plaintext) {
+  public static function sendMail(string $address, string $subject, string $text, string $plaintext): bool {
     if (!self::isMailConfigured()) {
       error_log(("Mail notification is not configured. No message sent."));
       return false;
@@ -1399,8 +1422,9 @@ class Util {
    *          length of random string to generate
    * @param string $charset
    * @return string random string
+   * @throws RandomException
    */
-  public static function randomString($length, $charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") {
+  public static function randomString(int $length, string $charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"): string {
     $result = "";
     for ($x = 0; $x < $length; $x++) {
       $result .= $charset[random_int(0, strlen($charset) - 1)];
@@ -1409,35 +1433,38 @@ class Util {
   }
   
   /**
+   * @deprecated php standard library now offers this
+   *
    * Checks if $search starts with $pattern. Shortcut for strpos==0
    * @param $search
    * @param $pattern
    * @return bool
    */
-  public static function startsWith($search, $pattern) {
-    if (strpos($search, $pattern) === 0) {
+  public static function startsWith($search, $pattern): bool {
+    if (str_starts_with($search, $pattern)) {
       return true;
     }
     return false;
   }
   
   /**
+   * @deprecated php standard library now offers this
+   *
    * if pattern is empty or if pattern is at the end of search
    * @param $search
    * @param $pattern
    * @return bool
    */
-  public static function endsWith($search, $pattern) {
-    // search forward starting from end minus needle length characters
-    return $pattern === "" || (($temp = strlen($search) - strlen($pattern)) >= 0 && strpos($search, $pattern, $temp) !== FALSE);
+  public static function endsWith($search, $pattern): bool {
+    return str_ends_with($search, $pattern);
   }
   
   /**
    * Converts a hex to binary
-   * @param $data
+   * @param string $data
    * @return string
    */
-  public static function hextobin($data) {
+  public static function hextobin(string $data): string {
     $res = "";
     for ($i = 0; $i < strlen($data) - 1; $i += 2) {
       $res .= chr(hexdec(substr($data, $i, 2)));
@@ -1446,12 +1473,15 @@ class Util {
   }
   
   /**
-   * @note dev
-   * Sets the max length of hashes in the database
    * @param $limit int limit for hash length
    * @return bool true on success
+   * @throws Exception
+   *
+   * @deprecated this should NOT be used anymore, hash is a text field!
+   *
+   * Sets the max length of hashes in the database
    */
-  public static function setMaxHashLength($limit) {
+  public static function setMaxHashLength(int $limit): bool {
     if ($limit < 1) {
       return false;
     }
@@ -1475,12 +1505,14 @@ class Util {
   }
   
   /**
-   * @note dev
    * Sets the max length of plaintexts in the database
    * @param $limit int limit for hash length
    * @return bool true on success
+   *
+   * @throws Exception
+   * @deprecated this should NOT be used anymore, plain is a text field!
    */
-  public static function setPlaintextMaxLength($limit) {
+  public static function setPlaintextMaxLength(int $limit): bool {
     if ($limit < 1) {
       return false;
     }
@@ -1504,7 +1536,7 @@ class Util {
    * @param $array AbstractModel[]
    * @return array
    */
-  public static function arrayOfIds($array) {
+  public static function arrayOfIds(array $array): array {
     $arr = array();
     foreach ($array as $entry) {
       $arr[] = $entry->getId();
@@ -1512,9 +1544,13 @@ class Util {
     return $arr;
   }
   
-  // new function added: fileLineCount(). This function is independent of OS.
-  // check whether we can remove one of these functions
-  public static function countLines($tmpfile) {
+  /**
+   * @param string $tmpfile
+   * @return int
+   *@deprecated fileLineCount() should be used
+   *
+   */
+  public static function countLines(string $tmpfile): int {
     if (stripos(PHP_OS, "WIN") === 0) {
       // windows line count
       $ret = exec('find /c /v "" "' . $tmpfile . '"');
@@ -1530,11 +1566,11 @@ class Util {
    * @param $deviceArray string[]
    * @return string[]
    */
-  public static function compressDevices($deviceArray) {
+  public static function compressDevices(array $deviceArray): array {
     $compressed = array();
     foreach ($deviceArray as $device) {
       foreach (DDeviceCompress::COMPRESSION as $pattern => $replacement) {
-        if (strpos($device, $pattern) !== false) {
+        if (str_contains($device, $pattern)) {
           $device = str_replace($pattern, $replacement, $device);
         }
       }
@@ -1543,27 +1579,51 @@ class Util {
     return $compressed;
   }
   
-  public static function getMinorVersion($version) {
+  /**
+   * @deprecated use semver functions
+   *
+   * @param string $version
+   * @return string
+   */
+  public static function getMinorVersion(string $version): string {
     $split = explode(".", $version);
     return $split[0] . "." . $split[1];
   }
   
-  public static function databaseColumnExists($table, $column) {
+  /**
+   * Does not use prepared statements, make sure input is sanitized!
+   *
+   * @throws Exception
+   */
+  public static function databaseColumnExists(string $table, string $column): bool {
     $result = Factory::getAgentFactory()->getDB()->query("SHOW COLUMNS FROM `$table` LIKE '$column'");
     return $result->rowCount() > 0;
   }
   
-  public static function databaseTableExists($table) {
+  /**
+   * Does not use prepared statements, make sure input is sanitized!
+   *
+   * @throws Exception
+   */
+  public static function databaseTableExists(string $table): bool {
     $result = Factory::getAgentFactory()->getDB()->query("SHOW TABLES LIKE '$table';");
     return $result->rowCount() > 0;
   }
   
-  public static function databaseIndexExists($table, $column) {
+  /**
+   * Does not use prepared statements, make sure input is sanitized!
+   *
+   * @throws Exception
+   */
+  public static function databaseIndexExists(string $table, string $column): bool {
     $result = Factory::getAgentFactory()->getDB()->query("SHOW INDEX FROM `$table` WHERE Column_name='$column'");
     return $result->rowCount() > 0;
   }
   
-  public static function checkDataDirectory($key, $dir) {
+  /**
+   * @throws Exception
+   */
+  public static function checkDataDirectory($key, $dir): void {
     $entry = Factory::getStoredValueFactory()->get($key);
     if ($entry == null) {
       $entry = new StoredValue($key, $dir);

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -227,10 +227,8 @@ class Util {
     
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($row != null) {
-      $pkName = $agentBinaryFactory->getNullObject()->getPrimaryKey();
-      $pk = $row[$pkName];
       $row["binaryType"] = $row["type"];
-      $binary = $agentBinaryFactory->createObjectFromDict($pk, $row);
+      $binary = $agentBinaryFactory->createObjectFromDict($row);
       
       if (Comparator::lessThan($binary->getVersion(), $version)) {
         if (!$silent) {
@@ -1586,7 +1584,7 @@ class Util {
    * @throws Exception
    */
   public static function checkOrCreateInitialObject(AbstractModelFactory $factory, array $data): void {
-    $object = $factory->createObjectFromDict('0', $data);
+    $object = $factory->createObjectFromDict($data);
     $check = $factory->get($object->getId());
     if ($check !== null) {
       return;

--- a/src/inc/agent/PQuery.php
+++ b/src/inc/agent/PQuery.php
@@ -13,5 +13,5 @@ abstract class PQuery { // include only generalized query values
    * @param $QUERY array the given query
    * @return bool true on valid, false if not
    */
-  abstract static function isValid($QUERY);
+  abstract static function isValid(array $QUERY): bool;
 }

--- a/src/inc/agent/PQueryCheckClientVersion.php
+++ b/src/inc/agent/PQueryCheckClientVersion.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryCheckClientVersion extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::VERSION]) || !isset($QUERY[self::TYPE])) {
       return false;
     }

--- a/src/inc/agent/PQueryClientError.php
+++ b/src/inc/agent/PQueryClientError.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryClientError extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::TASK_ID]) || !isset($QUERY[self::MESSAGE])) {
       return false;
     }

--- a/src/inc/agent/PQueryDeRegister.php
+++ b/src/inc/agent/PQueryDeRegister.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryDeRegister extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN])) {
       return false;
     }

--- a/src/inc/agent/PQueryDownloadBinary.php
+++ b/src/inc/agent/PQueryDownloadBinary.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryDownloadBinary extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::BINARY_TYPE])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetChunk.php
+++ b/src/inc/agent/PQueryGetChunk.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetChunk extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::TASK_ID])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetFile.php
+++ b/src/inc/agent/PQueryGetFile.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetFile extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::TASK_ID]) || !isset($QUERY[self::FILENAME])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetFileStatus.php
+++ b/src/inc/agent/PQueryGetFileStatus.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetFileStatus extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetFound.php
+++ b/src/inc/agent/PQueryGetFound.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetFound extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::HASHLIST_ID])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetHashlist.php
+++ b/src/inc/agent/PQueryGetHashlist.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetHashlist extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::HASHLIST_ID])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetHealthCheck.php
+++ b/src/inc/agent/PQueryGetHealthCheck.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetHealthCheck extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN])) {
       return false;
     }

--- a/src/inc/agent/PQueryGetTask.php
+++ b/src/inc/agent/PQueryGetTask.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryGetTask extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN])) {
       return false;
     }

--- a/src/inc/agent/PQueryLogin.php
+++ b/src/inc/agent/PQueryLogin.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryLogin extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::CLIENT_SIGNATURE])) {
       return false;
     }

--- a/src/inc/agent/PQueryRegister.php
+++ b/src/inc/agent/PQueryRegister.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryRegister extends PQuery {
-  public static function isValid($QUERY) {
+  public static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::VOUCHER]) || !isset($QUERY[self::AGENT_NAME])) {
       return false;
     }

--- a/src/inc/agent/PQuerySendBenchmark.php
+++ b/src/inc/agent/PQuerySendBenchmark.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQuerySendBenchmark extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::TASK_ID]) || !isset($QUERY[self::TYPE]) || !isset($QUERY[self::RESULT])) {
       return false;
     }

--- a/src/inc/agent/PQuerySendHealthCheck.php
+++ b/src/inc/agent/PQuerySendHealthCheck.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQuerySendHealthCheck extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::CHECK_ID]) || !isset($QUERY[self::NUM_CRACKED]) || !isset($QUERY[self::START]) || !isset($QUERY[self::END]) || !isset($QUERY[self::NUM_GPUS]) || !isset($QUERY[self::ERRORS])) {
       return false;
     }

--- a/src/inc/agent/PQuerySendKeyspace.php
+++ b/src/inc/agent/PQuerySendKeyspace.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQuerySendKeyspace extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::KEYSPACE]) || !isset($QUERY[self::TASK_ID])) {
       return false;
     }

--- a/src/inc/agent/PQuerySendProgress.php
+++ b/src/inc/agent/PQuerySendProgress.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQuerySendProgress extends PQuery {
-  static function isValid($QUERY) {
+  static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::CHUNK_ID]) || !isset($QUERY[self::KEYSPACE_PROGRESS]) || !isset($QUERY[self::KEYSPACE_PROGRESS]) || !isset($QUERY[self::RELATIVE_PROGRESS]) || !isset($QUERY[self::SPEED]) || !isset($QUERY[self::HASHCAT_STATE]) || !isset($QUERY[self::CRACKED_HASHES])) {
       return false;
     }

--- a/src/inc/agent/PQueryUpdateInformation.php
+++ b/src/inc/agent/PQueryUpdateInformation.php
@@ -3,7 +3,7 @@
 namespace Hashtopolis\inc\agent;
 
 class PQueryUpdateInformation extends PQuery {
-  public static function isValid($QUERY) {
+  public static function isValid(array $QUERY): bool {
     if (!isset($QUERY[self::TOKEN]) || !isset($QUERY[self::DEVICES]) || !isset($QUERY[self::UID]) || !isset($QUERY[self::OPERATING_SYSTEM])) {
       return false;
     }

--- a/src/inc/api/APIBasic.php
+++ b/src/inc/api/APIBasic.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\api;
 
 use Exception;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseErrorMessage;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DServerLog;
@@ -37,14 +38,17 @@ abstract class APIBasic {
   
   public function sendErrorResponse($action, $msg): void {
     $ANS = array();
-    $ANS[PResponseErrorMessage::ACTION] = $action;
-    $ANS[PResponseErrorMessage::RESPONSE] = PValues::ERROR;
+    $ANS[PResponse::ACTION] = $action;
+    $ANS[PResponse::RESPONSE] = PValues::ERROR;
     $ANS[PResponseErrorMessage::MESSAGE] = $msg;
     header("Content-Type: application/json");
     echo json_encode($ANS);
     die();
   }
   
+  /**
+   * @throws Exception
+   */
   public function checkToken($action, $QUERY): void {
     $qF = new QueryFilter(Agent::TOKEN, $QUERY[PQuery::TOKEN], "=");
     $agent = Factory::getAgentFactory()->filter([Factory::FILTER => array($qF)], true);

--- a/src/inc/api/APICheckClientVersion.php
+++ b/src/inc/api/APICheckClientVersion.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryCheckClientVersion;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseClientUpdate;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\agent\PValuesUpdateVersion;
@@ -17,7 +19,10 @@ use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\Util;
 
 class APICheckClientVersion extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     // check if provided hash is the same as script and send file contents if not
     if (!PQueryCheckClientVersion::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::CHECK_CLIENT_VERSION, 'Invalid version check query!');
@@ -38,8 +43,8 @@ class APICheckClientVersion extends APIBasic {
     if (Comparator::greaterThan($result->getVersion(), $version)) {
       DServerLog::log(DServerLog::DEBUG, "Agent " . $this->agent->getId() . " got notified about client update");
       $this->sendResponse(array(
-          PResponseClientUpdate::ACTION => PActions::CHECK_CLIENT_VERSION,
-          PResponseClientUpdate::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::CHECK_CLIENT_VERSION,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseClientUpdate::VERSION => PValuesUpdateVersion::NEW_VERSION,
           PResponseClientUpdate::URL => Util::buildServerUrl() . SConfig::getInstance()->getVal(DConfig::BASE_URL) . "/agents.php?download=" . $result->getId()
         )
@@ -47,8 +52,8 @@ class APICheckClientVersion extends APIBasic {
     }
     else {
       $this->sendResponse(array(
-          PResponseClientUpdate::ACTION => PActions::CHECK_CLIENT_VERSION,
-          PResponseClientUpdate::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::CHECK_CLIENT_VERSION,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseClientUpdate::VERSION => PValuesUpdateVersion::UP_TO_DATE
         )
       );

--- a/src/inc/api/APIClientError.php
+++ b/src/inc/api/APIClientError.php
@@ -2,9 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryClientError;
-use Hashtopolis\inc\agent\PResponseError;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\inc\defines\DAgentIgnoreErrors;
@@ -21,7 +22,10 @@ use Hashtopolis\inc\handlers\NotificationHandler;
 use Hashtopolis\inc\SConfig;
 
 class APIClientError extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     //check required values
     if (!PQueryClientError::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::CLIENT_ERROR, "Invalid error query!");
@@ -48,11 +52,11 @@ class APIClientError extends APIBasic {
     $whitelist = explode(",", SConfig::getInstance()->getVal(DConfig::HC_ERROR_IGNORE));
     foreach ($whitelist as $w) {
       $w = trim($w);
-      if (strpos($QUERY[PQueryClientError::MESSAGE], $w) !== false) {
+      if (str_contains($QUERY[PQueryClientError::MESSAGE], $w)) {
         // error can be ignored, we just acknowledge that we received it
         $this->sendResponse(array(
-            PQueryClientError::ACTION => PActions::CLIENT_ERROR,
-            PResponseError::RESPONSE => PValues::SUCCESS
+            PResponse::ACTION => PActions::CLIENT_ERROR,
+            PResponse::RESPONSE => PValues::SUCCESS
           )
         );
       }
@@ -79,8 +83,8 @@ class APIClientError extends APIBasic {
     
     $this->updateAgent(PActions::CLIENT_ERROR);
     $this->sendResponse(array(
-        PQueryClientError::ACTION => PActions::CLIENT_ERROR,
-        PResponseError::RESPONSE => PValues::SUCCESS
+        PResponse::ACTION => PActions::CLIENT_ERROR,
+        PResponse::RESPONSE => PValues::SUCCESS
       )
     );
   }

--- a/src/inc/api/APIDeRegisterAgent.php
+++ b/src/inc/api/APIDeRegisterAgent.php
@@ -2,9 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryDeRegister;
-use Hashtopolis\inc\agent\PResponseDeRegister;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\utils\AgentUtils;
@@ -12,7 +13,10 @@ use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\SConfig;
 
 class APIDeRegisterAgent extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     //check required values
     if (!PQueryDeRegister::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::DEREGISTER, "Invalid de-registering query!");
@@ -29,8 +33,8 @@ class APIDeRegisterAgent extends APIBasic {
       $this->sendErrorResponse(PActions::DEREGISTER, "Error occured during de-registration: " . $e->getMessage());
     }
     $this->sendResponse(array(
-        PQueryDeRegister::ACTION => PActions::DEREGISTER,
-        PResponseDeRegister::RESPONSE => PValues::SUCCESS
+        PResponse::ACTION => PActions::DEREGISTER,
+        PResponse::RESPONSE => PValues::SUCCESS
       )
     );
   }

--- a/src/inc/api/APIDownloadBinary.php
+++ b/src/inc/api/APIDownloadBinary.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryDownloadBinary;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseBinaryDownload;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\agent\PValuesDownloadBinaryType;
@@ -14,7 +16,10 @@ use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\Util;
 
 class APIDownloadBinary extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQueryDownloadBinary::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::DOWNLOAD_BINARY, "Invalid download query!");
     }
@@ -29,8 +34,8 @@ class APIDownloadBinary extends APIBasic {
         $filename = "7zr" . Util::getFileExtension($this->agent->getOs());
         $path = Util::buildServerUrl() . SConfig::getInstance()->getVal(DConfig::BASE_URL) . "/static/" . $filename;
         $this->sendResponse(array(
-            PResponseBinaryDownload::ACTION => PActions::DOWNLOAD_BINARY,
-            PResponseBinaryDownload::RESPONSE => PValues::SUCCESS,
+            PResponse::ACTION => PActions::DOWNLOAD_BINARY,
+            PResponse::RESPONSE => PValues::SUCCESS,
             PResponseBinaryDownload::EXECUTABLE => $path
           )
         );
@@ -40,8 +45,8 @@ class APIDownloadBinary extends APIBasic {
         $filename = "uftpd" . Util::getFileExtension($this->agent->getOs());
         $path = Util::buildServerUrl() . SConfig::getInstance()->getVal(DConfig::BASE_URL) . "/static/" . $filename;
         $this->sendResponse(array(
-            PResponseBinaryDownload::ACTION => PActions::DOWNLOAD_BINARY,
-            PResponseBinaryDownload::RESPONSE => PValues::SUCCESS,
+            PResponse::ACTION => PActions::DOWNLOAD_BINARY,
+            PResponse::RESPONSE => PValues::SUCCESS,
             PResponseBinaryDownload::EXECUTABLE => $path
           )
         );

--- a/src/inc/api/APIDownloadBinary.php
+++ b/src/inc/api/APIDownloadBinary.php
@@ -39,7 +39,6 @@ class APIDownloadBinary extends APIBasic {
             PResponseBinaryDownload::EXECUTABLE => $path
           )
         );
-        break;
       case PValuesDownloadBinaryType::UFTPD:
         DServerLog::log(DServerLog::TRACE, "Agent " . $this->agent->getId() . " downloaded uftpd binary");
         $filename = "uftpd" . Util::getFileExtension($this->agent->getOs());
@@ -50,7 +49,6 @@ class APIDownloadBinary extends APIBasic {
             PResponseBinaryDownload::EXECUTABLE => $path
           )
         );
-        break;
       case PValuesDownloadBinaryType::CRACKER:
         $crackerBinary = Factory::getCrackerBinaryFactory()->get($QUERY[PQueryDownloadBinary::BINARY_VERSION_ID]);
         if ($crackerBinary == null) {
@@ -61,14 +59,13 @@ class APIDownloadBinary extends APIBasic {
         
         $ext = Util::getFileExtension($this->agent->getOs());
         $this->sendResponse(array(
-            PResponseBinaryDownload::ACTION => PActions::DOWNLOAD_BINARY,
-            PResponseBinaryDownload::RESPONSE => PValues::SUCCESS,
+            PResponse::ACTION => PActions::DOWNLOAD_BINARY,
+            PResponse::RESPONSE => PValues::SUCCESS,
             PResponseBinaryDownload::URL => $crackerBinary->getDownloadUrl(),
             PResponseBinaryDownload::NAME => $crackerBinaryType->getTypeName(),
             PResponseBinaryDownload::EXECUTABLE => $crackerBinary->getBinaryName() . $ext
           )
         );
-        break;
       case PValuesDownloadBinaryType::PRINCE:
       case PValuesDownloadBinaryType::PREPROCESSOR:
         $preprocessor = Factory::getPreprocessorFactory()->get($QUERY[PQueryDownloadBinary::PREPROCESSOR_ID]);
@@ -79,8 +76,8 @@ class APIDownloadBinary extends APIBasic {
         
         $ext = Util::getFileExtension($this->agent->getOs());
         $this->sendResponse(array(
-            PResponseBinaryDownload::ACTION => PActions::DOWNLOAD_BINARY,
-            PResponseBinaryDownload::RESPONSE => PValues::SUCCESS,
+            PResponse::ACTION => PActions::DOWNLOAD_BINARY,
+            PResponse::RESPONSE => PValues::SUCCESS,
             PResponseBinaryDownload::URL => $preprocessor->getUrl(),
             PResponseBinaryDownload::NAME => $preprocessor->getName(),
             PResponseBinaryDownload::EXECUTABLE => $preprocessor->getBinaryName() . $ext,
@@ -89,7 +86,6 @@ class APIDownloadBinary extends APIBasic {
             PResponseBinaryDownload::LIMIT_CMD => $preprocessor->getLimitCommand()
           )
         );
-        break;
       default:
         DServerLog::log(DServerLog::WARNING, "Agent " . $this->agent->getId() . " requested invalid binary download: " . $QUERY[PQueryDownloadBinary::BINARY_TYPE]);
         $this->sendErrorResponse(PActions::DOWNLOAD_BINARY, "Unknown download type!");

--- a/src/inc/api/APIGetChunk.php
+++ b/src/inc/api/APIGetChunk.php
@@ -4,6 +4,7 @@ namespace Hashtopolis\inc\api;
 
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryGetChunk;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetChunk;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\agent\PValuesChunkType;
@@ -32,7 +33,7 @@ class APIGetChunk extends APIBasic {
    * @throws HTException
    * @throws Exception
    */
-  public function execute(array $QUERY = array()) {
+  public function execute(array $QUERY = array()): void {
     if (!PQueryGetChunk::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::GET_CHUNK, "Invalid chunk query!");
     }
@@ -44,8 +45,8 @@ class APIGetChunk extends APIBasic {
     if (HealthUtils::checkNeeded($this->agent)) {
       DServerLog::log(DServerLog::DEBUG, "Notifying agent about health check", [$this->agent]);
       $this->sendResponse(array(
-          PResponseGetChunk::ACTION => PActions::GET_CHUNK,
-          PResponseGetChunk::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_CHUNK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetChunk::CHUNK_STATUS => PValuesChunkType::HEALTH_CHECK
         )
       );
@@ -67,8 +68,8 @@ class APIGetChunk extends APIBasic {
     else if ($task->getKeyspace() == 0) {
       DServerLog::log(DServerLog::TRACE, "Need to measure keyspace!", [$this->agent, $task]);
       $this->sendResponse(array(
-          PResponseGetChunk::ACTION => PActions::GET_CHUNK,
-          PResponseGetChunk::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_CHUNK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetChunk::CHUNK_STATUS => PValuesChunkType::KEYSPACE_REQUIRED
         )
       );
@@ -76,8 +77,8 @@ class APIGetChunk extends APIBasic {
     else if ($assignment->getBenchmark() == 0 && $task->getIsSmall() == 0 && $task->getStaticChunks() == DTaskStaticChunking::NORMAL) { // benchmark only required on non-small tasks and on non-special chunk tasks
       DServerLog::log(DServerLog::TRACE, "Need to run a benchmark!", [$this->agent, $task]);
       $this->sendResponse(array(
-          PResponseGetChunk::ACTION => PActions::GET_CHUNK,
-          PResponseGetChunk::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_CHUNK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetChunk::CHUNK_STATUS => PValuesChunkType::BENCHMARK_REQUIRED
         )
       );
@@ -101,8 +102,8 @@ class APIGetChunk extends APIBasic {
       LockUtils::release($LOCKFILE);
       DServerLog::log(DServerLog::TRACE, "Released lock for chunking!", [$this->agent]);
       $this->sendResponse(array(
-          PResponseGetChunk::ACTION => PActions::GET_CHUNK,
-          PResponseGetChunk::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_CHUNK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetChunk::CHUNK_STATUS => PValuesChunkType::FULLY_DISPATCHED
         )
       );
@@ -175,8 +176,8 @@ class APIGetChunk extends APIBasic {
       LockUtils::release($LOCKFILE);
       DServerLog::log(DServerLog::TRACE, "Released lock for chunking!", [$this->agent]);
       $this->sendResponse(array(
-          PResponseGetChunk::ACTION => PActions::GET_CHUNK,
-          PResponseGetChunk::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_CHUNK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetChunk::CHUNK_STATUS => PValuesChunkType::FULLY_DISPATCHED
         )
       );
@@ -186,9 +187,10 @@ class APIGetChunk extends APIBasic {
   }
   
   /**
-   * @param $chunk Chunk
+   * @param ?Chunk $chunk
+   * @throws Exception
    */
-  protected function sendChunk($chunk) {
+  protected function sendChunk(?Chunk $chunk): void {
     if ($chunk == null) {
       return; // this can be safely done before the commit/release, because the only sendChunk which comes really at the end check for null before, so a lock which is not released cannot happen
     }
@@ -196,8 +198,8 @@ class APIGetChunk extends APIBasic {
     LockUtils::release(Lock::CHUNKING . $chunk->getTaskId());
     DServerLog::log(DServerLog::TRACE, "Released lock for chunking!", [$this->agent]);
     $this->sendResponse(array(
-        PResponseGetChunk::ACTION => PActions::GET_CHUNK,
-        PResponseGetChunk::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::GET_CHUNK,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetChunk::CHUNK_STATUS => PValuesChunkType::OK,
         PResponseGetChunk::CHUNK_ID => (int)($chunk->getId()),
         PResponseGetChunk::KEYSPACE_SKIP => (int)($chunk->getSkip()),

--- a/src/inc/api/APIGetFile.php
+++ b/src/inc/api/APIGetFile.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryGetFile;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetFile;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DServerLog;
@@ -14,7 +16,10 @@ use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\Factory;
 
 class APIGetFile extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     //check required values
     if (!PQueryGetFile::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::GET_FILE, "Invalid file query!");
@@ -60,10 +65,10 @@ class APIGetFile extends APIBasic {
     $this->updateAgent(PActions::GET_FILE);
     
     $this->sendResponse(array(
-        PQueryGetFile::ACTION => PActions::GET_FILE,
+        PResponse::ACTION => PActions::GET_FILE,
         PResponseGetFile::FILENAME => $filename,
         PResponseGetFile::EXTENSION => $extension,
-        PResponseGetFile::RESPONSE => PValues::SUCCESS,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetFile::URL => "getFile.php?file=" . $file->getId() . "&token=" . $this->agent->getToken(),
         PResponseGetFile::FILESIZE => (int)$file->getSize()
       )

--- a/src/inc/api/APIGetFileStatus.php
+++ b/src/inc/api/APIGetFileStatus.php
@@ -2,13 +2,18 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\agent\PActions;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetFileStatus;
 use Hashtopolis\inc\agent\PValues;
 
 class APIGetFileStatus extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     $deleteRequests = Factory::getFileDeleteFactory()->filter([]);
     $files = [];
     foreach ($deleteRequests as $deleteRequest) {
@@ -16,8 +21,8 @@ class APIGetFileStatus extends APIBasic {
     }
     
     $this->sendResponse(array(
-        PResponseGetFileStatus::ACTION => PActions::GET_FILE_STATUS,
-        PResponseGetFileStatus::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::GET_FILE_STATUS,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetFileStatus::FILENAMES => $files
       )
     );

--- a/src/inc/api/APIGetFound.php
+++ b/src/inc/api/APIGetFound.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryGetFound;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetFound;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DServerLog;
@@ -13,7 +15,10 @@ use Hashtopolis\dba\models\Assignment;
 use Hashtopolis\inc\Util;
 
 class APIGetFound extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     //check required values
     if (!PQueryGetFound::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::GET_FOUND, "Invalid found query!");
@@ -66,8 +71,8 @@ class APIGetFound extends APIBasic {
       $this->sendErrorResponse(PActions::GET_FOUND, "No hashlists selected/available!");
     }
     $this->sendResponse(array(
-        PResponseGetFound::ACTION => PActions::GET_FOUND,
-        PResponseGetFound::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::GET_FOUND,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetFound::URL => "getFound.php?hashlists=" . implode(",", Util::arrayOfIds($hashlists)) . "&token=" . $this->agent->getToken()
       )
     );

--- a/src/inc/api/APIGetHashlist.php
+++ b/src/inc/api/APIGetHashlist.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryGetHashlist;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetHashlist;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DServerLog;
@@ -13,7 +15,10 @@ use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\Util;
 
 class APIGetHashlist extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     //check required values
     if (!PQueryGetHashlist::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::GET_HASHLIST, "Invalid hashlist query!");
@@ -66,8 +71,8 @@ class APIGetHashlist extends APIBasic {
       $this->sendErrorResponse(PActions::GET_HASHLIST, "No hashlists selected/available!");
     }
     $this->sendResponse(array(
-        PResponseGetHashlist::ACTION => PActions::GET_HASHLIST,
-        PResponseGetHashlist::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::GET_HASHLIST,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetHashlist::URL => "getHashlist.php?hashlists=" . implode(",", Util::arrayOfIds($hashlists)) . "&token=" . $this->agent->getToken()
       )
     );

--- a/src/inc/api/APIGetHealthCheck.php
+++ b/src/inc/api/APIGetHealthCheck.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryGetHealthCheck;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetHealthCheck;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DConfig;
@@ -13,7 +15,10 @@ use Hashtopolis\inc\utils\HealthUtils;
 use Hashtopolis\inc\SConfig;
 
 class APIGetHealthCheck extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQueryGetHealthCheck::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::GET_HEALTH_CHECK, "Invalid get health check query!");
     }
@@ -33,8 +38,8 @@ class APIGetHealthCheck extends APIBasic {
     $hashes = explode("\n", $hashes);
     
     $this->sendResponse([
-        PResponseGetHealthCheck::ACTION => PActions::GET_HEALTH_CHECK,
-        PResponseGetHealthCheck::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::GET_HEALTH_CHECK,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetHealthCheck::ATTACK => " --hash-type=" . $healthCheck->getHashtypeId() . " " . $healthCheck->getAttackCmd() . " " . $this->agent->getCmdPars(),
         PResponseGetHealthCheck::CRACKER_BINARY_ID => (int)$healthCheck->getCrackerBinaryId(),
         PResponseGetHealthCheck::HASHES => $hashes,

--- a/src/inc/api/APIGetTask.php
+++ b/src/inc/api/APIGetTask.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryGetTask;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseGetTask;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\agent\PValuesTask;
@@ -21,7 +23,10 @@ use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\utils\TaskUtils;
 
 class APIGetTask extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQueryGetTask::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::GET_TASK, "Invalid task query!");
     }
@@ -33,8 +38,8 @@ class APIGetTask extends APIBasic {
     if (HealthUtils::checkNeeded($this->agent)) {
       DServerLog::log(DServerLog::INFO, "Notified about pending health check", [$this->agent]);
       $this->sendResponse(array(
-          PResponseGetTask::ACTION => PActions::GET_TASK,
-          PResponseGetTask::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_TASK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetTask::TASK_ID => PValuesTask::HEALTH_CHECK
         )
       );
@@ -43,8 +48,8 @@ class APIGetTask extends APIBasic {
     if ($this->agent->getIsActive() == 0) {
       DServerLog::log(DServerLog::TRACE, "Agent is inactive and cannot get a task", [$this->agent]);
       $this->sendResponse(array(
-          PResponseGetTask::ACTION => PActions::GET_TASK,
-          PResponseGetTask::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::GET_TASK,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseGetTask::TASK_ID => PValues::NONE,
           PResponseGetTask::REASON => "Agent is inactive!"
         )
@@ -111,10 +116,10 @@ class APIGetTask extends APIBasic {
     }
   }
   
-  private function noTask() {
+  private function noTask(): void {
     $this->sendResponse(array(
-        PResponseGetTask::ACTION => PActions::GET_TASK,
-        PResponseGetTask::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::GET_TASK,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseGetTask::TASK_ID => PValues::NONE,
         PResponseGetTask::REASON => "No suitable task available!"
       )
@@ -123,9 +128,10 @@ class APIGetTask extends APIBasic {
   
   /**
    * @param $task Task
-   * @param $assignment Assignment
+   * @param $assignment ?Assignment
+   * @throws Exception
    */
-  private function sendTask($task, $assignment) {
+  private function sendTask(Task $task, ?Assignment $assignment): void {
     // check if the assignment is up-to-date and correct if needed
     if ($assignment == null) {
       $assignment = new Assignment(null, $task->getId(), $this->agent->getId(), 0);
@@ -168,11 +174,11 @@ class APIGetTask extends APIBasic {
     
     DServerLog::log(DServerLog::TRACE, "Sending task to agent", [$this->agent, $task, $taskFiles]);
     
-    $brain = ($hashlist->getBrainId() && !$task->getForcePipe() && !$task->getUsePreprocessor()) ? true : false;
+    $brain = $hashlist->getBrainId() && !$task->getForcePipe() && !$task->getUsePreprocessor();
     
     $response = array(
-      PResponseGetTask::ACTION => PActions::GET_TASK,
-      PResponseGetTask::RESPONSE => PValues::SUCCESS,
+      PResponse::ACTION => PActions::GET_TASK,
+      PResponse::RESPONSE => PValues::SUCCESS,
       PResponseGetTask::TASK_ID => (int)$task->getId(),
       PResponseGetTask::ATTACK_COMMAND => $task->getAttackCmd(),
       PResponseGetTask::CMD_PARAMETERS => " --hash-type=" . $hashlist->getHashTypeId() . " " . $this->agent->getCmdPars(),
@@ -184,11 +190,11 @@ class APIGetTask extends APIBasic {
       PResponseGetTask::BENCHTYPE => ($task->getUseNewBench() == 1) ? "speed" : "run",
       PResponseGetTask::HASHLIST_ALIAS => SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS),
       PResponseGetTask::KEYSPACE => $task->getKeyspace(),
-      PResponseGetTask::USE_PREPROCESSOR => ($task->getUsePreprocessor()) ? true : false,
+      PResponseGetTask::USE_PREPROCESSOR => (bool)$task->getUsePreprocessor(),
       PResponseGetTask::PREPROCESSOR => $task->getUsePreprocessor(),
       PResponseGetTask::PREPROCESSOR_COMMAND => $task->getPreprocessorCommand(),
-      PResponseGetTask::ENFORCE_PIPE => ($task->getForcePipe()) ? true : false,
-      PResponseGetTask::SLOW_HASH => ($hashtype->getIsSlowHash()) ? true : false,
+      PResponseGetTask::ENFORCE_PIPE => (bool)$task->getForcePipe(),
+      PResponseGetTask::SLOW_HASH => (bool)$hashtype->getIsSlowHash(),
       PResponseGetTask::USE_BRAIN => $brain,
     );
     

--- a/src/inc/api/APILogin.php
+++ b/src/inc/api/APILogin.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryLogin;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseLogin;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DConfig;
@@ -15,7 +17,10 @@ use Hashtopolis\inc\StartupConfig;
 use Hashtopolis\inc\Util;
 
 class APILogin extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQueryLogin::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::LOGIN, "Invalid login query!");
     }
@@ -26,9 +31,9 @@ class APILogin extends APIBasic {
     DServerLog::log(DServerLog::DEBUG, "Agent logged in", [$this->agent]);
     
     $this->sendResponse(array(
-        PResponseLogin::ACTION => PActions::LOGIN,
-        PResponseLogin::RESPONSE => PValues::SUCCESS,
-        PResponseLogin::MULTICAST => (SConfig::getInstance()->getVal(DConfig::MULTICAST_ENABLE)) ? true : false,
+        PResponse::ACTION => PActions::LOGIN,
+        PResponse::RESPONSE => PValues::SUCCESS,
+        PResponseLogin::MULTICAST => (bool)SConfig::getInstance()->getVal(DConfig::MULTICAST_ENABLE),
         PResponseLogin::TIMEOUT => (int)SConfig::getInstance()->getVal(DConfig::AGENT_TIMEOUT),
         PResponseLogin::VERSION => StartupConfig::getInstance()->getVersion() . " (" . Util::getGitCommit() . ")"
       )

--- a/src/inc/api/APIRegisterAgent.php
+++ b/src/inc/api/APIRegisterAgent.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryRegister;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseRegister;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DConfig;
@@ -22,7 +24,10 @@ use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\Util;
 
 class APIRegisterAgent extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     //check required values
     if (!PQueryRegister::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::REGISTER, "Invalid registering query!");
@@ -37,7 +42,7 @@ class APIRegisterAgent extends APIBasic {
     $name = htmlentities($QUERY[PQueryRegister::AGENT_NAME], ENT_QUOTES, "UTF-8");
     
     $cpuOnly = 0;
-    if (isset($QUERY[PQueryRegister::CPU_ONLY]) && $QUERY[PQueryRegister::CPU_ONLY] == true) {
+    if (isset($QUERY[PQueryRegister::CPU_ONLY]) && $QUERY[PQueryRegister::CPU_ONLY]) {
       $cpuOnly = 1;
     }
     
@@ -61,8 +66,8 @@ class APIRegisterAgent extends APIBasic {
       DServerLog::log(DServerLog::INFO, "Assigned agent to access group", [$agent, $accessGroup]);
       
       $this->sendResponse(array(
-          PQueryRegister::ACTION => PActions::REGISTER,
-          PResponseRegister::RESPONSE => PValues::SUCCESS,
+          PResponse::ACTION => PActions::REGISTER,
+          PResponse::RESPONSE => PValues::SUCCESS,
           PResponseRegister::TOKEN => $token
         )
       );

--- a/src/inc/api/APISendBenchmark.php
+++ b/src/inc/api/APISendBenchmark.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQuerySendBenchmark;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseSendBenchmark;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\agent\PValuesBenchmarkType;
@@ -16,7 +18,10 @@ use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\SConfig;
 
 class APISendBenchmark extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQuerySendBenchmark::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::SEND_BENCHMARK, "Invalid benchmark query!");
     }
@@ -68,8 +73,8 @@ class APISendBenchmark extends APIBasic {
     Factory::getAssignmentFactory()->update($assignment);
     DServerLog::log(DServerLog::DEBUG, "Saved agent benchmark", [$this->agent, $task, $assignment]);
     $this->sendResponse(array(
-        PResponseSendBenchmark::ACTION => PActions::SEND_BENCHMARK,
-        PResponseSendBenchmark::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::SEND_BENCHMARK,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseSendBenchmark::BENCHMARK => PValues::OK
       )
     );

--- a/src/inc/api/APISendHealthCheck.php
+++ b/src/inc/api/APISendHealthCheck.php
@@ -6,7 +6,6 @@ use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQuerySendHealthCheck;
 use Hashtopolis\inc\agent\PResponse;
-use Hashtopolis\inc\agent\PResponseSendHealthCheck;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DAgentIgnoreErrors;
 use Hashtopolis\inc\defines\DHealthCheckAgentStatus;

--- a/src/inc/api/APISendHealthCheck.php
+++ b/src/inc/api/APISendHealthCheck.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQuerySendHealthCheck;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseSendHealthCheck;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DAgentIgnoreErrors;
@@ -15,7 +17,10 @@ use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\inc\utils\HealthUtils;
 
 class APISendHealthCheck extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQuerySendHealthCheck::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::SEND_HEALTH_CHECK, "Invalid send health check query!");
     }
@@ -65,8 +70,8 @@ class APISendHealthCheck extends APIBasic {
     
     HealthUtils::checkCompletion($healthCheck);
     $this->sendResponse([
-        PResponseSendHealthCheck::ACTION => PActions::SEND_HEALTH_CHECK,
-        PResponseSendHealthCheck::RESPONSE => PValues::OK
+        PResponse::ACTION => PActions::SEND_HEALTH_CHECK,
+        PResponse::RESPONSE => PValues::OK
       ]
     );
   }

--- a/src/inc/api/APISendKeyspace.php
+++ b/src/inc/api/APISendKeyspace.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQuerySendKeyspace;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseSendKeyspace;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\defines\DLogEntry;
@@ -17,7 +19,10 @@ use Hashtopolis\dba\models\Task;
 use Hashtopolis\inc\Util;
 
 class APISendKeyspace extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQuerySendKeyspace::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::SEND_KEYSPACE, "Invalid keyspace query!");
     }
@@ -68,8 +73,8 @@ class APISendKeyspace extends APIBasic {
     }
     
     $this->sendResponse(array(
-        PResponseSendKeyspace::ACTION => PActions::SEND_KEYSPACE,
-        PResponseSendKeyspace::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::SEND_KEYSPACE,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseSendKeyspace::KEYSPACE => PValues::OK
       )
     );

--- a/src/inc/api/APISendProgress.php
+++ b/src/inc/api/APISendProgress.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQuerySendProgress;
+use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PResponseSendProgress;
 use Hashtopolis\inc\agent\PValues;
 use Hashtopolis\inc\DataSet;
@@ -44,7 +46,10 @@ use Hashtopolis\inc\utils\TaskUtils;
 use Hashtopolis\inc\Util;
 
 class APISendProgress extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     if (!PQuerySendProgress::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::SEND_PROGRESS, "Invalid progress query!");
     }
@@ -100,9 +105,9 @@ class APISendProgress extends APIBasic {
       $isSuperhashlist = true;
     }
     $hashlists = Util::checkSuperHashlist($hashlist);
-    foreach ($hashlists as $hashlist) {
-      if ($hashlist->getIsSecret() > $this->agent->getIsTrusted()) {
-        DServerLog::log(DServerLog::TRACE, "For some reason agent was working on a hashlist he is not allowed to (probabily permission change)", [$this->agent, $task, $hashlist]);
+    foreach ($hashlists as $hl) {
+      if ($hl->getIsSecret() > $this->agent->getIsTrusted()) {
+        DServerLog::log(DServerLog::TRACE, "For some reason agent was working on a hashlist he is not allowed to (probabily permission change)", [$this->agent, $task, $hl]);
         $this->sendErrorResponse(PActions::SEND_PROGRESS, "Unknown Error. The API does not trust you with more information");
       }
     }
@@ -197,8 +202,8 @@ class APISendProgress extends APIBasic {
     // reset values
     $skipped = 0;
     $cracked = array();
-    foreach ($hashlists as $hashlist) {
-      $cracked[$hashlist->getId()] = 0;
+    foreach ($hashlists as $hl) {
+      $cracked[$hl->getId()] = 0;
     }
     
     // process solved hashes, should there be any
@@ -212,8 +217,8 @@ class APISendProgress extends APIBasic {
     $zaps = [];
     
     $isNewWPA = false;
-    foreach ($hashlists as $hashlist) {
-      if ($hashlist->getHashTypeId() == 22000) {
+    foreach ($hashlists as $hl) {
+      if ($hl->getHashTypeId() == 22000) {
         $isNewWPA = true;
         break;
       }
@@ -531,8 +536,8 @@ class APISendProgress extends APIBasic {
           
           //stop agent
           $this->sendResponse(array(
-              PResponseSendProgress::ACTION => PActions::SEND_PROGRESS,
-              PResponseSendProgress::RESPONSE => PValues::SUCCESS,
+              PResponse::ACTION => PActions::SEND_PROGRESS,
+              PResponse::RESPONSE => PValues::SUCCESS,
               PResponseSendProgress::NUM_CRACKED => $sumCracked,
               PResponseSendProgress::NUM_SKIPPED => $skipped,
               PResponseSendProgress::AGENT_COMMAND => "stop"
@@ -574,8 +579,8 @@ class APISendProgress extends APIBasic {
     }
     Util::cleaning();
     $this->sendResponse(array(
-        PResponseSendProgress::ACTION => PActions::SEND_PROGRESS,
-        PResponseSendProgress::RESPONSE => PValues::SUCCESS,
+        PResponse::ACTION => PActions::SEND_PROGRESS,
+        PResponse::RESPONSE => PValues::SUCCESS,
         PResponseSendProgress::NUM_CRACKED => $sumCracked,
         PResponseSendProgress::NUM_SKIPPED => $skipped,
         PResponseSendProgress::HASH_ZAPS => $toZap

--- a/src/inc/api/APITestConnection.php
+++ b/src/inc/api/APITestConnection.php
@@ -8,7 +8,7 @@ use Hashtopolis\inc\agent\PResponse;
 use Hashtopolis\inc\agent\PValues;
 
 class APITestConnection extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  public function execute(array $QUERY = array()): void {
     $this->sendResponse(array(
         PResponse::ACTION => PActions::TEST_CONNECTION,
         PResponse::RESPONSE => PValues::SUCCESS

--- a/src/inc/api/APIUpdateClientInformation.php
+++ b/src/inc/api/APIUpdateClientInformation.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\api;
 
+use Exception;
 use Hashtopolis\inc\agent\PActions;
 use Hashtopolis\inc\agent\PQueryUpdateInformation;
 use Hashtopolis\inc\agent\PResponse;
@@ -11,7 +12,10 @@ use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\Factory;
 
 class APIUpdateClientInformation extends APIBasic {
-  public function execute(array $QUERY = array()) {
+  /**
+   * @throws Exception
+   */
+  public function execute(array $QUERY = array()): void {
     // check required values and token
     if (!PQueryUpdateInformation::isValid($QUERY)) {
       $this->sendErrorResponse(PActions::UPDATE_CLIENT_INFORMATION, "Invalid update query!");
@@ -47,7 +51,7 @@ class APIUpdateClientInformation extends APIBasic {
     DServerLog::log(DServerLog::DEBUG, "Agent sent updated client information", [$this->agent]);
     
     $this->sendResponse(array(
-        PQueryUpdateInformation::ACTION => PActions::UPDATE_CLIENT_INFORMATION,
+        PResponse::ACTION => PActions::UPDATE_CLIENT_INFORMATION,
         PResponse::RESPONSE => PValues::SUCCESS
       )
     );

--- a/src/inc/apiv2/auth/HashtopolisAuthenticator.php
+++ b/src/inc/apiv2/auth/HashtopolisAuthenticator.php
@@ -5,6 +5,7 @@
 
 namespace Hashtopolis\inc\apiv2\auth;
 
+use Exception;
 use Hashtopolis\inc\defines\DLogEntry;
 use Hashtopolis\inc\defines\DLogEntryIssuer;
 use Hashtopolis\inc\Encryption;
@@ -16,6 +17,10 @@ use Tuupola\Middleware\HttpBasicAuthentication\AuthenticatorInterface;
 use Hashtopolis\inc\Util;
 
 class HashtopolisAuthenticator implements AuthenticatorInterface {
+  /**
+   * @throws HttpForbidden
+   * @throws Exception
+   */
   public function __invoke(array $arguments): bool {
     $username = $arguments["user"];
     $password = $arguments["password"];

--- a/src/inc/apiv2/auth/JWTBeforeHandler.php
+++ b/src/inc/apiv2/auth/JWTBeforeHandler.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\auth;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
@@ -12,6 +13,9 @@ use Psr\Http\Message\ServerRequestInterface;
 class JWTBeforeHandler implements BeforeHandlerInterface {
   /**
    * @param array{decoded: array<string, mixed>, token: string} $arguments
+   * @throws HttpError
+   * @throws HttpForbidden
+   * @throws Exception
    */
   public function __invoke(ServerRequestInterface $request, array $arguments): ServerRequestInterface {
     if (isset ($arguments["decoded"]["aud"]) && $arguments["decoded"]["aud"] == ApiTokenAPI::API_AUD) {

--- a/src/inc/apiv2/auth/token.routes.php
+++ b/src/inc/apiv2/auth/token.routes.php
@@ -7,6 +7,8 @@ use Hashtopolis\inc\StartupConfig;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
+use Random\RandomException;
+use Slim\App;
 use Slim\Routing\RouteCollectorProxy;
 
 use Hashtopolis\dba\QueryFilter;
@@ -20,7 +22,14 @@ use Hashtopolis\inc\apiv2\error\HttpForbidden;
 require_once(dirname(__FILE__) . "/../../startup/include.php");
 
 const USER_AUD = "user_hashtopolis";
-function generateTokenForUser(Request $request, string $userName, int $expires) {
+
+/**
+ * @throws HttpError
+ * @throws RandomException
+ * @throws HttpForbidden
+ * @throws Exception
+ */
+function generateTokenForUser(Request $request, string $userName, int $expires): string {
   $jti = bin2hex(random_bytes(16));
   
   $filter = new QueryFilter(User::USERNAME, $userName, "=");
@@ -71,10 +80,8 @@ function generateTokenForUser(Request $request, string $userName, int $expires) 
     "kid" =>  hash("sha256", $secret),
     "aud" => USER_AUD
   ];
-
-  $token = JWT::encode($payload, $secret, "HS256");
-
-  return $token;
+  
+  return JWT::encode($payload, $secret, "HS256");
 }
 
 function extractBearerToken(Request $request): ?string {
@@ -92,7 +99,7 @@ function extractBearerToken(Request $request): ?string {
 }
 
 // Exchanges an oauth token for a application JWT token
-/** @var \Slim\App $app */
+/** @var App $app */
 $app->group("/api/v2/auth/oauth-token", function (RouteCollectorProxy $group) {
 
   $group->post('', function (Request $request, Response $response, array $args): Response {

--- a/src/inc/apiv2/auth/token.routes.php
+++ b/src/inc/apiv2/auth/token.routes.php
@@ -167,8 +167,6 @@ $app->group("/api/v2/auth/refresh", function (RouteCollectorProxy $group) {
   });
   
   $group->post('', function (Request $request, Response $response, array $args): Response {
-    include(dirname(__FILE__) . '/../conf.php');
-    
     $now = new DateTime();
     $future = new DateTime("now +2 hours");
     

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\common;
 
+use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\AbstractModelFactory;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
@@ -69,6 +71,8 @@ use Hashtopolis\inc\utils\UserUtils;
 
 /**
  * This class acts as the BaseAPI implementation of API model endpoints
+ *
+ * @template TModel of AbstractModel
  */
 abstract class AbstractBaseAPI {
   abstract public static function getBaseUri(): string;
@@ -351,8 +355,9 @@ abstract class AbstractBaseAPI {
   /**
    * @param string $model
    * @param int $pk
-   * @return object
+   * @return TModel
    * @throws ResourceNotFoundError|HttpError
+   * @throws Exception
    */
   final protected static function fetchOne(string $model, int $pk): object {
     $factory = self::getModelFactory($model);
@@ -444,9 +449,6 @@ abstract class AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    */
   final protected function getObjectTypeName(mixed $obj): string {
-    
-    $container = $this->container->get('classMapper');
-    
     if (is_string($obj)) {
       $apiClass = $this->container->get('classMapper')->get($obj);
     }
@@ -1089,8 +1091,8 @@ abstract class AbstractBaseAPI {
   //TODO: nice to have would be to be able to include objects that are further away in the relationship
   //ex. from Hash include=hashlist.task to include all tasks from a hash (section 8.3 JSON API) 
   protected function makeExpandables(Request $request, array $validExpandables): array {
-    $data = $request->getParsedBody();
-    $queryExpands = (array_key_exists('include', $request->getQueryParams())) ? preg_split("/[,\ ]+/", $request->getQueryParams()['include']) : [];
+    $request->getParsedBody();
+    $queryExpands = (array_key_exists('include', $request->getQueryParams())) ? preg_split("/[, ]+/", $request->getQueryParams()['include']) : [];
     
     foreach ($queryExpands as $expand) {
       if (!in_array($expand, $validExpandables)) {
@@ -1113,19 +1115,14 @@ abstract class AbstractBaseAPI {
       }
       array_push($required_perms, ...$expandedPerms);
     }
-    $permissionResponse = $this->validatePermissions($request->getAttribute("scope"), $required_perms, $request->getMethod(), $request->getAttribute("aud"), $permsExpandMatching);
+    $this->validatePermissions($request->getAttribute("scope"), $required_perms, $request->getMethod(), $request->getAttribute("aud"), $permsExpandMatching);
     $expands_to_remove = [];
     
     // remove expands with missing permissions
     foreach ($this->missing_permissions as $missing_permission) {
       $expands_to_remove = array_merge($expands_to_remove, $permsExpandMatching[$missing_permission]);
     }
-    $queryExpands = array_diff($queryExpands, $expands_to_remove);
-    
-    // if ($permissionResponse === FALSE) {
-    //   throw new HttpError('Permissions missing on expand parameter objects! || ' . join('||', $this->permissionErrors));
-    // }
-    return $queryExpands;
+    return array_diff($queryExpands, $expands_to_remove);
   }
   
   /**
@@ -1147,7 +1144,7 @@ abstract class AbstractBaseAPI {
     return $this->getQueryParameterFamily($request, 'filter');
   }
   
-  protected static function checkJoinExists(array $joins, string $modelName) {
+  protected static function checkJoinExists(array $joins, string $modelName): bool {
     foreach ($joins as $join) {
       if ($join->getOtherFactory()->getModelName() === $modelName) {
         return true;
@@ -1187,7 +1184,7 @@ abstract class AbstractBaseAPI {
       
       if (!array_key_exists($cast_key, $features)) {
         throw new HttpForbidden("Filter parameter '" . $filter . "' is not valid (key not valid field)");
-      };
+      }
       
       // Only __in and __nin support comma-separated multiple values;
       // all other operators treat the value as a literal string.
@@ -1196,25 +1193,24 @@ abstract class AbstractBaseAPI {
       $valueList = $isListOperator ? explode(",", $value) : [$value];
       
       // TODO Merge/Combine with validate parameters 
-      foreach ($valueList as &$value) {
+      foreach ($valueList as &$element_value) {
         switch ($features[$cast_key]['type']) {
           case 'bool':
-            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-            if (is_null($value)) {
+            $element_value = filter_var($element_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if (is_null($element_value)) {
               throw new HttpForbidden("Filter parameter '" . $filter . "' is not valid boolean value");
             }
-            $value = (int)$value;
+            $element_value = (int)$element_value;
             break;
           case 'int':
-            $value = filter_var($value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
-            if (is_null($value)) {
+            $element_value = filter_var($element_value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+            if (is_null($element_value)) {
               throw new HttpForbidden("Filter parameter '" . $filter . "' is not valid integer value");
             }
-            $value = (int)$value;
+            $element_value = (int)$element_value;
             break;
         }
       }
-      unset($value);
       
       // We need to remap any aliased key to the key as it appears in the database.
       $remappedKey = $features[$cast_key]['dbname'];
@@ -1285,6 +1281,8 @@ abstract class AbstractBaseAPI {
   /**
    * Retrieves the relation from a sort/filter value. ex task.taskName when task is a relation for the current
    * Model endpoint. This works only for relations of 1 deep
+   * @throws HttpError
+   * @throws HttpForbidden
    */
   protected function retrieveRelationKey(string $value): object {
     $parts = explode(".", $value);
@@ -1330,7 +1328,7 @@ abstract class AbstractBaseAPI {
     $contains_primary_key = false;
     foreach ($orderings as $order) {
       $features_sort = $features;
-      if (preg_match('/^(?P<operator>[-])?(?P<key>[_a-zA-Z.]+)$/', $order, $matches)) {
+      if (preg_match('/^(?P<operator>-)?(?P<key>[_a-zA-Z.]+)$/', $order, $matches)) {
         // Special filtering of id to use for uniform access to model primary key
         $cast_key = $matches['key'] == 'id' ? $this->getPrimaryKey() : $matches['key'];
         if ($cast_key == $this->getPrimaryKey()) {
@@ -1451,7 +1449,7 @@ abstract class AbstractBaseAPI {
         if ($permission_set) {
           $user_available_perms = array_unique(array_merge($user_available_perms, self::$acl_mapping[$rightgroup_perm]));
         }
-      };
+      }
     }
     else {
       $user_available_perms = array_keys($rightgroup_perms, true, true);
@@ -1469,7 +1467,7 @@ abstract class AbstractBaseAPI {
       // attributes are stripped away.
       if ($method === "GET" && $this instanceof AbstractModelAPI) {
         $features = $this->getFeatures();
-        foreach ($features as $key => $arr) {
+        foreach ($features as $arr) {
           if ($arr['public']) {
             $this->addPublicAttributeClass($this->getDBAClass());
           }
@@ -1599,7 +1597,7 @@ abstract class AbstractBaseAPI {
   protected function getQueryParameterAsList(Request $request, string $name): array {
     $queryParams = $request->getQueryParams();
     if (array_key_exists($name, $queryParams)) {
-      return preg_split("/[,\ ]+/", $queryParams[$name]);
+      return preg_split("/[, ]+/", $queryParams[$name]);
     }
     else {
       return [];

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -112,16 +112,6 @@ abstract class AbstractBaseAPI {
   }
   
   /**
-   * Checks if a user has access to the given single element retrieved
-   * @param User $user
-   * @param object $object
-   * @return bool true if the access is allowed
-   */
-  protected function getSingleACL(User $user, object $object): bool {
-    return true;
-  }
-  
-  /**
    * Returns an array containing all filters and joins to be added to the query to ensure
    * that only the elements are retrieved matching the access groups the user is in
    * @return array
@@ -176,16 +166,17 @@ abstract class AbstractBaseAPI {
   /**
    * Overridable function to aggregate data in the object. Used for Tasks and Agents.
    *
-   * @param object $object The object to aggregate data from.
+   * @param AbstractModel $object $object The object to aggregate data from.
    * @param array &$includedData Array passed by reference; implementations can add related resources
    *   for inclusion in the response by appending to this array.
+   * @param array|null $aggregateFieldsets
    * @return array Aggregated data as key-value pairs.
    *
    * Implementations should use $includedData to collect related resources that should be included
    * in the API response, such as related entities or additional data.
    * @throws HttpError
    */
-  public function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
+  public function aggregateData(AbstractModel $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $aggregatedData = [];
     
     if (is_array($aggregateFieldsets)) {
@@ -358,7 +349,7 @@ abstract class AbstractBaseAPI {
    * @throws ResourceNotFoundError|HttpError
    * @throws Exception
    */
-  final protected static function fetchOne(string $model, int $pk): object {
+  final protected static function fetchOne(string $model, int $pk): AbstractModel {
     $factory = self::getModelFactory($model);
     $object = $factory->get($pk);
     if ($object === null) {
@@ -652,7 +643,7 @@ abstract class AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    * @throws ContainerExceptionInterface
    */
-  protected function obj2Array(object $obj): array {
+  protected function obj2Array(AbstractModel $obj): array {
     // Convert values to JSON supported types
     $features = $obj->getFeatures();
     $kv = $obj->getKeyValueDict();
@@ -680,7 +671,7 @@ abstract class AbstractBaseAPI {
    * @throws ContainerExceptionInterface
    * @throws HttpError
    */
-  protected function obj2Resource(object $obj, array &$expandResult = [], ?array $sparseFieldsets = null, ?array $aggregateFieldsets = null): array {
+  protected function obj2Resource(AbstractModel $obj, array &$expandResult = [], ?array $sparseFieldsets = null, ?array $aggregateFieldsets = null): array {
     // Convert values to JSON supported types
     $features = $obj->getFeatures();
     $kv = $obj->getKeyValueDict();
@@ -811,8 +802,9 @@ abstract class AbstractBaseAPI {
    * Quick to resolve objects via ManyToMany relation table
    * @throws NotFoundExceptionInterface
    * @throws ContainerExceptionInterface
+   * @throws Exception
    */
-  protected function joinQuery(mixed $objFactory, QueryFilter $qF, JoinFilter $jF): array {
+  protected function joinQuery(AbstractModelFactory $objFactory, QueryFilter $qF, JoinFilter $jF): array {
     $joined = $objFactory->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
     $objects = $joined[$objFactory->getModelName()];
     
@@ -827,8 +819,9 @@ abstract class AbstractBaseAPI {
    * Quick to resolve objects via ForeignKey relation table
    * @throws NotFoundExceptionInterface
    * @throws ContainerExceptionInterface
+   * @throws Exception
    */
-  protected function filterQuery(mixed $objFactory, QueryFilter $qF): array {
+  protected function filterQuery(AbstractModelFactory $objFactory, QueryFilter $qF): array {
     $objects = $objFactory->filter([Factory::FILTER => $qF]);
     
     $ret = [];
@@ -839,14 +832,14 @@ abstract class AbstractBaseAPI {
   }
   
   /**
-   * @param object $object
+   * @param AbstractModel $object
    * @param array $expands
    * @param array $expandResult
    * @return array
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
    */
-  protected function applyExpansions(object $object, array $expands, array $expandResult): array {
+  protected function applyExpansions(AbstractModel $object, array $expands, array $expandResult): array {
     $newObject = $this->obj2Array($object);
     foreach ($expands as $expand) {
       if (!array_key_exists($object->getId(), $expandResult[$expand])) {
@@ -876,7 +869,7 @@ abstract class AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    * @throws ContainerExceptionInterface
    */
-  protected function object2Array(object $object, array $expands = []): array {
+  protected function object2Array(AbstractModel $object, array $expands = []): array {
     $expandResult = [];
     foreach ($expands as $expand) {
       $apiClass = $this->container->get('classMapper')->get(get_class($object));
@@ -896,13 +889,13 @@ abstract class AbstractBaseAPI {
   
   /**
    * Helper conversion of single object to JSON string
-   * @param object $object
+   * @param AbstractModel $object
    * @return string
    * @throws ContainerExceptionInterface
    * @throws JsonException
    * @throws NotFoundExceptionInterface
    */
-  protected function object2JSON(object $object): string {
+  protected function object2JSON(AbstractModel $object): string {
     $item = $this->object2Array($object, []);
     return $this->ret2json($item);
   }
@@ -1158,7 +1151,7 @@ abstract class AbstractBaseAPI {
    * @throws InternalError
    * @throws HttpError
    */
-  protected function makeFilter(array $filters, object $apiClass, array &$joinFilters = []): array {
+  protected function makeFilter(array $filters, AbstractModelAPI $apiClass, array &$joinFilters = []): array {
     $qFs = [];
     $features = $apiClass->getAliasedFeatures();
     $factory = $apiClass->getFactory();
@@ -1383,10 +1376,15 @@ abstract class AbstractBaseAPI {
     return $relatedResources;
   }
   
+  /**
+   * @throws NotFoundExceptionInterface
+   * @throws HttpError
+   * @throws ContainerExceptionInterface
+   */
   protected function processExpands(
-    object $apiClass,
+    AbstractModelAPI $apiClass,
     array $expands,
-    object $object,
+    AbstractModel $object,
     array $expandResult,
     array $includedResources,
     ?array $sparseFieldsets = null,
@@ -1537,6 +1535,7 @@ abstract class AbstractBaseAPI {
    * Common features for all requests, like setting user and checking basic permissions
    * @throws HTException
    * @throws HttpForbidden
+   * @throws Exception
    */
   protected function preCommon(Request $request): void {
     $userId = $request->getAttribute(('userId'));
@@ -1661,8 +1660,22 @@ abstract class AbstractBaseAPI {
   
   /**
    * Get single Resource
+   *
+   * @param AbstractModelAPI $apiClass
+   * @param AbstractModel $object
+   * @param Request $request
+   * @param Response $response
+   * @param int $statusCode
+   * @return Response
+   * @throws ContainerExceptionInterface
+   * @throws HTException
+   * @throws HttpError
+   * @throws HttpForbidden
+   * @throws InternalError
+   * @throws JsonException
+   * @throws NotFoundExceptionInterface
    */
-  protected static function getOneResource(object $apiClass, object $object, Request $request, Response $response, int $statusCode = 200): Response {
+  protected static function getOneResource(AbstractModelAPI $apiClass, AbstractModel $object, Request $request, Response $response, int $statusCode = 200): Response {
     $apiClass->preCommon($request);
     $validExpandables = $apiClass->getExpandables();
     $expands = $apiClass->makeExpandables($request, $validExpandables);

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -71,8 +71,6 @@ use Hashtopolis\inc\utils\UserUtils;
 
 /**
  * This class acts as the BaseAPI implementation of API model endpoints
- *
- * @template TModel of AbstractModel
  */
 abstract class AbstractBaseAPI {
   abstract public static function getBaseUri(): string;
@@ -353,7 +351,8 @@ abstract class AbstractBaseAPI {
   }
   
   /**
-   * @param string $model
+   * @template TModel of AbstractModel
+   * @param class-string<TModel> $model
    * @param int $pk
    * @return TModel
    * @throws ResourceNotFoundError|HttpError

--- a/src/inc/apiv2/common/AbstractBaseAPI.php
+++ b/src/inc/apiv2/common/AbstractBaseAPI.php
@@ -896,7 +896,7 @@ abstract class AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    */
   protected function object2JSON(AbstractModel $object): string {
-    $item = $this->object2Array($object, []);
+    $item = $this->object2Array($object);
     return $this->ret2json($item);
   }
   
@@ -1556,15 +1556,7 @@ abstract class AbstractBaseAPI {
     $routeContext = RouteContext::fromRequest($request);
     $this->routeParser = $routeContext->getRouteParser();
     
-    try {
-      $required_perms = $this->getRequiredPermissions($request->getMethod());
-    }
-    catch (HTException $e) {
-      # Annotate error message, with suitable candidates
-      throw new HttpForbidden($e->getMessage() .
-        "(valid methods are for model are: " . join(",", $this->getAvailableMethods()) . ")"
-      );
-    }
+    $required_perms = $this->getRequiredPermissions($request->getMethod());
     
     if ($this->validatePermissions($request->getAttribute("scope"), $required_perms, $request->getMethod(), $request->getAttribute("aud")) === FALSE) {
       throw new HttpForbidden(join('||', $this->permissionErrors));

--- a/src/inc/apiv2/common/AbstractHelperAPI.php
+++ b/src/inc/apiv2/common/AbstractHelperAPI.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\apiv2\common;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
+use Hashtopolis\inc\apiv2\error\InternalError;
 use Hashtopolis\inc\HTException;
 use InvalidArgumentException;
 use JsonException;
@@ -16,7 +18,7 @@ use Slim\Exception\HttpForbiddenException;
 use Hashtopolis\inc\Util;
 
 abstract class AbstractHelperAPI extends AbstractBaseAPI {
-  abstract public function actionPost(array $data): object|array|null;
+  abstract public function actionPost(array $data): AbstractModel|array|null;
   
   /**
    * Function in order to create swagger documentation. Should return either a map of strings that
@@ -41,6 +43,7 @@ abstract class AbstractHelperAPI extends AbstractBaseAPI {
    * @throws JsonException
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
+   * @throws InternalError
    */
   public function processPost(Request $request, Response $response, array $args): Response {
     /* Required calls for all custom requests */

--- a/src/inc/apiv2/common/AbstractHelperAPI.php
+++ b/src/inc/apiv2/common/AbstractHelperAPI.php
@@ -90,7 +90,7 @@ abstract class AbstractHelperAPI extends AbstractBaseAPI {
    * Override-able registering of options
    */
   static public function register(App $app): void {
-    $me = get_called_class();
+    $me = static::class;
     $baseUri = $me::getBaseUri();
     
     /* Allow CORS preflight requests */
@@ -126,16 +126,15 @@ abstract class AbstractHelperAPI extends AbstractBaseAPI {
    *
    * @param int &$start A reference to the starting byte of the range. This value will be updated.
    * @param int &$end A reference to the ending byte of the range. This value will be updated.
-   * @param int &$size The total size of the content in bytes.
-   * @param resource &$fp A file pointer resource to seek to the correct position for the range.
+   * @param int $size The total size of the content in bytes.
+   * @param resource $fp A file pointer resource to seek to the correct position for the range.
    * @return bool Returns `true` if the range request is valid and successfully processed, or `false` otherwise.
    *
    * @throws InvalidArgumentException If the `Range` header is malformed.
    *
    * @note This function assumes the presence of the `HTTP_RANGE` header in the `$_SERVER` superglobal.
    */
-  protected function handleRangeRequest(int &$start, int &$end, int &$size, &$fp): bool {
-    $c_start = $start;
+  protected function handleRangeRequest(int &$start, int &$end, int $size, $fp): bool {
     $c_end = $end;
     
     list(, $range) = explode('=', $_SERVER['HTTP_RANGE'], 2);

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -684,8 +684,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
      */
     $sortList = $apiClass->getQueryParameterAsList($request, 'sort');
     $isNegativeSort = $sortList != null && $sortList[0][0] == '-';
-    //this is used to reverse the array to show the data correctly for the user 
-    $reverseArray = false;
+    //this is used to reverse the array to show the data correctly for the user
 
     if ($isNegativeSort) {
       $firstCursorSort = "DESC";
@@ -730,9 +729,11 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     else if ($isNegativeSort) {
       //the default negative case to retrieve the first elements in a descending way
       $defaultSort = "DESC";
+      $reverseArray = false;
     }
     else {
       $defaultSort = "ASC";
+      $reverseArray = false;
     }
     $primaryKey = $apiClass->getPrimaryKey();
     
@@ -825,7 +826,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     // $lastParams['page']['before'] = $apiClass::encode_cursor(self::calculate_next_cursor($max));
     if ($primaryKeyIsNotPrimaryFilter && isset($lastCursorObject)) {
       $new_secondary_cursor = $apiClass::calculate_next_cursor($lastCursorObject->getId(), !$isNegativeSort);
-      $last_cursor = $apiClass::build_cursor($primaryFilter, $lastCursorObject->expose()[$primaryFilter], $primaryKeyIsNotPrimaryFilter, $primaryKey, $new_secondary_cursor);
+      $last_cursor = $apiClass::build_cursor($primaryFilter, $lastCursorObject->expose()[$primaryFilter], true, $primaryKey, $new_secondary_cursor);
     }
     else if (isset($lastCursorObject)) {
       $new_cursor = $apiClass::calculate_next_cursor($lastCursorObject->getId(), !$isNegativeSort);
@@ -1097,7 +1098,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     
     // Return updated object
     $newObject = $this->getFactory()->get($object->getId());
-    return $this->getOneResource($this, $newObject, $request, $response, 200);
+    return $this->getOneResource($this, $newObject, $request, $response);
   }
   
   /**
@@ -1732,7 +1733,6 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         $table_entry = $factory->createObjectFromDict($table_entry_dict);
         $factory->save($table_entry);
       }
-      $factory->getDB()->commit();
     }
     else {
       $relationType = $relation['relationType'];
@@ -1758,8 +1758,8 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
       }
       
       $factory->massSingleUpdate($primaryKey, $relationKey, $updates);
-      $factory->getDB()->commit();
     }
+    $factory->getDB()->commit();
     
     return $response->withStatus(201)
       ->withHeader("Content-Type", "application/vnd.api+json");
@@ -1815,9 +1815,6 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         $object = $factory->filter([Factory::FILTER => [$qF, $qF2]])[0];
         $factory->delete($object);
       }
-      if (!$factory->getDB()->commit()) {
-        throw new HttpError("Some resources failed updating");
-      }
     }
     else {
       $updates = [];
@@ -1830,9 +1827,9 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
       }
       $factory->getDB()->beginTransaction(); //start transaction to be able roll back
       $factory->massSingleUpdate($primaryKey, $relationKey, $updates);
-      if (!$factory->getDB()->commit()) {
-        throw new HttpError("Some resources failed updating");
-      }
+    }
+    if (!$factory->getDB()->commit()) {
+      throw new HttpError("Some resources failed updating");
     }
     
     return $response->withStatus(201)
@@ -1917,7 +1914,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    */
   static public function register(App $app): void {
-    $me = get_called_class();
+    $me = static::class;
     $baseUri = $me::getBaseUri();
     $baseUriOne = $baseUri . '/{id:[0-9]+}';
     $baseUriCount = $baseUri . "/count";

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -46,7 +46,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws InternalError
    * @throws HttpError
    */
-  protected static function fetchExpandObjects(array $objects, string $expand): mixed {
+  protected static function fetchExpandObjects(array $objects, string $expand): array {
     //disabled the check because with intermediate objects its possible to fetch a different model
     /* Ensure we receive the proper type */
     // $baseModel = static::getDBAClass();

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\apiv2\common;
 
+use Exception;
 use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\MassUpdateSet;
+use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\apiv2\error\ErrorHandler;
 use Hashtopolis\inc\apiv2\error\HttpConflict;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -55,6 +57,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * Fetch objects for  $expand on $objects
    * @throws InternalError
    * @throws HttpError
+   * @throws Exception
    */
   protected static function fetchExpandObjects(array $objects, string $expand): array {
     //disabled the check because with intermediate objects its possible to fetch a different model
@@ -78,7 +81,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
           $toOneRelationships[$expand]['relationKey'],
           $toOneRelationships[$expand]['parentKey']
         );
-      };
+      }
       
       return self::getForeignKeyRelation(
         $objects,
@@ -86,7 +89,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         $relationFactory,
         $toOneRelationships[$expand]['relationKey'],
       );
-    };
+    }
     
     $toManyRelationships = static::getToManyRelationships();
     if (array_key_exists($expand, $toManyRelationships)) {
@@ -103,7 +106,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
           $relationFactory,
           $toManyRelationships[$expand]['relationKey'],
         );
-      };
+      }
       
       return self::getManyToOneRelation(
         $objects,
@@ -111,7 +114,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         $relationFactory,
         $toManyRelationships[$expand]['relationKey'],
       );
-    };
+    }
     
     throw new InternalError("Internal error: Expansion '$expand' not implemented!");
   }
@@ -167,6 +170,9 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * of $intermediateFactory joining on $joinField (between 'intermediate' and 'target'). Filtered by
    * $filterField at $intermediateFactory.
    *
+   * A bit hacky solution to get a to one through an intermediate table, currently only used by tasks to include a hashlist through the taskwrapper
+   * another solution can be to overwrite fetchExpandObjects() in tasks.routes
+   *
    * @param array $objects Objects Fetch relation for selected Objects
    * @param string $objectField Field to use as base for $objects
    * @param object $intermediateFactory Factory used as intermediate between parentObject and targetObject
@@ -175,9 +181,9 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @param string $parentKey
    * @return array $many2One which is a map where the key is the id of the parent object and the value is an array of the included
    *                objects that are included for this parent object
+   * @throws HttpError
+   * @throws Exception
    */
-  //A bit hacky solution to get a to one through an intermediate table, currently only used by tasks to include a hashlist through the taskwrapper
-  //another solution can be to overwrite fetchExpandObjects() in tasks.routes
   final protected static function getManyToOneRelationViaIntermediate(
     array $objects,
     string $objectField,
@@ -226,18 +232,18 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    *
    * @param array $objects Objects Fetch relation for selected Objects
    * @param string $objectField Field to use as base for $objects
-   * @param object $factory Factory used to retrieve objects
+   * @param AbstractModelFactory $factory Factory used to retrieve objects
    * @param string $filterField Filter field of $field to filter against $objects field
    *
    * @return array
+   * @throws Exception
    */
   final protected static function getForeignKeyRelation(
     array $objects,
     string $objectField,
-    object $factory,
+    AbstractModelFactory $factory,
     string $filterField
   ): array {
-    assert($factory instanceof AbstractModelFactory);
     $retval = array();
     
     /* Fetch required objects */
@@ -253,7 +259,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     $f2o = [];
     foreach ($hO as $relationObject) {
       $f2o[$relationObject->getKeyValueDict()[$filterField]] = $relationObject;
-    };
+    }
     
     /* Map objects */
     foreach ($objects as $object) {
@@ -275,6 +281,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @param string $filterField Filter field of $field to filter against $objects field
    *
    * @return array
+   * @throws Exception
    */
   final protected static function getManyToOneRelation(
     array $objects,
@@ -317,6 +324,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @param string $joinField Field to connect 'intermediate' to 'target'
    * @return array $many2many which is a map where the key is the id of the parent object and the value is an array of the included
    *                objects that are included for this parent object
+   * @throws Exception
    */
   final protected static function getManyToManyRelationViaIntermediate(
     array $objects,
@@ -382,6 +390,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws HTException
    * @throws HttpForbidden
    * @throws ResourceNotFoundError
+   * @throws HttpError
    */
   public function deleteOne(Request $request, Response $response, array $args): Response
     // TODO how to handle cascading deletes?
@@ -401,12 +410,22 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   }
   
   /**
+   * Checks if a user has access to the given single element retrieved
+   * @param User $user
+   * @param AbstractModel $object
+   * @return bool true if the access is allowed
+   */
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
+    return true;
+  }
+  
+  /**
    * Request single object from database & validate permissions
    * @return TModel
    * @throws ResourceNotFoundError
    * @throws HttpForbidden
    * @throws HttpError
-   * @throws \Exception
+   * @throws Exception
    */
   protected function doFetch(string $pk, ?AbstractModelFactory $otherFactory = null): mixed {
     if ($otherFactory != null) {
@@ -459,6 +478,9 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     return $updates;
   }
   
+  /**
+   * @throws HttpError
+   */
   protected static function calculate_next_cursor(string|int $cursor, bool $ascending = true): int|string {
     if (is_int($cursor)) {
       if ($ascending) {
@@ -538,7 +560,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    */
   protected static function decode_cursor(string $encoded_cursor): array {
     $json = base64_decode($encoded_cursor);
-    if ($json == false) {
+    if (!$json) {
       throw new HttpError("Invallid pagination cursor, cursor has to be base64 encoded");
     }
     $cursor = json_decode($json, true);
@@ -601,6 +623,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   /**
    * API entry point for requesting multiple objects
    * @throws HttpError
+   * @throws Exception
    */
   public static function getManyResources(object $apiClass, Request $request, Response $response, array $relationFs = []): Response {
     $apiClass->preCommon($request);
@@ -939,7 +962,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         $cast_key = $matches['key'] == '_id' ? array_column($features, 'alias', 'dbname')[$this->getPrimaryKey()] : $matches['key'];
         if (!array_key_exists($cast_key, $features)) {
           continue; //not a valid filter for current model
-        };
+        }
         $modelFilterMap[$model::class][$filter] = $value;
         break; //filter has been found for current model, so break to go to next filter
       }
@@ -960,6 +983,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws JsonException
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
+   * @throws Exception
    */
   public function count(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1018,10 +1042,12 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @return Response
    * @throws ContainerExceptionInterface
    * @throws HTException
+   * @throws HttpError
    * @throws HttpForbidden
+   * @throws InternalError
+   * @throws JsonException
    * @throws NotFoundExceptionInterface
    * @throws ResourceNotFoundError
-   * @throws HttpError
    */
   public function getOne(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1039,10 +1065,15 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @param mixed $object
    * @param mixed $data
    * @return Response
+   * @throws ContainerExceptionInterface
    * @throws HTException
    * @throws HttpError
    * @throws HttpForbidden
+   * @throws InternalError
+   * @throws JsonException
+   * @throws NotFoundExceptionInterface
    * @throws ResourceNotFoundError
+   * @throws Exception
    */
   public function patchSingleObject(Request $request, Response $response, mixed $object, mixed $data): Response {
     if (!$this->validateResourceRecord($data)) {
@@ -1075,9 +1106,13 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @param Response $response
    * @param array $args
    * @return Response
+   * @throws ContainerExceptionInterface
    * @throws HTException
    * @throws HttpError
    * @throws HttpForbidden
+   * @throws InternalError
+   * @throws JsonException
+   * @throws NotFoundExceptionInterface
    * @throws ResourceNotFoundError
    */
   public function patchOne(Request $request, Response $response, array $args): Response {
@@ -1173,6 +1208,12 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   /**
    * Overridable function to update multiple objects
    * @objects ia an array where id is the key and the values are the attributes that need to be patched
+   * @param array $objects
+   *
+   * @return void
+   * @throws HttpError
+   * @throws HttpForbidden
+   * @throws ResourceNotFoundError
    */
   protected function updateObjects(array $objects): void {
     foreach ($objects as $objectId => $attributes) {
@@ -1186,9 +1227,14 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @param Response $response
    * @param array $args
    * @return Response
+   * @throws ContainerExceptionInterface
    * @throws HTException
    * @throws HttpError
    * @throws HttpForbidden
+   * @throws InternalError
+   * @throws JsonException
+   * @throws NotFoundExceptionInterface
+   * @throws Exception
    */
   public function post(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1234,6 +1280,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    * @throws ResourceNotFoundError
    * @throws HttpError
+   * @throws Exception
    */
   public function getToOneRelatedResource(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1294,6 +1341,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws NotFoundExceptionInterface
    * @throws ResourceNotFoundError
    * @throws HttpError
+   * @throws Exception
    */
   public function getToOneRelationshipLink(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1331,7 +1379,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     }
     else {
       $object = $this->doFetch($args['id']);
-    };
+    }
     
     $id = $object->getKeyValueDict()[$relation['key']];
     
@@ -1377,6 +1425,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws HttpError
    * @throws HttpForbidden
    * @throws ResourceNotFoundError
+   * @throws Exception
    */
   public function patchToOneRelationshipLink(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1397,7 +1446,6 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     $features = $this->getFeatures();
     $this->isAllowedToMutate($features, $relationKey, $data == null);
     
-    $factory = $this->getFactory();
     $object = $this->doFetch(intval($args['id']));
     if ($data == null) {
       $this->DatabaseSet($object, $relationKey, null);
@@ -1561,6 +1609,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws HttpError
    * @throws HttpForbidden
    * @throws InternalError
+   * @throws Exception
    */
   protected function updateToManyRelationship(Request $request, array $data, array $args): void {
     $relation = $this->getToManyRelationships()[$args['relation']];
@@ -1626,6 +1675,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws InternalError
    * @throws ResourceNotFoundError
    * @throws HttpConflict
+   * @throws Exception
    */
   public function postToManyRelationshipLink(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1724,6 +1774,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws HTException
    * @throws HttpError
    * @throws HttpForbidden
+   * @throws Exception
    */
   public function deleteToManyRelationshipLink(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);
@@ -1790,6 +1841,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   /**
    * Function to update fields in the database
    * @throws HttpError
+   * @throws Exception
    */
   protected function DatabaseSet($object, $key, $value): void {
     try {
@@ -1847,7 +1899,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
       }
       
       $validFeatures[$name] = $feature;
-    };
+    }
     
     // Ensure debugging response lists are in sorted order
     ksort($validFeatures);
@@ -1857,6 +1909,11 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   
   /**
    * Override-able registering of options
+   *
+   * @param App $app
+   * @return void
+   * @throws ContainerExceptionInterface
+   * @throws NotFoundExceptionInterface
    */
   static public function register(App $app): void {
     $me = get_called_class();

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -1152,6 +1152,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
    * @throws HTException
    * @throws HttpError
    * @throws HttpForbidden
+   * @throws ResourceNotFoundError
    */
   public function patchMultiple(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\common;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\MassUpdateSet;
 use Hashtopolis\inc\apiv2\error\ErrorHandler;
 use Hashtopolis\inc\apiv2\error\HttpConflict;
@@ -27,12 +28,21 @@ use Hashtopolis\dba\PaginationFilter;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\inc\Util;
 
+/**
+ * @template TModel of AbstractModel
+ */
 abstract class AbstractModelAPI extends AbstractBaseAPI {
-  abstract static public function getDBAClass();
+  /**
+   * @return class-string<TModel>
+   */
+  abstract static public function getDBAClass(): string;
   
   abstract protected function createObject(array $data): int;
   
-  abstract protected function deleteObject(object $object): void;
+  /**
+   * @param TModel $object
+   */
+  abstract protected function deleteObject(AbstractModel $object): void;
   
   /**
    * Available 'expand' parameters on $object
@@ -108,6 +118,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   
   
   /**
+   * @return AbstractModelFactory<TModel>
    * @throws HttpError
    */
   final protected static function getFactory(): object {
@@ -391,9 +402,11 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
   
   /**
    * Request single object from database & validate permissions
+   * @return TModel
    * @throws ResourceNotFoundError
    * @throws HttpForbidden
    * @throws HttpError
+   * @throws \Exception
    */
   protected function doFetch(string $pk, ?AbstractModelFactory $otherFactory = null): mixed {
     if ($otherFactory != null) {

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -1665,7 +1665,7 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
           $relation["junctionTableFilterField"] => $baseItem->getId(),
           $relation["junctionTableJoinField"] => $relationItem->getId(),
         ];
-        $table_entry = $factory->createObjectFromDict(-1, $table_entry_dict);
+        $table_entry = $factory->createObjectFromDict($table_entry_dict);
         $factory->save($table_entry);
       }
       $factory->getDB()->commit();

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -1935,15 +1935,15 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     $available_methods = $me::getAvailableMethods();
     
     if (in_array("GET", $available_methods)) {
-      $app->get($baseUri, $me . ':get')->setname($me . ':get');
-      $app->get($baseUriCount, $me . ':count')->setname($me . ':count');
+      $app->get($baseUri, [$me, 'get'])->setname($me . ':get');
+      $app->get($baseUriCount, [$me, 'count'])->setname($me . ':count');
     }
-    
+
     foreach ($me::getToOneRelationships() as $name => $relationship) {
       $relationUri = '{relation:' . $name . '}';
-      $app->get($baseUriOne . '/' . $relationUri, $me . ':getToOneRelatedResource')->setname($me . ':getToOneRelatedResource');
-      $app->get($baseUriRelationships . '/' . $relationUri, $me . ':getToOneRelationshipLink')->setname($me . ':getToOneRelationshipLink');
-      $app->patch($baseUriRelationships . '/' . $relationUri, $me . ':patchToOneRelationshipLink')->setname($me . ':patchToOneRelationshipLink');
+      $app->get($baseUriOne . '/' . $relationUri, [$me, 'getToOneRelatedResource'])->setname($me . ':getToOneRelatedResource');
+      $app->get($baseUriRelationships . '/' . $relationUri, [$me, 'getToOneRelationshipLink'])->setname($me . ':getToOneRelationshipLink');
+      $app->patch($baseUriRelationships . '/' . $relationUri, [$me, 'patchToOneRelationshipLink'])->setname($me . ':patchToOneRelationshipLink');
       $app->options($baseUriOne . '/' . $relationUri, function (Request $request, Response $response): Response {
         return $response;
       });
@@ -1951,14 +1951,14 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         return $response;
       });
     }
-    
+
     foreach ($me::getToManyRelationships() as $name => $relationship) {
       $relationUri = '{relation:' . $name . '}';
-      $app->get($baseUriOne . '/' . $relationUri, $me . ':getToManyRelatedResource')->setname($me . ':getToManyRelatedResource');
-      $app->get($baseUriRelationships . '/' . $relationUri, $me . ':getToManyRelationshipLink')->setname($me . ':getToManyRelationshipLink');
-      $app->patch($baseUriRelationships . '/' . $relationUri, $me . ':patchToManyRelationshipLink')->setname($me . ':patchToManyRelationshipLink');
-      $app->post($baseUriRelationships . '/' . $relationUri, $me . ':postToManyRelationshipLink')->setname($me . ':postToManyRelationshipLink');
-      $app->delete($baseUriRelationships . '/' . $relationUri, $me . ':deleteToManyRelationshipLink')->setname($me . ':deleteToManyRelationshipLink');
+      $app->get($baseUriOne . '/' . $relationUri, [$me, 'getToManyRelatedResource'])->setname($me . ':getToManyRelatedResource');
+      $app->get($baseUriRelationships . '/' . $relationUri, [$me, 'getToManyRelationshipLink'])->setname($me . ':getToManyRelationshipLink');
+      $app->patch($baseUriRelationships . '/' . $relationUri, [$me, 'patchToManyRelationshipLink'])->setname($me . ':patchToManyRelationshipLink');
+      $app->post($baseUriRelationships . '/' . $relationUri, [$me, 'postToManyRelationshipLink'])->setname($me . ':postToManyRelationshipLink');
+      $app->delete($baseUriRelationships . '/' . $relationUri, [$me, 'deleteToManyRelationshipLink'])->setname($me . ':deleteToManyRelationshipLink');
       $app->options($baseUriOne . '/' . $relationUri, function (Request $request, Response $response): Response {
         return $response;
       });
@@ -1966,23 +1966,23 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
         return $response;
       });
     }
-    
+
     if (in_array("POST", $available_methods)) {
-      $app->post($baseUri, $me . ':post')->setname($me . ':post');
+      $app->post($baseUri, [$me, 'post'])->setname($me . ':post');
     }
-    
+
     if (in_array("GET", $available_methods)) {
-      $app->get($baseUriOne, $me . ':getOne')->setName($me . ':getOne');
+      $app->get($baseUriOne, [$me, 'getOne'])->setName($me . ':getOne');
     }
-    
+
     if (in_array("PATCH", $available_methods)) {
-      $app->patch($baseUriOne, $me . ':patchOne')->setName($me . ':patchOne');
-      $app->patch($baseUri, $me . ':patchMultiple')->setName($me . ':patchMultiple');
+      $app->patch($baseUriOne, [$me, 'patchOne'])->setName($me . ':patchOne');
+      $app->patch($baseUri, [$me, 'patchMultiple'])->setName($me . ':patchMultiple');
     }
-    
+
     if (in_array("DELETE", $available_methods)) {
-      $app->delete($baseUriOne, $me . ':deleteOne')->setName($me . ':deleteOne');
-      $app->delete($baseUri, $me . ':deleteMultiple')->setName($me . 'deleteMultiple');
+      $app->delete($baseUriOne, [$me, 'deleteOne'])->setName($me . ':deleteOne');
+      $app->delete($baseUri, [$me, 'deleteMultiple'])->setName($me . 'deleteMultiple');
     }
   }
 }

--- a/src/inc/apiv2/common/OpenAPISchemaUtils.php
+++ b/src/inc/apiv2/common/OpenAPISchemaUtils.php
@@ -166,6 +166,10 @@ class OpenAPISchemaUtils {
   }
   
   //TODO expandables array is unnecessarily indexed in the swagger UI
+  
+  /**
+   * @throws HttpErrorException
+   */
   static function makeExpandables($expandables, $container): array {
     $properties = [];
     foreach ($expandables as $expand => $expandVal) {
@@ -186,7 +190,7 @@ class OpenAPISchemaUtils {
           ]
         ]
       ];
-    };
+    }
     return $properties;
   }
   
@@ -220,10 +224,9 @@ class OpenAPISchemaUtils {
         }
         return ["type" => "array", "items" => $itemSchema];
       } else {
-        $properties = [];
-        foreach ($value as $key => $val) {
-          $properties[$key] = self::mapToProperties($val);
-        }
+        $properties = array_map(function ($val) {
+          return self::mapToProperties($val);
+        }, $value);
         return ["type" => "object", "properties" => $properties];
       }
     }
@@ -279,7 +282,7 @@ class OpenAPISchemaUtils {
   }
   
   /**
-   * This function builds the post/patch attributes for a relationship. When $istomany is false,
+   * This function builds the post/patch attributes for a relationship. When $isToMany is false,
    * it would build the attributes for a to one relationship. If it is true it will build it for a too many relationship.
    * */
   static function buildPostPatchRelation($name, $isToMany): array {
@@ -355,6 +358,7 @@ class OpenAPISchemaUtils {
         else {
           $description = "PATCH request to update attributes of a single object.";
         }
+        break;
       case "delete":
         if ($isRelation) {
           if ($singleObject) {

--- a/src/inc/apiv2/common/openAPISchema.routes.php
+++ b/src/inc/apiv2/common/openAPISchema.routes.php
@@ -111,15 +111,20 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
       $path = $route->getPattern();
       $method = strtolower($route->getMethods()[0]);
       
-      if (!is_string($reflectionCallable)) {
+      if (is_string($reflectionCallable)) {
+        $explodedCallable = explode(':', $reflectionCallable);
+        if (count($explodedCallable) !== 2) {
+          continue;
+        }
+        [$apiClassName, $apiMethod] = $explodedCallable;
+      } elseif (is_array($reflectionCallable)
+        && isset($reflectionCallable[0], $reflectionCallable[1])
+        && is_string($reflectionCallable[0]) && is_string($reflectionCallable[1])) {
+        [$apiClassName, $apiMethod] = $reflectionCallable;
+      } else {
         /* OPTIONS (CORS) have an function callable, ignore for now */
         continue;
       }
-      
-      /* Retrieve parameters */
-      $explodedCallable = explode(':', $reflectionCallable);
-      $apiClassName = $explodedCallable[0];
-      $apiMethod = $explodedCallable[1];
       $class = new $apiClassName($app->getContainer());
 
       

--- a/src/inc/apiv2/common/openAPISchema.routes.php
+++ b/src/inc/apiv2/common/openAPISchema.routes.php
@@ -6,6 +6,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 use ReflectionMethod;
+use ReflectionObject;
 use Slim\Routing\RouteCollectorProxy;
 
 use Middlewares\Utils\HttpErrorException;
@@ -100,7 +101,7 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
     $routes = $app->getRouteCollector()->getRoutes();
     foreach ($routes as $route) {
       /* Quirk to receive className, since it is hidden in a protected variable */
-      $reflectionOfRoute = new \ReflectionObject($route);
+      $reflectionOfRoute = new ReflectionObject($route);
       $protectedCallable = $reflectionOfRoute->getProperty('callable');
       $reflectionCallable = ($protectedCallable->getValue($route));
       
@@ -122,7 +123,7 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
       $class = new $apiClassName($app->getContainer());
 
       
-      $path = preg_replace('/\{([^:}]+):(.+)\}/', '{$1}', $path);
+      $path = preg_replace('/\{([^:}]+):(.+)}/', '{$1}', $path);
       if (!($class instanceof AbstractModelAPI)) {
         $name_parts = explode('\\', $class::class);
         $name = end($name_parts);
@@ -193,7 +194,7 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
           ]
         ];
         continue;
-      };
+      }
       
       /* Quick to find out if single parameter object is used */
       $singleObject = ((strstr($path, '/{id}')) !== false);
@@ -631,7 +632,7 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
             ],
             "description" => "Items to include. Comma seperated"
           ];
-        };
+        }
       }
       else {
         if ($method == 'get') {
@@ -727,7 +728,7 @@ $app->group("/api/v2/openapi.json", function (RouteCollectorProxy $group) use ($
         }
       }
       $paths[$path][$method]["parameters"] = $parameters;
-    };
+    }
     
     /**
      * Build static entries

--- a/src/inc/apiv2/helper/AbortChunkHelperAPI.php
+++ b/src/inc/apiv2/helper/AbortChunkHelperAPI.php
@@ -4,6 +4,8 @@ namespace Hashtopolis\inc\apiv2\helper;
 
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\TaskUtils;
 
@@ -35,7 +37,11 @@ class AbortChunkHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to stop a running chunk.
+   * @param array $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost(array $data): object|array|null {
     $chunk = self::getChunk($data[Chunk::CHUNK_ID]);

--- a/src/inc/apiv2/helper/AbortChunkHelperAPI.php
+++ b/src/inc/apiv2/helper/AbortChunkHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -38,12 +39,12 @@ class AbortChunkHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to stop a running chunk.
    * @param array $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     $chunk = self::getChunk($data[Chunk::CHUNK_ID]);
     
     TaskUtils::abortChunk($chunk->getId(), $this->getCurrentUser());

--- a/src/inc/apiv2/helper/AssignAgentHelperAPI.php
+++ b/src/inc/apiv2/helper/AssignAgentHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AgentUtils;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\models\Task;
@@ -40,10 +41,13 @@ class AssignAgentHelperAPI extends AbstractHelperAPI {
   
   /**
    * This endpoint is responsible for assigning a task to a specific agent.
+   *
+   * @param $data
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     AgentUtils::assign($data[Agent::AGENT_ID], $data[Task::TASK_ID], $this->getCurrentUser());
     
     return self::getResponse();

--- a/src/inc/apiv2/helper/BulkSupertaskBuilderHelperAPI.php
+++ b/src/inc/apiv2/helper/BulkSupertaskBuilderHelperAPI.php
@@ -2,9 +2,11 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\SupertaskUtils;
 
@@ -41,9 +43,12 @@ class BulkSupertaskBuilderHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to import cracked hashes into a hashlist.
+   *
+   * @param $data
+   * @return AbstractModel|array|null
    * @throws HTException
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     return SupertaskUtils::bulkSupertask($data['name'], $data['command'], $data['isCpu'], $data['maxAgents'], $data['isSmall'], $data['crackerBinaryTypeId'], $data['benchtype'], $data['basefiles'], $data['iterfiles'], $this->getCurrentUser());
   }
 }

--- a/src/inc/apiv2/helper/BulkSupertaskBuilderHelperAPI.php
+++ b/src/inc/apiv2/helper/BulkSupertaskBuilderHelperAPI.php
@@ -6,7 +6,6 @@ use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
-use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\SupertaskUtils;
 

--- a/src/inc/apiv2/helper/ChangeOwnPasswordHelperAPI.php
+++ b/src/inc/apiv2/helper/ChangeOwnPasswordHelperAPI.php
@@ -5,7 +5,6 @@ namespace Hashtopolis\inc\apiv2\helper;
 use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
-use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\UserUtils;
 
 class ChangeOwnPasswordHelperAPI extends AbstractHelperAPI {

--- a/src/inc/apiv2/helper/ChangeOwnPasswordHelperAPI.php
+++ b/src/inc/apiv2/helper/ChangeOwnPasswordHelperAPI.php
@@ -2,7 +2,9 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\UserUtils;
 
@@ -39,9 +41,12 @@ class ChangeOwnPasswordHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to set a password of an user.
-   * @throws HTException
+   *
+   * @param $data
+   * @return AbstractModel|array|null
+   * @throws HttpError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $user = $this->getCurrentUser();
     
     /* Set user password if provided */

--- a/src/inc/apiv2/helper/CreateSuperHashlistHelperAPI.php
+++ b/src/inc/apiv2/helper/CreateSuperHashlistHelperAPI.php
@@ -2,6 +2,9 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\defines\DHashlistFormat;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\Factory;
@@ -42,7 +45,12 @@ class CreateSuperHashlistHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to create a super hashlist from multiple hashlists
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
+   * @throws Exception
    */
   public function actionPost($data): object|array|null {
     /* Validate incoming hashlists */

--- a/src/inc/apiv2/helper/CreateSuperHashlistHelperAPI.php
+++ b/src/inc/apiv2/helper/CreateSuperHashlistHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\defines\DHashlistFormat;
@@ -46,13 +47,13 @@ class CreateSuperHashlistHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to create a super hashlist from multiple hashlists
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    * @throws Exception
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     /* Validate incoming hashlists */
     $hashlistIds = [];
     foreach ($data["hashlistIds"] as $hashlistId) {

--- a/src/inc/apiv2/helper/CreateSupertaskHelperAPI.php
+++ b/src/inc/apiv2/helper/CreateSupertaskHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\OrderFilter;
 use Hashtopolis\dba\QueryFilter;
@@ -12,6 +13,8 @@ use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\dba\models\Task;
 use Hashtopolis\dba\models\TaskWrapper;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\defines\DTaskTypes;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\SupertaskUtils;
@@ -48,7 +51,12 @@ class CreateSupertaskHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to create a supertask from a supertask template
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
+   * @throws Exception
    */
   public function actionPost($data): object|array|null {
     $supertaskTemplate = self::getSupertask($data["supertaskTemplateId"]);

--- a/src/inc/apiv2/helper/CreateSupertaskHelperAPI.php
+++ b/src/inc/apiv2/helper/CreateSupertaskHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\OrderFilter;
 use Hashtopolis\dba\QueryFilter;
@@ -52,13 +53,13 @@ class CreateSupertaskHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to create a supertask from a supertask template
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    * @throws Exception
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $supertaskTemplate = self::getSupertask($data["supertaskTemplateId"]);
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);
     $crackerBinary = self::getCrackerBinary($data["crackerVersionId"]);

--- a/src/inc/apiv2/helper/CurrentUserHelperAPI.php
+++ b/src/inc/apiv2/helper/CurrentUserHelperAPI.php
@@ -4,6 +4,7 @@ namespace Hashtopolis\inc\apiv2\helper;
 
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\HTException;
 use JsonException;
 use Psr\Container\ContainerExceptionInterface;
@@ -33,10 +34,15 @@ class CurrentUserHelperAPI extends AbstractHelperAPI {
   }
   
   /**
-   * @throws NotFoundExceptionInterface
+   * @param Request $request
+   * @param Response $response
+   * @return Response
    * @throws ContainerExceptionInterface
    * @throws HTException
+   * @throws HttpError
    * @throws JsonException
+   * @throws NotFoundExceptionInterface
+   * @throws HttpForbidden
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);
@@ -62,8 +68,10 @@ class CurrentUserHelperAPI extends AbstractHelperAPI {
   }
   
   // PATCH endpoint in order to patch attributes of own user, even when user doesnt have permissions to alter users
+  
   /**
    * @throws HTException
+   * @throws HttpForbidden
    */
   public function actionPatch(Request $request, Response $response, array $args): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/helper/CurrentUserHelperAPI.php
+++ b/src/inc/apiv2/helper/CurrentUserHelperAPI.php
@@ -87,8 +87,8 @@ class CurrentUserHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\CurrentUserHelperAPI:handleGet");
-    $app->patch($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\CurrentUserHelperAPI:actionPatch");
+    $app->get($baseUri, [self::class, 'handleGet']);
+    $app->patch($baseUri, [self::class, 'actionPatch']);
   }
   
   public static function getResponse(): array|string|null {

--- a/src/inc/apiv2/helper/CurrentUserHelperAPI.php
+++ b/src/inc/apiv2/helper/CurrentUserHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
@@ -11,10 +12,7 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Hashtopolis\inc\apiv2\model\UserAPI;
 use Hashtopolis\inc\utils\AccountUtils;
-use Hashtopolis\inc\utils\UserUtils;
-use Slim\Routing\RouteContext;
 
 class CurrentUserHelperAPI extends AbstractHelperAPI {
   public static function getBaseUri(): string {
@@ -60,10 +58,10 @@ class CurrentUserHelperAPI extends AbstractHelperAPI {
   
   /**
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HttpError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     throw new HttpError("GetCurrentUser has no actionPOST");
   }
   

--- a/src/inc/apiv2/helper/ExportCrackedHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/ExportCrackedHashesHelperAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\dba\models\Hash;
@@ -37,7 +39,11 @@ class ExportCrackedHashesHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to export cracked hashes.
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost($data): object|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);

--- a/src/inc/apiv2/helper/ExportCrackedHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/ExportCrackedHashesHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
@@ -40,12 +41,12 @@ class ExportCrackedHashesHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to export cracked hashes.
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);
     
     return HashlistUtils::export($hashlist->getId(), $this->getCurrentUser());

--- a/src/inc/apiv2/helper/ExportLeftHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/ExportLeftHashesHelperAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\dba\models\Hash;
@@ -37,7 +39,11 @@ class ExportLeftHashesHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to export uncracked hashes of a hashlist.
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost($data): object|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);

--- a/src/inc/apiv2/helper/ExportLeftHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/ExportLeftHashesHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
@@ -40,12 +41,12 @@ class ExportLeftHashesHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to export uncracked hashes of a hashlist.
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);
     
     return HashlistUtils::leftlist($hashlist->getId(), $this->getCurrentUser());

--- a/src/inc/apiv2/helper/ExportWordlistHelperAPI.php
+++ b/src/inc/apiv2/helper/ExportWordlistHelperAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\dba\models\Hash;
@@ -37,7 +39,11 @@ class ExportWordlistHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to export a wordlist of the cracked hashes inside a hashlist.
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost($data): object|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);

--- a/src/inc/apiv2/helper/ExportWordlistHelperAPI.php
+++ b/src/inc/apiv2/helper/ExportWordlistHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
@@ -40,12 +41,12 @@ class ExportWordlistHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to export a wordlist of the cracked hashes inside a hashlist.
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);
     
     $arr = HashlistUtils::createWordlists($hashlist->getId(), $this->getCurrentUser());

--- a/src/inc/apiv2/helper/GetAccessGroupsHelperAPI.php
+++ b/src/inc/apiv2/helper/GetAccessGroupsHelperAPI.php
@@ -79,7 +79,7 @@ class GetAccessGroupsHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetAccessGroupsHelperAPI:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
   
   /**

--- a/src/inc/apiv2/helper/GetAccessGroupsHelperAPI.php
+++ b/src/inc/apiv2/helper/GetAccessGroupsHelperAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -40,6 +42,7 @@ class GetAccessGroupsHelperAPI extends AbstractHelperAPI {
    * @throws JsonException
    * @throws NotFoundExceptionInterface
    * @throws HttpForbidden
+   * @throws Exception
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);
@@ -62,10 +65,10 @@ class GetAccessGroupsHelperAPI extends AbstractHelperAPI {
   
   /**
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HttpError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     throw new HttpError("GetAccessGroups has no POST");
   }
   

--- a/src/inc/apiv2/helper/GetAccessGroupsHelperAPI.php
+++ b/src/inc/apiv2/helper/GetAccessGroupsHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -30,10 +31,15 @@ class GetAccessGroupsHelperAPI extends AbstractHelperAPI {
   }
   
   /**
-   * @throws NotFoundExceptionInterface
+   * @param Request $request
+   * @param Response $response
+   * @return Response
    * @throws ContainerExceptionInterface
    * @throws HTException
+   * @throws HttpError
    * @throws JsonException
+   * @throws NotFoundExceptionInterface
+   * @throws HttpForbidden
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/helper/GetAgentBinaryHelperAPI.php
+++ b/src/inc/apiv2/helper/GetAgentBinaryHelperAPI.php
@@ -111,6 +111,6 @@ class GetAgentBinaryHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetAgentBinaryHelperAPI:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
 }

--- a/src/inc/apiv2/helper/GetAgentBinaryHelperAPI.php
+++ b/src/inc/apiv2/helper/GetAgentBinaryHelperAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\HTException;
@@ -34,14 +36,17 @@ class GetAgentBinaryHelperAPI extends AbstractHelperAPI {
   
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpErrorException
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpErrorException("getAgentBinary has no POST");
   }
   
   /**
    * @throws HTException
+   * @throws Exception
    */
   public function validateAgent($request, int $agentBinaryId): string {
     $agentBinary = Factory::getAgentBinaryFactory()->get($agentBinaryId);

--- a/src/inc/apiv2/helper/GetAgentBinaryHelperAPI.php
+++ b/src/inc/apiv2/helper/GetAgentBinaryHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\HTException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -32,6 +33,9 @@ class GetAgentBinaryHelperAPI extends AbstractHelperAPI {
   }
   
   
+  /**
+   * @throws HttpErrorException
+   */
   public function actionPost(array $data): object|array|null {
     throw new HttpErrorException("getAgentBinary has no POST");
   }
@@ -81,6 +85,7 @@ class GetAgentBinaryHelperAPI extends AbstractHelperAPI {
    * @return Response
    * @throws HTException
    * @throws HttpErrorException
+   * @throws HttpForbidden
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/helper/GetBestTasksAgent.php
+++ b/src/inc/apiv2/helper/GetBestTasksAgent.php
@@ -2,13 +2,19 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
+use Hashtopolis\inc\HTException;
+use JsonException;
 use Middlewares\Utils\HttpErrorException;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\models\Task;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\utils\TaskUtils;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -30,6 +36,9 @@ class GetBestTasksAgent extends AbstractHelperAPI {
   }
   
   
+  /**
+   * @throws HttpErrorException
+   */
   public function actionPost(array $data): object|array|null {
     throw new HttpErrorException("getBestTasksAgent has no POST");
   }
@@ -58,13 +67,19 @@ class GetBestTasksAgent extends AbstractHelperAPI {
    * @param Request $request
    * @param Response $response
    * @return Response
-   * @throws HttpErrorException
+   * @throws HttpError
+   * @throws HTException
+   * @throws HttpForbidden
+   * @throws JsonException
+   * @throws ContainerExceptionInterface
+   * @throws NotFoundExceptionInterface
+   * @throws Exception
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);
     $queryParams = $request->getQueryParams();
     $agentParam = $queryParams['agent'] ?? null;
-    if ($agentParam === null || !is_numeric($agentParam)) {
+    if (!is_numeric($agentParam)) {
       throw new HttpError("Invalid or missing 'agent' query parameter");
     }
     $agentId = (int) $agentParam;

--- a/src/inc/apiv2/helper/GetBestTasksAgent.php
+++ b/src/inc/apiv2/helper/GetBestTasksAgent.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\HTException;
@@ -37,9 +38,11 @@ class GetBestTasksAgent extends AbstractHelperAPI {
   
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpErrorException
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpErrorException("getBestTasksAgent has no POST");
   }
   

--- a/src/inc/apiv2/helper/GetBestTasksAgent.php
+++ b/src/inc/apiv2/helper/GetBestTasksAgent.php
@@ -112,6 +112,6 @@ class GetBestTasksAgent extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetBestTasksAgent:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
 }

--- a/src/inc/apiv2/helper/GetCracksOfTaskHelper.php
+++ b/src/inc/apiv2/helper/GetCracksOfTaskHelper.php
@@ -120,6 +120,6 @@ class GetCracksOfTaskHelper extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetCracksOfTaskHelper:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
 }

--- a/src/inc/apiv2/helper/GetCracksOfTaskHelper.php
+++ b/src/inc/apiv2/helper/GetCracksOfTaskHelper.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\JoinFilter;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -42,9 +43,11 @@ class GetCracksOfTaskHelper extends AbstractHelperAPI {
   
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpErrorException
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpErrorException("getCracksOfTask has no POST");
   }
   

--- a/src/inc/apiv2/helper/GetCracksOfTaskHelper.php
+++ b/src/inc/apiv2/helper/GetCracksOfTaskHelper.php
@@ -2,10 +2,12 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\dba\JoinFilter;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\defines\DHashlistFormat;
 use Hashtopolis\inc\HTException;
 use JsonException;
@@ -75,6 +77,8 @@ class GetCracksOfTaskHelper extends AbstractHelperAPI {
    * @throws JsonException
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
+   * @throws HttpForbidden
+   * @throws Exception
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
+++ b/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
@@ -80,6 +80,6 @@ class GetCracksPerDayHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, self::class . ":handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
 }

--- a/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
+++ b/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\dba\Factory;
@@ -31,9 +32,11 @@ class GetCracksPerDayHelperAPI extends AbstractHelperAPI {
   }
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpError
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpError("getCracksPerDay has no POST");
   }
 

--- a/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
+++ b/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
@@ -7,14 +7,11 @@ use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\Hash;
-use Hashtopolis\dba\models\HashBinary;
 use Hashtopolis\dba\models\Hashlist;
 use Hashtopolis\dba\QueryFilter;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use stdClass;
-
-use function PHPUnit\Framework\isEmpty;
 
 class GetCracksPerDayHelperAPI extends AbstractHelperAPI {
   public static function getBaseUri(): string {
@@ -32,7 +29,10 @@ class GetCracksPerDayHelperAPI extends AbstractHelperAPI {
   public static function getResponse(): null {
     return null;
   }
-
+  
+  /**
+   * @throws HttpError
+   */
   public function actionPost(array $data): object|array|null {
     throw new HttpError("getCracksPerDay has no POST");
   }

--- a/src/inc/apiv2/helper/GetFileHelperAPI.php
+++ b/src/inc/apiv2/helper/GetFileHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
@@ -37,9 +38,11 @@ class GetFileHelperAPI extends AbstractHelperAPI {
   
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpErrorException
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpErrorException("GetFile has no POST");
   }
   

--- a/src/inc/apiv2/helper/GetFileHelperAPI.php
+++ b/src/inc/apiv2/helper/GetFileHelperAPI.php
@@ -118,6 +118,6 @@ class GetFileHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetFileHelperAPI:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
 }

--- a/src/inc/apiv2/helper/GetFileHelperAPI.php
+++ b/src/inc/apiv2/helper/GetFileHelperAPI.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\defines\DDirectories;
 use Hashtopolis\inc\HTException;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -34,12 +36,16 @@ class GetFileHelperAPI extends AbstractHelperAPI {
   }
   
   
+  /**
+   * @throws HttpErrorException
+   */
   public function actionPost(array $data): object|array|null {
     throw new HttpErrorException("GetFile has no POST");
   }
   
   /**
    * @throws HTException
+   * @throws Exception
    */
   public function validateFile($request, $file_id): string {
     if (!is_numeric($file_id)) {
@@ -87,6 +93,7 @@ class GetFileHelperAPI extends AbstractHelperAPI {
    * @return Response
    * @throws HTException
    * @throws HttpErrorException
+   * @throws HttpForbidden
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/helper/GetTaskProgressImageHelperAPI.php
+++ b/src/inc/apiv2/helper/GetTaskProgressImageHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -83,6 +84,7 @@ class GetTaskProgressImageHelperAPI extends AbstractHelperAPI {
    * @throws HTException
    * @throws HttpError
    * @throws HttpForbidden
+   * @throws Exception
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);
@@ -161,7 +163,6 @@ class GetTaskProgressImageHelperAPI extends AbstractHelperAPI {
       }
     }
     else if (isset($task)) {
-      $progress = $task->getKeyspaceProgress();
       $keyspace = max($task->getKeyspace(), 1);
       
       //load chunks

--- a/src/inc/apiv2/helper/GetTaskProgressImageHelperAPI.php
+++ b/src/inc/apiv2/helper/GetTaskProgressImageHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -40,9 +41,11 @@ class GetTaskProgressImageHelperAPI extends AbstractHelperAPI {
   
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpErrorException
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpErrorException("GetTaskProgressImage has no POST");
   }
   

--- a/src/inc/apiv2/helper/GetTaskProgressImageHelperAPI.php
+++ b/src/inc/apiv2/helper/GetTaskProgressImageHelperAPI.php
@@ -230,6 +230,6 @@ class GetTaskProgressImageHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetTaskProgressImageHelperAPI:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
 }

--- a/src/inc/apiv2/helper/GetUserPermissionHelperAPI.php
+++ b/src/inc/apiv2/helper/GetUserPermissionHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -59,9 +60,11 @@ class GetUserPermissionHelperAPI extends AbstractHelperAPI {
   }
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HttpError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     throw new HttpError("GetAccessGroups has no POST");
   }
   

--- a/src/inc/apiv2/helper/GetUserPermissionHelperAPI.php
+++ b/src/inc/apiv2/helper/GetUserPermissionHelperAPI.php
@@ -75,7 +75,7 @@ class GetUserPermissionHelperAPI extends AbstractHelperAPI {
     $app->options($baseUri, function (Request $request, Response $response): Response {
       return $response;
     });
-    $app->get($baseUri, "Hashtopolis\\inc\\apiv2\\helper\\GetUserPermissionHelperAPI:handleGet");
+    $app->get($baseUri, [self::class, 'handleGet']);
   }
   
   /**

--- a/src/inc/apiv2/helper/GetUserPermissionHelperAPI.php
+++ b/src/inc/apiv2/helper/GetUserPermissionHelperAPI.php
@@ -2,9 +2,11 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\HTException;
 use JsonException;
 use Psr\Container\ContainerExceptionInterface;
@@ -30,10 +32,16 @@ class GetUserPermissionHelperAPI extends AbstractHelperAPI {
   }
   
   /**
-   * @throws NotFoundExceptionInterface
+   * @param Request $request
+   * @param Response $response
+   * @return Response
    * @throws ContainerExceptionInterface
    * @throws HTException
+   * @throws HttpError
    * @throws JsonException
+   * @throws NotFoundExceptionInterface
+   * @throws HttpForbidden
+   * @throws Exception
    */
   public function handleGet(Request $request, Response $response): Response {
     $this->preCommon($request);

--- a/src/inc/apiv2/helper/ImportCrackedHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/ImportCrackedHashesHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
@@ -54,13 +55,13 @@ class ImportCrackedHashesHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to import cracked hashes into a hashlist.
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws HttpErrorException
    * @throws ResourceNotFoundError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);
     
     // Cast to processZap compatible upload format

--- a/src/inc/apiv2/helper/ImportCrackedHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/ImportCrackedHashesHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\models\Hash;
 use Hashtopolis\dba\models\Hashlist;
@@ -52,8 +53,12 @@ class ImportCrackedHashesHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to import cracked hashes into a hashlist.
+   * @param $data
+   * @return object|array|null
    * @throws HTException
    * @throws HttpError
+   * @throws HttpErrorException
+   * @throws ResourceNotFoundError
    */
   public function actionPost($data): object|array|null {
     $hashlist = self::getHashlist($data[Hashlist::HASHLIST_ID]);
@@ -79,12 +84,12 @@ class ImportCrackedHashesHelperAPI extends AbstractHelperAPI {
       if (strlen($data["sourceData"]) == 0) {
         throw new HttpError("sourceType=paste, requires sourceData to be non-empty");
       }
-      else if ($dummyPost["hashfield"] == false) {
+      else if (!$dummyPost["hashfield"]) {
         throw new HttpError("sourceData not valid base64 encoding");
       }
     }
     
-    $result = HashlistUtils::processZap($hashlist->getId(), $data["separator"], $data["sourceType"], $dummyPost, [], $this->getCurrentUser(), (isset($data["overwrite"]) && intval($data["overwrite"]) == 1) ? true : false);
+    $result = HashlistUtils::processZap($hashlist->getId(), $data["separator"], $data["sourceType"], $dummyPost, [], $this->getCurrentUser(), isset($data["overwrite"]) && intval($data["overwrite"]) == 1);
     
     return [
       "totalLines" => $result[0],

--- a/src/inc/apiv2/helper/ImportFileHelperAPI.php
+++ b/src/inc/apiv2/helper/ImportFileHelperAPI.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\defines\DDirectories;
@@ -101,8 +102,13 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
     file_put_contents($metaPath, json_encode($newDs));
   }
   
-  //register is overridden so no actionPost needed
-  function actionPost(array $data): object|array|null {
+  /**
+   * register is overridden so no actionPost needed
+   *
+   * @param array $data
+   * @return AbstractModel|array|null
+   */
+  function actionPost(array $data): AbstractModel|array|null {
     return null;
   }
   

--- a/src/inc/apiv2/helper/ImportFileHelperAPI.php
+++ b/src/inc/apiv2/helper/ImportFileHelperAPI.php
@@ -178,7 +178,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
     $update = [];
     if ($request->hasHeader('Upload-Metadata')) {
       $update["upload_metadata_raw"] = $request->getHeader('Upload-Metadata')[0];
-      if (preg_match('/^[a-zA-Z0-9=, ]+$/', $update["upload_metadata_raw"], $match) === false) {
+      if (preg_match('/^[a-zA-Z0-9=, ]+$/', $update["upload_metadata_raw"]) === false) {
         $response->getBody()->write('Error Upload-Metadata contains non-ASCII characters');
         return $response->withStatus(400);
       }
@@ -450,7 +450,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
   }
   
   static public function register(App $app): void {
-    $me = get_called_class();
+    $me = static::class;
     $baseUri = $me::getBaseUri();
     
     $app->group($baseUri, function (RouteCollectorProxy $group) use ($me) {

--- a/src/inc/apiv2/helper/ImportFileHelperAPI.php
+++ b/src/inc/apiv2/helper/ImportFileHelperAPI.php
@@ -465,8 +465,8 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
         //TODO: Option for Tus-Max-Size: 1073741824
       });
       
-      $group->post('', $me . ":processPost")->setName($me . ":processPost");
-      $group->get('', $me . ":processGet")->setName($me . ":processGet");
+      $group->post('', [$me, 'processPost'])->setName($me . ":processPost");
+      $group->get('', [$me, 'processGet'])->setName($me . ":processGet");
     });
     
     $app->group($baseUri . "/{id:[0-9]{14}-[0-9a-f]{32}}", function (RouteCollectorProxy $group) use ($me) {
@@ -475,9 +475,9 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
         return $response;
       });
       
-      $group->map(['HEAD'], '', $me . ":processHead")->setName($me . ":processHead");
-      $group->patch('', $me . ":processPatch")->setName($me . ":processPatch");
-      $group->delete('', $me . ":processDelete")->setName($me . ":processDelete");
+      $group->map(['HEAD'], '', [$me, 'processHead'])->setName($me . ":processHead");
+      $group->patch('', [$me, 'processPatch'])->setName($me . ":processPatch");
+      $group->delete('', [$me, 'processDelete'])->setName($me . ":processDelete");
     });
   }
 }

--- a/src/inc/apiv2/helper/ImportFileHelperAPI.php
+++ b/src/inc/apiv2/helper/ImportFileHelperAPI.php
@@ -5,6 +5,7 @@ namespace Hashtopolis\inc\apiv2\helper;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Exception;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\defines\DDirectories;
@@ -45,16 +46,25 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
     return [];
   }
   
+  /**
+   * @throws Exception
+   */
   static function getUploadPath(string $id): string {
     return Factory::getStoredValueFactory()->get(DDirectories::TUS)->getVal() . DIRECTORY_SEPARATOR . 'uploads' .
       DIRECTORY_SEPARATOR . basename($id) . ".part";
   }
   
+  /**
+   * @throws Exception
+   */
   static function getMetaPath(string $id): string {
     return Factory::getStoredValueFactory()->get(DDirectories::TUS)->getVal() . DIRECTORY_SEPARATOR . 'meta'
       . DIRECTORY_SEPARATOR . basename($id) . ".meta";
   }
   
+  /**
+   * @throws Exception
+   */
   static function getImportPath(string $id): string {
     return Factory::getStoredValueFactory()->get(DDirectories::IMPORT)->getVal() . DIRECTORY_SEPARATOR . basename($id);
   }
@@ -70,13 +80,19 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
     return ['md5', 'sha1', 'crc32'];
   }
   
-  
-  /* Database quick for temporary storage during upload */
+  /**
+   * Database quick for temporary storage during upload
+   *
+   * @throws Exception
+   */
   static function getMetaStorage(string $id): array {
     $metaPath = self::getMetaPath($id);
     return file_exists($metaPath) ? (array)json_decode(file_get_contents($metaPath), true) : array();
   }
   
+  /**
+   * @throws Exception
+   */
   static function updateStorage(string $id, array $update): void {
     $ds = self::getMetaStorage($id);
     
@@ -93,6 +109,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
   /**
    * A HEAD request is used in the TUS protocol to determine the offset at which the upload should be continued.
    * And to retrieve the upload status.
+   * @throws Exception
    */
   function processHead(Request $request, Response $response, array $args): Response {
     $filename = self::getUploadPath($args['id']);
@@ -149,6 +166,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
    *     - Checked if not present yet (import/<filename>)
    *     - Marks file and stores as import/<filename>
    * @throws RandomException
+   * @throws Exception
    */
   function processPost(Request $request, Response $response, array $args): Response {
     $update = [];
@@ -229,6 +247,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
   /**
    * Given the offset in the 'Upload Offset' header, the user can use this PATCH endpoint in order to resume the upload.
    * @throws HttpError
+   * @throws Exception
    */
   function processPatch(Request $request, Response $response, array $args): Response {
     // Check for Content-Type: application/offset+octet-stream or return 415
@@ -289,7 +308,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
       $uploadChecksum = $request->getHeader('Upload-Checksum')[0];
       /* algo base64_checksum */
       $regex = "/^(" . join("|", self::getChecksumAlgorithm()) . ")" .
-        "[ ]+((?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=))?$/";
+        " +((?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=))?$/";
       
       if (preg_match($regex, $uploadChecksum, $matches) === false) {
         $response->getBody()->write('Syntax of Upload-Checksum header incorrect');
@@ -298,20 +317,12 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
       else {
         $algo = $matches[1];
         $incomingHash = $matches[2];
-        switch ($algo) {
-          case "md5":
-            $chunkHash = base64_encode(md5($chunk, true));
-            break;
-          case "sha1":
-            $chunkHash = base64_encode(sha1($chunk, true));
-            break;
-          case "crc32":
-            $chunkHash = base64_encode(crc32($chunk));
-            break;
-          default:
-            /* Since algorithms are checked in regex, this should never happen */
-            throw new HttpError("Hash algorithm not supported");
-        }
+        $chunkHash = match ($algo) {
+          "md5" => base64_encode(md5($chunk, true)),
+          "sha1" => base64_encode(sha1($chunk, true)),
+          "crc32" => base64_encode(crc32($chunk)),
+          default => throw new HttpError("Hash algorithm not supported"),
+        };
         
         if ($chunkHash != $incomingHash) {
           $response->getBody()->write('Checksum Mismatch');
@@ -352,7 +363,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
       if (file_exists($importPath)) {
         $response->getBody()->write("Error filename '$targetFile' already exists!");
         return $response->withStatus(400);
-      };
+      }
       
       /* Migrate completed file to import folder */
       rename($filename, $importPath);
@@ -374,6 +385,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
   
   /**
    * Deletes the upload and meta file, if they exist. This can be used by the client to cancel an upload.
+   * @throws Exception
    */
   function processDelete(Request $request, Response $response, array $args): Response {
     /* Return 404 if entry is not found */
@@ -404,6 +416,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
   /**
    * Scans the import-directory for files. Directories are ignored.
    * @return array of all files in the top-level directory /../import
+   * @throws Exception
    */
   function scanImportDirectory(): array {
     $directory = Factory::getStoredValueFactory()->get(DDirectories::IMPORT)->getVal() . "/";
@@ -423,6 +436,7 @@ class ImportFileHelperAPI extends AbstractHelperAPI {
   
   /**
    * Retrieves the file and its size
+   * @throws Exception
    */
   function processGet(Request $request, Response $response, array $args): Response {
     $importFiles = $this->scanImportDirectory();

--- a/src/inc/apiv2/helper/MaskSupertaskBuilderHelperAPI.php
+++ b/src/inc/apiv2/helper/MaskSupertaskBuilderHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -40,9 +41,11 @@ class MaskSupertaskBuilderHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to import cracked hashes into a hashlist.
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HTException
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     return SupertaskUtils::importSupertask($data['name'], $data['isCpu'], $data['maxAgents'], $data['isSmall'], $data['optimized'], $data['crackerBinaryTypeId'], explode("\n", str_replace("\r\n", "\n", $data['masks'])), $data['benchtype']);
   }
 }

--- a/src/inc/apiv2/helper/PurgeTaskHelperAPI.php
+++ b/src/inc/apiv2/helper/PurgeTaskHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\dba\models\Task;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -39,12 +40,12 @@ class PurgeTaskHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to purge a task. Meaning all chunks of a task will be deleted and keyspace and progress will be set to 0.
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     $task = self::getTask($data[Task::TASK_ID]);
     
     TaskUtils::purgeTask($task->getId(), $this->getCurrentUser());

--- a/src/inc/apiv2/helper/PurgeTaskHelperAPI.php
+++ b/src/inc/apiv2/helper/PurgeTaskHelperAPI.php
@@ -5,6 +5,8 @@ namespace Hashtopolis\inc\apiv2\helper;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\dba\models\Task;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\TaskUtils;
 
@@ -36,7 +38,11 @@ class PurgeTaskHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to purge a task. Meaning all chunks of a task will be deleted and keyspace and progress will be set to 0.
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost($data): object|array|null {
     $task = self::getTask($data[Task::TASK_ID]);

--- a/src/inc/apiv2/helper/RebuildChunkCacheHelperAPI.php
+++ b/src/inc/apiv2/helper/RebuildChunkCacheHelperAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\ConfigUtils;
 use Hashtopolis\dba\models\Config;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -29,10 +31,11 @@ class RebuildChunkCacheHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to recount files for when there is size mismatch
-   * @param $data
-   * @return object|array|null
+   * @param $data array
+   * @return AbstractModel|array|null
+   * @throws Exception
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     $result = ConfigUtils::rebuildCache();
     $response = $this->getResponse();
     $response["correctedChunks"] = $result[0];

--- a/src/inc/apiv2/helper/RecountFileLinesHelperAPI.php
+++ b/src/inc/apiv2/helper/RecountFileLinesHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\FileUtils;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -38,12 +39,12 @@ class RecountFileLinesHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to recount files for when there is size mismatch
    * @param $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost($data): AbstractModel|array|null {
     // first retrieve the file, as fileCountLines does not check any permissions, therefore to be sure call getFile() first, even if it is not required technically
     FileUtils::getFile($data[File::FILE_ID], $this->getCurrentUser());
     

--- a/src/inc/apiv2/helper/RescanGlobalFilesHelperAPI.php
+++ b/src/inc/apiv2/helper/RescanGlobalFilesHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\ConfigUtils;
 use Hashtopolis\dba\models\Config;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
@@ -30,11 +31,11 @@ class RescanGlobalFilesHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to recount files for when there is size mismatch
-   * @param $data
-   * @return object|array|null
+   * @param $data array
+   * @return AbstractModel|array|null
    * @throws HTMessages
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     ConfigUtils::scanFiles();
     return $this->getResponse();
   }

--- a/src/inc/apiv2/helper/ResetChunkHelperAPI.php
+++ b/src/inc/apiv2/helper/ResetChunkHelperAPI.php
@@ -4,6 +4,8 @@ namespace Hashtopolis\inc\apiv2\helper;
 
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\TaskUtils;
 
@@ -35,7 +37,11 @@ class ResetChunkHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to reset a chunk.
+   * @param array $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost(array $data): object|array|null {
     $chunk = self::getChunk($data[Chunk::CHUNK_ID]);

--- a/src/inc/apiv2/helper/ResetChunkHelperAPI.php
+++ b/src/inc/apiv2/helper/ResetChunkHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -38,12 +39,12 @@ class ResetChunkHelperAPI extends AbstractHelperAPI {
   /**
    * Endpoint to reset a chunk.
    * @param array $data
-   * @return object|array|null
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost(array $data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     $chunk = self::getChunk($data[Chunk::CHUNK_ID]);
     TaskUtils::resetChunk($chunk->getId(), $this->getCurrentUser());
     return $this->getResponse();

--- a/src/inc/apiv2/helper/ResetUserPasswordHelperAPI.php
+++ b/src/inc/apiv2/helper/ResetUserPasswordHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\HTException;
@@ -37,9 +38,11 @@ class ResetUserPasswordHelperAPI extends AbstractHelperAPI {
   }
   
   /**
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HTException
    */
-  public function actionPost($data): array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     UserUtils::userForgotPassword($data[User::USERNAME], $data[User::EMAIL]);
     
     return $this->getResponse();

--- a/src/inc/apiv2/helper/ResetUserPasswordHelperAPI.php
+++ b/src/inc/apiv2/helper/ResetUserPasswordHelperAPI.php
@@ -5,7 +5,7 @@ namespace Hashtopolis\inc\apiv2\helper;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\HTException;
-use \Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Hashtopolis\inc\utils\UserUtils;
 
 class ResetUserPasswordHelperAPI extends AbstractHelperAPI {

--- a/src/inc/apiv2/helper/SearchHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/SearchHashesHelperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\helper;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\Util;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\ContainFilter;
@@ -114,14 +115,14 @@ class SearchHashesHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to search for hashes in accessible hashlists.
-   * @param $data
-   * @return object|array|null
+   * @param $data array
+   * @return AbstractModel|array|null
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
    * @throws HttpError
    * @throws Exception
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     $search = base64_decode($data['searchData'], true);
     $isSalted = $data['isSalted'];
     $separator = $data['separator'];

--- a/src/inc/apiv2/helper/SearchHashesHelperAPI.php
+++ b/src/inc/apiv2/helper/SearchHashesHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Exception;
 use Hashtopolis\inc\Util;
 use Hashtopolis\inc\utils\HashlistUtils;
 use Hashtopolis\dba\ContainFilter;
@@ -15,7 +16,6 @@ use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Slim\App;
 
 class SearchHashesHelperAPI extends AbstractHelperAPI {
   public static function getBaseUri(): string {
@@ -119,6 +119,7 @@ class SearchHashesHelperAPI extends AbstractHelperAPI {
    * @throws ContainerExceptionInterface
    * @throws NotFoundExceptionInterface
    * @throws HttpError
+   * @throws Exception
    */
   public function actionPost($data): object|array|null {
     $search = base64_decode($data['searchData'], true);
@@ -128,7 +129,7 @@ class SearchHashesHelperAPI extends AbstractHelperAPI {
     if (strlen($search) == 0) {
       throw new HttpError("Search query cannot be empty!");
     }
-    else if ($search === false || mb_check_encoding($search, "UTF-8") == false) {
+    else if ($search === false || !mb_check_encoding($search, "UTF-8")) {
       throw new HttpError("Search query is not valid base64!");
     }
     else if ($isSalted && strlen($separator) == 0) {
@@ -138,7 +139,7 @@ class SearchHashesHelperAPI extends AbstractHelperAPI {
     $search = str_replace("\r\n", "\n", $search);
     $search = explode("\n", $search);
     $resultEntries = array();
-    $userHashlists = HashlistUtils::getHashlists(self::getCurrentUser(), false);
+    $userHashlists = HashlistUtils::getHashlists(self::getCurrentUser());
     $userHashlists += HashlistUtils::getHashlists(self::getCurrentUser(), true);
     foreach ($search as $searchEntry) {
       if (strlen($searchEntry) == 0) {

--- a/src/inc/apiv2/helper/SetUserPasswordHelperAPI.php
+++ b/src/inc/apiv2/helper/SetUserPasswordHelperAPI.php
@@ -4,6 +4,8 @@ namespace Hashtopolis\inc\apiv2\helper;
 
 use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
+use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\UserUtils;
 
@@ -37,7 +39,11 @@ class SetUserPasswordHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to set a password of an user.
+   * @param $data
+   * @return object|array|null
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
    */
   public function actionPost($data): object|array|null {
     $user = self::getUser($data[User::USER_ID]);

--- a/src/inc/apiv2/helper/SetUserPasswordHelperAPI.php
+++ b/src/inc/apiv2/helper/SetUserPasswordHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\apiv2\common\AbstractHelperAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -39,13 +40,13 @@ class SetUserPasswordHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to set a password of an user.
-   * @param $data
-   * @return object|array|null
+   * @param $data array
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    * @throws ResourceNotFoundError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     $user = self::getUser($data[User::USER_ID]);
     
     /* Set user password if provided */

--- a/src/inc/apiv2/helper/UnassignAgentHelperAPI.php
+++ b/src/inc/apiv2/helper/UnassignAgentHelperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\helper;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AgentUtils;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\models\Task;
@@ -37,10 +38,12 @@ class UnassignAgentHelperAPI extends AbstractHelperAPI {
   
   /**
    * Endpoint to unassign an agent.
+   * @param array $data
+   * @return AbstractModel|array|null
    * @throws HTException
    * @throws HttpError
    */
-  public function actionPost($data): object|array|null {
+  public function actionPost(array $data): AbstractModel|array|null {
     AgentUtils::assign($data[Agent::AGENT_ID], 0, $this->getCurrentUser());
     
     return $this->getResponse();

--- a/src/inc/apiv2/model/AccessGroupAPI.php
+++ b/src/inc/apiv2/model/AccessGroupAPI.php
@@ -14,6 +14,9 @@ use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<AccessGroup>
+ */
 class AccessGroupAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/accessgroups";

--- a/src/inc/apiv2/model/AccessGroupAPI.php
+++ b/src/inc/apiv2/model/AccessGroupAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\inc\apiv2\error\HttpConflict;
+use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\utils\AccessGroupUtils;
 use Hashtopolis\dba\models\AccessGroup;
 use Hashtopolis\dba\models\AccessGroupAgent;
@@ -53,7 +55,10 @@ class AccessGroupAPI extends AbstractModelAPI {
   }
   
   /**
-   * @throws HTException
+   * @param array $data
+   * @return int
+   * @throws HttpConflict
+   * @throws HttpError
    */
   protected function createObject(array $data): int {
     $object = AccessGroupUtils::createGroup($data[AccessGroup::GROUP_NAME]);

--- a/src/inc/apiv2/model/AccessGroupAPI.php
+++ b/src/inc/apiv2/model/AccessGroupAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpConflict;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\utils\AccessGroupUtils;
@@ -69,9 +70,10 @@ class AccessGroupAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param AccessGroup $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     AccessGroupUtils::deleteGroup($object->getId());
   }
 }

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -27,6 +27,9 @@ use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<Agent>
+ */
 class AgentAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/agents";
@@ -95,6 +98,9 @@ class AgentAPI extends AbstractModelAPI {
     return parent::aggregateData($object, $includedData, $aggregateFieldsets);
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     /** @var Agent $object */
@@ -103,6 +109,9 @@ class AgentAPI extends AbstractModelAPI {
     return count(array_intersect($accessGroupsAgent, $accessGroupsUser)) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -60,11 +60,11 @@ class AgentAPI extends AbstractModelAPI {
   }
   
   /**
-   * @param object $object
+   * @param Agent $object
    * @return int
    * @throws Exception
    */
-  protected function getAggregateCrackingTime(object $object): int {
+  protected function getAggregateCrackingTime(AbstractModel $object): int {
     // in order to make sense of the diff, we need to make sure that both values solve time and dispatch time are set (i.e. >0).
     $qF1 = new QueryFilter(Chunk::AGENT_ID, $object->getId(), "=");
     $qF2 = new QueryFilter(Chunk::SOLVE_TIME, 0, ">");
@@ -79,13 +79,13 @@ class AgentAPI extends AbstractModelAPI {
    * Overridable function to aggregate data in the object. active chunk of agent is appended to
    * $included_data.
    *
-   * @param object $object the agent object were data is aggregated from
+   * @param AbstractModel $object the agent object were data is aggregated from
    * @param array &$includedData
    * @param array|null $aggregateFieldsets
    * @return array not used here
    * @throws Exception
    */
-  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(AbstractModel $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     $agentId = $object->getId();
     $qFs = [];
     $qFs[] = new QueryFilter(Chunk::AGENT_ID, $agentId, "=");
@@ -100,9 +100,10 @@ class AgentAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Agent $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     /** @var Agent $object */
     $accessGroupsAgent = Util::arrayOfIds(AccessUtils::getAccessGroupsOfAgent($object));

--- a/src/inc/apiv2/model/AgentAPI.php
+++ b/src/inc/apiv2/model/AgentAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\Aggregation;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\AgentUtils;
@@ -190,9 +191,10 @@ class AgentAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Agent $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     AgentUtils::delete($object->getId(), $this->getCurrentUser());
   }
 }

--- a/src/inc/apiv2/model/AgentAssignmentAPI.php
+++ b/src/inc/apiv2/model/AgentAssignmentAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\AgentUtils;
 use Hashtopolis\inc\utils\AssignmentUtils;
@@ -36,6 +37,9 @@ class AgentAssignmentAPI extends AbstractModelAPI {
     return Assignment::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());

--- a/src/inc/apiv2/model/AgentAssignmentAPI.php
+++ b/src/inc/apiv2/model/AgentAssignmentAPI.php
@@ -24,6 +24,9 @@ use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<Assignment>
+ */
 class AgentAssignmentAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/agentassignments";
@@ -48,6 +51,9 @@ class AgentAssignmentAPI extends AbstractModelAPI {
     return count(array_intersect($accessGroupsAgent, $accessGroupsUser)) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/AgentAssignmentAPI.php
+++ b/src/inc/apiv2/model/AgentAssignmentAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\AgentUtils;
 use Hashtopolis\inc\utils\AssignmentUtils;
@@ -41,9 +42,10 @@ class AgentAssignmentAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Assignment $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
     $accessGroupsAgent = Util::arrayOfIds(AccessUtils::getAccessGroupsOfAgent($agent));
@@ -106,10 +108,11 @@ class AgentAssignmentAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Assignment $object
    * @throws HTException
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     AgentUtils::assign($object->getAgentId(), 0, $this->getCurrentUser());
   }
 }

--- a/src/inc/apiv2/model/AgentBinaryAPI.php
+++ b/src/inc/apiv2/model/AgentBinaryAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AgentBinaryUtils;
 
 use Hashtopolis\dba\models\AgentBinary;
@@ -38,9 +39,10 @@ class AgentBinaryAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param AgentBinary $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     AgentBinaryUtils::deleteBinary($object->getId());
   }
   

--- a/src/inc/apiv2/model/AgentBinaryAPI.php
+++ b/src/inc/apiv2/model/AgentBinaryAPI.php
@@ -10,6 +10,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<AgentBinary>
+ */
 class AgentBinaryAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/agentbinaries";

--- a/src/inc/apiv2/model/AgentErrorAPI.php
+++ b/src/inc/apiv2/model/AgentErrorAPI.php
@@ -19,6 +19,9 @@ use Hashtopolis\inc\Util;
 use Hashtopolis\dba\ExistsFilter;
 
 
+/**
+ * @extends AbstractModelAPI<AgentError>
+ */
 class AgentErrorAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/agenterrors";
@@ -56,6 +59,9 @@ class AgentErrorAPI extends AbstractModelAPI {
     return count(array_intersect($accessGroupsAgent, $accessGroupsUser)) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/AgentErrorAPI.php
+++ b/src/inc/apiv2/model/AgentErrorAPI.php
@@ -2,9 +2,9 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
-use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\models\Hashlist;
 use Hashtopolis\dba\JoinFilter;
@@ -45,6 +45,9 @@ class AgentErrorAPI extends AbstractModelAPI {
     return AgentError::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
@@ -83,6 +86,9 @@ class AgentErrorAPI extends AbstractModelAPI {
     throw new HttpError("AgentErrors cannot be updated via API");
   }
   
+  /**
+   * @throws Exception
+   */
   protected function deleteObject(object $object): void {
     Factory::getAgentErrorFactory()->delete($object);
   }

--- a/src/inc/apiv2/model/AgentErrorAPI.php
+++ b/src/inc/apiv2/model/AgentErrorAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
@@ -49,9 +50,10 @@ class AgentErrorAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param AgentError $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
     $accessGroupsAgent = Util::arrayOfIds(AccessUtils::getAccessGroupsOfAgent($agent));
@@ -93,9 +95,10 @@ class AgentErrorAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param AgentError $object
    * @throws Exception
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     Factory::getAgentErrorFactory()->delete($object);
   }
 }

--- a/src/inc/apiv2/model/AgentStatAPI.php
+++ b/src/inc/apiv2/model/AgentStatAPI.php
@@ -15,6 +15,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<AgentStat>
+ */
 class AgentStatAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/agentstats";
@@ -39,6 +42,9 @@ class AgentStatAPI extends AbstractModelAPI {
     return count(array_intersect($accessGroupsAgent, $accessGroupsUser)) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     
@@ -67,6 +73,5 @@ class AgentStatAPI extends AbstractModelAPI {
    * @throws Exception
    */
   protected function deleteObject(object $object): void {
-    Factory::getAgentStatFactory()->delete($object);
   }
 }

--- a/src/inc/apiv2/model/AgentStatAPI.php
+++ b/src/inc/apiv2/model/AgentStatAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
@@ -32,9 +33,10 @@ class AgentStatAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param AgentStat $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
     $accessGroupsAgent = Util::arrayOfIds(AccessUtils::getAccessGroupsOfAgent($agent));
@@ -70,8 +72,9 @@ class AgentStatAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param AgentStat $object
    * @throws Exception
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
   }
 }

--- a/src/inc/apiv2/model/AgentStatAPI.php
+++ b/src/inc/apiv2/model/AgentStatAPI.php
@@ -2,12 +2,11 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\Factory;
-
-use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\models\AgentStat;
 use Hashtopolis\dba\ExistsFilter;
 use Hashtopolis\dba\models\User;
@@ -29,6 +28,9 @@ class AgentStatAPI extends AbstractModelAPI {
     return AgentStat::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
@@ -61,6 +63,9 @@ class AgentStatAPI extends AbstractModelAPI {
     throw new HttpError("AgentStats cannot be updated via API");
   }
   
+  /**
+   * @throws Exception
+   */
   protected function deleteObject(object $object): void {
     Factory::getAgentStatFactory()->delete($object);
   }

--- a/src/inc/apiv2/model/ApiTokenAPI.php
+++ b/src/inc/apiv2/model/ApiTokenAPI.php
@@ -6,6 +6,7 @@ use Firebase\JWT\JWT;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\JwtApiKey;
 use Hashtopolis\dba\models\User;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -16,9 +17,6 @@ use Hashtopolis\inc\StartupConfig;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\JwtTokenUtils;
 
-/**
- * @extends AbstractModelAPI<JwtApiKey>
- */
 class ApiTokenAPI extends AbstractModelAPI {
   const API_AUD = "api_hashtopolis";
   private ?string $jwtToken = null;
@@ -61,7 +59,10 @@ class ApiTokenAPI extends AbstractModelAPI {
     ];
   }
   
-  protected function getSingleACL(User $user, object $object): bool {
+  /**
+   * @param JwtApiKey $object
+   */
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     return ($object->getUserId() === $user->getId());
   }
   
@@ -115,7 +116,7 @@ class ApiTokenAPI extends AbstractModelAPI {
     return $token->getId();
   }
   
-  function aggregateData(object $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
+  function aggregateData(AbstractModel $object, array &$includedData = [], ?array $aggregateFieldsets = null): array {
     // $token is only set in POST, this way the actual token is only returned after creation.
     $aggregatedData = [];
     $token = $this->getJwtToken();
@@ -127,9 +128,10 @@ class ApiTokenAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param JwtApiKey $object
    * @throws HttpForbidden
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     JwtTokenUtils::deleteKey($object);
   }
 }

--- a/src/inc/apiv2/model/ApiTokenAPI.php
+++ b/src/inc/apiv2/model/ApiTokenAPI.php
@@ -16,6 +16,9 @@ use Hashtopolis\inc\StartupConfig;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\JwtTokenUtils;
 
+/**
+ * @extends AbstractModelAPI<JwtApiKey>
+ */
 class ApiTokenAPI extends AbstractModelAPI {
   const API_AUD = "api_hashtopolis";
   private ?string $jwtToken = null;
@@ -124,7 +127,6 @@ class ApiTokenAPI extends AbstractModelAPI {
   }
   
   /**
-   * @param object $object
    * @throws HttpForbidden
    */
   protected function deleteObject(object $object): void {

--- a/src/inc/apiv2/model/ChunkAPI.php
+++ b/src/inc/apiv2/model/ChunkAPI.php
@@ -22,6 +22,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<Chunk>
+ */
 class ChunkAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/chunks";
@@ -51,6 +54,9 @@ class ChunkAPI extends AbstractModelAPI {
     return count($chunks) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     $baseFilter = new QueryFilter(Chunk::AGENT_ID, null, "=");

--- a/src/inc/apiv2/model/ChunkAPI.php
+++ b/src/inc/apiv2/model/ChunkAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
@@ -34,6 +35,9 @@ class ChunkAPI extends AbstractModelAPI {
     return Chunk::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     

--- a/src/inc/apiv2/model/ChunkAPI.php
+++ b/src/inc/apiv2/model/ChunkAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
@@ -39,9 +40,10 @@ class ChunkAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Chunk $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     $qF1 = new ContainFilter(Hashlist::ACCESS_GROUP_ID, $accessGroupsUser, Factory::getHashlistFactory());
@@ -107,9 +109,10 @@ class ChunkAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Chunk $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("Chunks cannot be deleted via API");
   }
 }

--- a/src/inc/apiv2/model/ConfigAPI.php
+++ b/src/inc/apiv2/model/ConfigAPI.php
@@ -10,6 +10,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<Config>
+ */
 class ConfigAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/configs";

--- a/src/inc/apiv2/model/ConfigAPI.php
+++ b/src/inc/apiv2/model/ConfigAPI.php
@@ -47,7 +47,10 @@ class ConfigAPI extends AbstractModelAPI {
   protected function deleteObject(object $object): void {
     throw new HttpError("Configs cannot be deleted via API");
   }
-
+  
+  /**
+   * @throws HTException
+   */
   protected function updateObject(int $objectId, array $data): void {
     ConfigUtils::updateSingleConfig($objectId, $data);
   }

--- a/src/inc/apiv2/model/ConfigAPI.php
+++ b/src/inc/apiv2/model/ConfigAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\ConfigUtils;
 use Hashtopolis\dba\models\Config;
 use Hashtopolis\dba\models\ConfigSection;
@@ -45,9 +46,10 @@ class ConfigAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Config $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("Configs cannot be deleted via API");
   }
   

--- a/src/inc/apiv2/model/ConfigSectionAPI.php
+++ b/src/inc/apiv2/model/ConfigSectionAPI.php
@@ -7,6 +7,9 @@ use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 
 
+/**
+ * @extends AbstractModelAPI<ConfigSection>
+ */
 class ConfigSectionAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/configsections";

--- a/src/inc/apiv2/model/ConfigSectionAPI.php
+++ b/src/inc/apiv2/model/ConfigSectionAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\ConfigSection;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -38,9 +39,10 @@ class ConfigSectionAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param ConfigSection $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("ConfigSections cannot be deleted via API");
   }
 }

--- a/src/inc/apiv2/model/CrackerBinaryAPI.php
+++ b/src/inc/apiv2/model/CrackerBinaryAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\CrackerUtils;
 
 use Hashtopolis\dba\models\CrackerBinary;
@@ -61,9 +62,10 @@ class CrackerBinaryAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param CrackerBinary $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     CrackerUtils::deleteBinary($object->getId());
   }
 }

--- a/src/inc/apiv2/model/CrackerBinaryAPI.php
+++ b/src/inc/apiv2/model/CrackerBinaryAPI.php
@@ -12,6 +12,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<CrackerBinary>
+ */
 class CrackerBinaryAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/crackers";

--- a/src/inc/apiv2/model/CrackerBinaryTypeAPI.php
+++ b/src/inc/apiv2/model/CrackerBinaryTypeAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\CrackerUtils;
 
 use Hashtopolis\dba\models\CrackerBinary;
@@ -65,9 +66,10 @@ class CrackerBinaryTypeAPI extends AbstractModelAPI {
   
   
   /**
+   * @param CrackerBinaryType $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     CrackerUtils::deleteBinaryType($object->getId());
   }
 }

--- a/src/inc/apiv2/model/CrackerBinaryTypeAPI.php
+++ b/src/inc/apiv2/model/CrackerBinaryTypeAPI.php
@@ -13,6 +13,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<CrackerBinaryType>
+ */
 class CrackerBinaryTypeAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/crackertypes";

--- a/src/inc/apiv2/model/FileAPI.php
+++ b/src/inc/apiv2/model/FileAPI.php
@@ -30,12 +30,18 @@ class FileAPI extends AbstractModelAPI {
     return File::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     return in_array($object->getAccessGroupId(), $accessGroupsUser);
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/FileAPI.php
+++ b/src/inc/apiv2/model/FileAPI.php
@@ -65,10 +65,16 @@ class FileAPI extends AbstractModelAPI {
     ];
   }
   
+  /**
+   * @throws Exception
+   */
   static protected function getImportPath(): string {
     return Factory::getStoredValueFactory()->get(DDirectories::IMPORT)->getVal() . '/';
   }
   
+  /**
+   * @throws Exception
+   */
   static protected function getFilesPath(): string {
     return Factory::getStoredValueFactory()->get(DDirectories::FILES)->getVal() . '/';
   }
@@ -79,6 +85,7 @@ class FileAPI extends AbstractModelAPI {
   /**
    * @throws HTException
    * @throws HttpError
+   * @throws Exception
    */
   protected function createObject(array $data): int {
     /* Validate target filename */
@@ -146,7 +153,7 @@ class FileAPI extends AbstractModelAPI {
         $this->getImportPath() . $data["sourceData"],
         $this->getImportPath() . $data[File::FILENAME]
       );
-    };
+    }
     
     try {
       /* Create the file, calculating (e.g. lines) and checking validity (e.g. file exists) */
@@ -159,7 +166,7 @@ class FileAPI extends AbstractModelAPI {
           $this->getImportPath() . $data[File::FILENAME],
           $this->getImportPath() . $data["sourceData"]
         );
-      };
+      }
       throw $e;
     }
     

--- a/src/inc/apiv2/model/FileAPI.php
+++ b/src/inc/apiv2/model/FileAPI.php
@@ -21,6 +21,9 @@ use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<File>
+ */
 class FileAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/files";

--- a/src/inc/apiv2/model/FileAPI.php
+++ b/src/inc/apiv2/model/FileAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\defines\DDirectories;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\defines\DFileType;
@@ -34,9 +35,10 @@ class FileAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param File $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     return in_array($object->getAccessGroupId(), $accessGroupsUser);
@@ -203,9 +205,10 @@ class FileAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param File $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     FileUtils::delete($object->getId(), $this->getCurrentUser());
   }
 }

--- a/src/inc/apiv2/model/GlobalPermissionGroupAPI.php
+++ b/src/inc/apiv2/model/GlobalPermissionGroupAPI.php
@@ -14,6 +14,9 @@ use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<RightGroup>
+ */
 class GlobalPermissionGroupAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/globalpermissiongroups";
@@ -68,7 +71,6 @@ class GlobalPermissionGroupAPI extends AbstractModelAPI {
   }
   
   /**
-   * @param object $object
    * @throws HTException
    * @throws HttpError
    */

--- a/src/inc/apiv2/model/GlobalPermissionGroupAPI.php
+++ b/src/inc/apiv2/model/GlobalPermissionGroupAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessControlUtils;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\User;
@@ -71,10 +72,11 @@ class GlobalPermissionGroupAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param RightGroup $object
    * @throws HTException
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     AccessControlUtils::deleteGroup($object->getId());
   }
   

--- a/src/inc/apiv2/model/GlobalPermissionGroupAPI.php
+++ b/src/inc/apiv2/model/GlobalPermissionGroupAPI.php
@@ -68,6 +68,8 @@ class GlobalPermissionGroupAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param object $object
+   * @throws HTException
    * @throws HttpError
    */
   protected function deleteObject(object $object): void {

--- a/src/inc/apiv2/model/HashAPI.php
+++ b/src/inc/apiv2/model/HashAPI.php
@@ -17,6 +17,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<Hash>
+ */
 class HashAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/hashes";
@@ -40,6 +43,9 @@ class HashAPI extends AbstractModelAPI {
     return in_array($hashlist->getAccessGroupId(), $accessGroupsUser);
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/HashAPI.php
+++ b/src/inc/apiv2/model/HashAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\Factory;
@@ -29,6 +30,9 @@ class HashAPI extends AbstractModelAPI {
     return Hash::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $hashlist = Factory::getHashlistFactory()->get($object->getHashlistId());

--- a/src/inc/apiv2/model/HashAPI.php
+++ b/src/inc/apiv2/model/HashAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\Factory;
@@ -34,9 +35,10 @@ class HashAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Hash $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $hashlist = Factory::getHashlistFactory()->get($object->getHashlistId());
     
@@ -91,9 +93,10 @@ class HashAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Hash $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("Hashes cannot be deleted via API");
   }
 }

--- a/src/inc/apiv2/model/HashTypeAPI.php
+++ b/src/inc/apiv2/model/HashTypeAPI.php
@@ -9,6 +9,9 @@ use Hashtopolis\inc\utils\HashtypeUtils;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<HashType>
+ */
 class HashTypeAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/hashtypes";

--- a/src/inc/apiv2/model/HashTypeAPI.php
+++ b/src/inc/apiv2/model/HashTypeAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\HashType;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -37,9 +38,10 @@ class HashTypeAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param HashType $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     HashtypeUtils::deleteHashtype($object->getId());
   }
 }

--- a/src/inc/apiv2/model/HashlistAPI.php
+++ b/src/inc/apiv2/model/HashlistAPI.php
@@ -24,6 +24,9 @@ use Middlewares\Utils\HttpErrorException;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<Hashlist>
+ */
 class HashlistAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/hashlists";
@@ -84,12 +87,18 @@ class HashlistAPI extends AbstractModelAPI {
     ];
   }
   
+  /**
+   * @throws \Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     return in_array($object->getAccessGroupId(), $accessGroupsUser);
   }
   
+  /**
+   * @throws \Exception
+   */
   protected function getFilterACL(): array {
     return [
       Factory::FILTER => [

--- a/src/inc/apiv2/model/HashlistAPI.php
+++ b/src/inc/apiv2/model/HashlistAPI.php
@@ -134,7 +134,7 @@ class HashlistAPI extends AbstractModelAPI {
       if (strlen($data["sourceData"]) == 0) {
         throw new HttpError("sourceType=paste, requires sourceData to be non-empty");
       }
-      else if ($dummyPost["hashfield"] == false) {
+      else if (!$dummyPost["hashfield"]) {
         throw new HttpError("sourceData not valid base64 encoding");
       }
     }
@@ -160,7 +160,7 @@ class HashlistAPI extends AbstractModelAPI {
     // Modify fields not set on hashlist creation
     if (array_key_exists("notes", $data)) {
       HashlistUtils::editNotes($hashlist->getId(), $data["notes"], $this->getCurrentUser());
-    };
+    }
     HashlistUtils::setArchived($hashlist->getId(), $data[UQueryHashlist::HASHLIST_IS_ARCHIVED], $this->getCurrentUser());
     
     return $hashlist->getId();

--- a/src/inc/apiv2/model/HashlistAPI.php
+++ b/src/inc/apiv2/model/HashlistAPI.php
@@ -2,6 +2,8 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\defines\UQueryHashlist;
 use Hashtopolis\inc\utils\AccessUtils;
@@ -88,16 +90,17 @@ class HashlistAPI extends AbstractModelAPI {
   }
   
   /**
-   * @throws \Exception
+   * @param Hashlist $object
+   * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     return in_array($object->getAccessGroupId(), $accessGroupsUser);
   }
   
   /**
-   * @throws \Exception
+   * @throws Exception
    */
   protected function getFilterACL(): array {
     return [
@@ -176,9 +179,10 @@ class HashlistAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Hashlist $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     HashlistUtils::delete($object->getId(), $this->getCurrentUser());
   }
   

--- a/src/inc/apiv2/model/HealthCheckAPI.php
+++ b/src/inc/apiv2/model/HealthCheckAPI.php
@@ -12,6 +12,9 @@ use Hashtopolis\inc\utils\HealthUtils;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<HealthCheck>
+ */
 class HealthCheckAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/healthchecks";
@@ -52,6 +55,7 @@ class HealthCheckAPI extends AbstractModelAPI {
   
   /**
    * @throws HttpError
+   * @throws HTException
    */
   protected function createObject(array $data): int {
     $healthCheck = HealthUtils::createHealthCheck(

--- a/src/inc/apiv2/model/HealthCheckAPI.php
+++ b/src/inc/apiv2/model/HealthCheckAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\CrackerBinary;
 use Hashtopolis\dba\models\HashType;
 use Hashtopolis\dba\models\HealthCheck;
@@ -68,9 +69,10 @@ class HealthCheckAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param HealthCheck $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     HealthUtils::deleteHealthCheck($object->getId());
   }
 }

--- a/src/inc/apiv2/model/HealthCheckAgentAPI.php
+++ b/src/inc/apiv2/model/HealthCheckAgentAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
@@ -30,6 +31,9 @@ class HealthCheckAgentAPI extends AbstractModelAPI {
     return HealthCheckAgent::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
@@ -71,7 +75,7 @@ class HealthCheckAgentAPI extends AbstractModelAPI {
   /**
    * @throws HttpError
    */
-  protected function createObject(array $object): int {
+  protected function createObject(array $data): int {
     throw new HttpError("HealthCheckAgents cannot be created via API");
   }
   

--- a/src/inc/apiv2/model/HealthCheckAgentAPI.php
+++ b/src/inc/apiv2/model/HealthCheckAgentAPI.php
@@ -18,6 +18,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<HealthCheckAgent>
+ */
 class HealthCheckAgentAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/healthcheckagents";
@@ -42,6 +45,9 @@ class HealthCheckAgentAPI extends AbstractModelAPI {
     return count(array_intersect($accessGroupsAgent, $accessGroupsUser)) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/HealthCheckAgentAPI.php
+++ b/src/inc/apiv2/model/HealthCheckAgentAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\ContainFilter;
@@ -35,9 +36,10 @@ class HealthCheckAgentAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param HealthCheckAgent $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
     $accessGroupsAgent = Util::arrayOfIds(AccessUtils::getAccessGroupsOfAgent($agent));
@@ -93,9 +95,10 @@ class HealthCheckAgentAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param HealthCheckAgent $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     /* Dummy code to implement abstract functions */
     throw new HttpError("HealthCheckAgents cannot be deleted via API");
   }

--- a/src/inc/apiv2/model/LogEntryAPI.php
+++ b/src/inc/apiv2/model/LogEntryAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\LogEntry;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -27,9 +28,10 @@ class LogEntryAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param LogEntry $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("Logentries cannot be deleted via API");
   }
 

--- a/src/inc/apiv2/model/LogEntryAPI.php
+++ b/src/inc/apiv2/model/LogEntryAPI.php
@@ -7,6 +7,9 @@ use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 
 
+/**
+ * @extends AbstractModelAPI<LogEntry>
+ */
 class LogEntryAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/logentries";

--- a/src/inc/apiv2/model/NotificationSettingAPI.php
+++ b/src/inc/apiv2/model/NotificationSettingAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\NotificationSetting;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
@@ -76,9 +77,10 @@ class NotificationSettingAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param NotificationSetting $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     NotificationUtils::delete($object->getId(), $this->getCurrentUser());
   }
   

--- a/src/inc/apiv2/model/NotificationSettingAPI.php
+++ b/src/inc/apiv2/model/NotificationSettingAPI.php
@@ -11,6 +11,9 @@ use Hashtopolis\inc\defines\DNotificationType;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\NotificationUtils;
 
+/**
+ * @extends AbstractModelAPI<NotificationSetting>
+ */
 class NotificationSettingAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/notifications";

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\QueryFilter;
 
@@ -57,6 +58,7 @@ class PreTaskAPI extends AbstractModelAPI {
   /**
    * @param object $object
    * @return int
+   * @throws Exception
    */
   protected function getAggregateAuxiliaryKeyspace(object $object): int {
     $qF1 = new QueryFilter(FilePretask::PRETASK_ID, $object->getId(), "=", Factory::getFilePretaskFactory());

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\QueryFilter;
 
@@ -59,11 +60,11 @@ class PreTaskAPI extends AbstractModelAPI {
   }
   
   /**
-   * @param object $object
+   * @param Pretask $object
    * @return int
    * @throws Exception
    */
-  protected function getAggregateAuxiliaryKeyspace(object $object): int {
+  protected function getAggregateAuxiliaryKeyspace(AbstractModel $object): int {
     $qF1 = new QueryFilter(FilePretask::PRETASK_ID, $object->getId(), "=", Factory::getFilePretaskFactory());
     $jF1 = new JoinFilter(Factory::getFilePretaskFactory(), File::FILE_ID, FilePretask::FILE_ID);
     $files = Factory::getFileFactory()->filter([Factory::FILTER => $qF1, Factory::JOIN => $jF1]);
@@ -111,9 +112,10 @@ class PreTaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Pretask $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     PretaskUtils::deletePretask($object->getId());
   }
 }

--- a/src/inc/apiv2/model/PreTaskAPI.php
+++ b/src/inc/apiv2/model/PreTaskAPI.php
@@ -16,6 +16,9 @@ use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\PretaskUtils;
 
 
+/**
+ * @extends AbstractModelAPI<Pretask>
+ */
 class PreTaskAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/pretasks";

--- a/src/inc/apiv2/model/PreprocessorAPI.php
+++ b/src/inc/apiv2/model/PreprocessorAPI.php
@@ -6,9 +6,13 @@ use Hashtopolis\dba\models\Preprocessor;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpConflict;
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\PreprocessorUtils;
 
 
+/**
+ * @extends AbstractModelAPI<Preprocessor>
+ */
 class PreprocessorAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/preprocessors";
@@ -46,6 +50,7 @@ class PreprocessorAPI extends AbstractModelAPI {
   
   /**
    * @throws HttpError
+   * @throws HTException
    */
   protected function deleteObject(object $object): void {
     PreprocessorUtils::delete($object->getId());

--- a/src/inc/apiv2/model/PreprocessorAPI.php
+++ b/src/inc/apiv2/model/PreprocessorAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\models\Preprocessor;
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpConflict;
@@ -49,10 +50,11 @@ class PreprocessorAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Preprocessor $object
    * @throws HttpError
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     PreprocessorUtils::delete($object->getId());
   }
 }

--- a/src/inc/apiv2/model/SpeedAPI.php
+++ b/src/inc/apiv2/model/SpeedAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\defines\DAccessControl;
 use Hashtopolis\dba\models\AccessGroupAgent;
@@ -43,9 +44,10 @@ class SpeedAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Speed $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     $agent = Factory::getAgentFactory()->get($object->getAgentId());
@@ -117,9 +119,10 @@ class SpeedAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Speed $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("Speeds cannot be deleted via API");
   }
 }

--- a/src/inc/apiv2/model/SpeedAPI.php
+++ b/src/inc/apiv2/model/SpeedAPI.php
@@ -21,6 +21,9 @@ use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\Util;
 
 
+/**
+ * @extends AbstractModelAPI<Speed>
+ */
 class SpeedAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/speeds";
@@ -61,6 +64,9 @@ class SpeedAPI extends AbstractModelAPI {
     return count($hashlist) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/SpeedAPI.php
+++ b/src/inc/apiv2/model/SpeedAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\defines\DAccessControl;
 use Hashtopolis\dba\models\AccessGroupAgent;
@@ -38,6 +39,9 @@ class SpeedAPI extends AbstractModelAPI {
     return Speed::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     

--- a/src/inc/apiv2/model/SupertaskAPI.php
+++ b/src/inc/apiv2/model/SupertaskAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\Supertask;
@@ -115,17 +116,19 @@ class SupertaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Supertask $object
    * @throws Exception
    */
-  protected function getAggregateAmountPretasks(object $object): int {
+  protected function getAggregateAmountPretasks(AbstractModel $object): int {
     $qF = new QueryFilter(SupertaskPretask::SUPERTASK_ID, $object->getId(), "=", Factory::getSupertaskPretaskFactory());
     return Factory::getSupertaskPretaskFactory()->countFilter([Factory::FILTER => $qF]);
   }
 
   /**
+   * @param Supertask $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     SupertaskUtils::deleteSupertask($object->getId());
   }
 }

--- a/src/inc/apiv2/model/SupertaskAPI.php
+++ b/src/inc/apiv2/model/SupertaskAPI.php
@@ -16,6 +16,9 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Hashtopolis\inc\utils\SupertaskUtils;
 
 
+/**
+ * @extends AbstractModelAPI<Supertask>
+ */
 class SupertaskAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/supertasks";

--- a/src/inc/apiv2/model/SupertaskAPI.php
+++ b/src/inc/apiv2/model/SupertaskAPI.php
@@ -6,8 +6,6 @@ use Exception;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\dba\models\SupertaskPretask;
-
-
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;

--- a/src/inc/apiv2/model/SupertaskAPI.php
+++ b/src/inc/apiv2/model/SupertaskAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\dba\models\SupertaskPretask;
@@ -9,6 +10,7 @@ use Hashtopolis\dba\models\SupertaskPretask;
 
 use Hashtopolis\inc\apiv2\common\AbstractModelAPI;
 use Hashtopolis\inc\apiv2\error\HttpError;
+use Hashtopolis\inc\apiv2\error\ResourceNotFoundError;
 use Hashtopolis\inc\HTException;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Hashtopolis\inc\utils\SupertaskUtils;
@@ -44,6 +46,9 @@ class SupertaskAPI extends AbstractModelAPI {
     ];
   }
   
+  /**
+   * @throws HttpError
+   */
   protected function createObject(array $data): int {
     /* Use quirk on 'pretasks' since this is casted to DB representation  */
     $supertask = SupertaskUtils::createSupertask(
@@ -54,8 +59,13 @@ class SupertaskAPI extends AbstractModelAPI {
   }
   
   /**
-   * @throws HttpError
+   * @param Request $request
+   * @param array $data
+   * @param array $args
    * @throws HTException
+   * @throws HttpError
+   * @throws ResourceNotFoundError
+   * @throws Exception
    */
   public function updateToManyRelationship(Request $request, array $data, array $args): void {
     $id = $args['id'];

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -180,7 +180,6 @@ class TaskAPI extends AbstractModelAPI {
    * @return string
    */
   protected function getAggregateDispatched(AbstractModel $object): string {
-    /** @var Task $object */
     $keyspace = $object->getKeyspace();
     $keyspaceProgress = $object->getKeyspaceProgress();
     return Util::showperc($keyspaceProgress, $keyspace);

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -31,6 +31,9 @@ use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\utils\TaskUtils;
 use Hashtopolis\inc\Util;
 
+/**
+ * @extends AbstractModelAPI<Task>
+ */
 class TaskAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/tasks";
@@ -55,6 +58,9 @@ class TaskAPI extends AbstractModelAPI {
     return count($tasks) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     
@@ -182,6 +188,9 @@ class TaskAPI extends AbstractModelAPI {
     return Util::showperc(TaskUtils::getTaskProgress($object), $keyspace);
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getAggregateStatus(object $object): int {
     /** @var Task $object */
     return TaskUtils::getStatus($object);

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -3,9 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
-use Hashtopolis\dba\OrderFilter;
 use Hashtopolis\inc\defines\DConfig;
-use Hashtopolis\inc\defines\DPrince;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\Factory;
@@ -40,6 +38,9 @@ class TaskAPI extends AbstractModelAPI {
     return Task::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -3,7 +3,9 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\defines\DConfig;
+use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\ContainFilter;
 use Hashtopolis\dba\Factory;
@@ -239,7 +241,11 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param array $data
+   * @return int
    * @throws HttpError
+   * @throws HTException
+   * @throws HttpForbidden
    */
   protected function createObject(array $data): int {
     /* Parameter is used as primary key in database */
@@ -271,6 +277,9 @@ class TaskAPI extends AbstractModelAPI {
     return $task->getId();
   }
   
+  /**
+   * @throws Exception
+   */
   protected function deleteObject(object $object): void {
     /** @var Task $object */
     TaskUtils::deleteTask($object);

--- a/src/inc/apiv2/model/TaskAPI.php
+++ b/src/inc/apiv2/model/TaskAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\HTException;
@@ -44,9 +45,10 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     $qF1 = new ContainFilter(Hashlist::ACCESS_GROUP_ID, $accessGroupsUser, Factory::getHashlistFactory());
@@ -165,14 +167,19 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateTotalAssignedAgents(object $object): int {
+  protected function getAggregateTotalAssignedAgents(AbstractModel $object): int {
     $qF = new QueryFilter(Assignment::TASK_ID, $object->getId(), "=");
     return Factory::getAssignmentFactory()->countFilter([Factory::FILTER => $qF]);
   }
   
-  protected function getAggregateDispatched(object $object): string {
+  /**
+   * @param Task $object
+   * @return string
+   */
+  protected function getAggregateDispatched(AbstractModel $object): string {
     /** @var Task $object */
     $keyspace = $object->getKeyspace();
     $keyspaceProgress = $object->getKeyspaceProgress();
@@ -180,34 +187,36 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateSearched(object $object): string {
-    /** @var Task $object */
+  protected function getAggregateSearched(AbstractModel $object): string {
     $keyspace = $object->getKeyspace();
     return Util::showperc(TaskUtils::getTaskProgress($object), $keyspace);
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateStatus(object $object): int {
-    /** @var Task $object */
+  protected function getAggregateStatus(AbstractModel $object): int {
     return TaskUtils::getStatus($object);
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateTotalChunks(object $object): int {
+  protected function getAggregateTotalChunks(AbstractModel $object): int {
     $qF = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
     return Factory::getChunkFactory()->countFilter([Factory::FILTER => $qF]);
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateCurrentSpeed(object $object): int {
+  protected function getAggregateCurrentSpeed(AbstractModel $object): int {
     $qF1 = new QueryFilter(Chunk::TASK_ID, $object->getId(), "=");
     $qF2 = new QueryFilter(Chunk::SOLVE_TIME, time() - SConfig::getInstance()->getVal(DConfig::CHUNK_TIMEOUT), ">");
     $qF3 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
@@ -220,10 +229,10 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateEstimatedTime(object $object): int {
-    /** @var Task $object */
+  protected function getAggregateEstimatedTime(AbstractModel $object): int {
     $keyspace = $object->getKeyspace();
     
     // not a 100% efficient, but we would have to break up the nice generic handling of the aggregations to deal with this
@@ -234,18 +243,18 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateCProgress(object $object): int {
-    /** @var Task $object */
+  protected function getAggregateCProgress(AbstractModel $object): int {
     return TaskUtils::getTaskProgress($object);
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function getAggregateTimeSpent(object $object): int {
-    /** @var Task $object */
+  protected function getAggregateTimeSpent(AbstractModel $object): int {
     return TaskUtils::getTimeSpentOnTask($object);
   }
   
@@ -287,10 +296,10 @@ class TaskAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param Task $object
    * @throws Exception
    */
-  protected function deleteObject(object $object): void {
-    /** @var Task $object */
+  protected function deleteObject(AbstractModel $object): void {
     TaskUtils::deleteTask($object);
   }
   

--- a/src/inc/apiv2/model/TaskWrapperAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\defines\DTaskTypes;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroup;
@@ -41,9 +42,10 @@ class TaskWrapperAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapper $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     $qF1 = new ContainFilter(Hashlist::ACCESS_GROUP_ID, $accessGroupsUser, Factory::getHashlistFactory());
@@ -135,11 +137,12 @@ class TaskWrapperAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapper $object
    * @throws HTException
    * @throws HttpError
    * @throws Exception
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     switch ($object->getTaskType()) {
       case DTaskTypes::NORMAL:
         $qF = new QueryFilter(TaskWrapper::TASK_WRAPPER_ID, $object->getId(), "=", Factory::getTaskWrapperFactory());

--- a/src/inc/apiv2/model/TaskWrapperAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperAPI.php
@@ -24,6 +24,9 @@ use Hashtopolis\inc\Util;
 use Hashtopolis\inc\utils\TaskWrapperUtils;
 
 
+/**
+ * @extends AbstractModelAPI<TaskWrapper>
+ */
 class TaskWrapperAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/taskwrappers";
@@ -51,6 +54,9 @@ class TaskWrapperAPI extends AbstractModelAPI {
     return count($wrappers) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
     

--- a/src/inc/apiv2/model/TaskWrapperAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Exception;
 use Hashtopolis\inc\defines\DTaskTypes;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\models\AccessGroup;
@@ -36,6 +37,9 @@ class TaskWrapperAPI extends AbstractModelAPI {
     return TaskWrapper::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
@@ -127,6 +131,7 @@ class TaskWrapperAPI extends AbstractModelAPI {
   /**
    * @throws HTException
    * @throws HttpError
+   * @throws Exception
    */
   protected function deleteObject(object $object): void {
     switch ($object->getTaskType()) {

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\model;
 
 use Exception;
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\dba\Aggregation;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\dba\ContainFilter;
@@ -45,9 +46,10 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws Exception
    */
-  protected function getSingleACL(User $user, object $object): bool {
+  protected function getSingleACL(User $user, AbstractModel $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     $qF1 = new ContainFilter(Hashlist::ACCESS_GROUP_ID, $accessGroupsUser, Factory::getHashlistFactory());
@@ -90,9 +92,10 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws Exception
    */
-  protected function getAggregateTotalAssignedAgents(object $object): int {
+  protected function getAggregateTotalAssignedAgents(AbstractModel $object): int {
     $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $object->getId(), "=", Factory::getTaskFactory());
     $jF = new JoinFilter(Factory::getTaskFactory(), Assignment::TASK_ID, Task::TASK_ID);
     
@@ -100,9 +103,10 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
-   * @throws HttpError
+   * @param TaskWrapperDisplay $object
+   * @return ?string
    */
-  protected function getAggregateDispatched(object $object): ?string {
+  protected function getAggregateDispatched(AbstractModel $object): ?string {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
       return null;
     }
@@ -113,10 +117,11 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateSearched(object $object): ?string {
+  protected function getAggregateSearched(AbstractModel $object): ?string {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
       return null;
     }
@@ -127,9 +132,10 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws Exception
    */
-  protected function getAggregateStatus(object $object): int {
+  protected function getAggregateStatus(AbstractModel $object): int {
     // TODO: this could be optimized by only requesting taskId, keyspace and keyspaceProgress of all tasks of that wrapper (columnFilter)
     $tasks = TaskUtils::getTasksOfWrapper($object->getId());
     $completed = 0;
@@ -159,10 +165,11 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateCurrentSpeed(object $object): ?int {
+  protected function getAggregateCurrentSpeed(AbstractModel $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
       return null;
     }
@@ -181,10 +188,11 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateEstimatedTime(object $object): ?int {
+  protected function getAggregateEstimatedTime(AbstractModel $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
       return null;
     }
@@ -196,10 +204,11 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateCProgress(object $object): ?int {
+  protected function getAggregateCProgress(AbstractModel $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
       return null;
     }
@@ -209,10 +218,11 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws HttpError
    * @throws Exception
    */
-  protected function getAggregateTimeSpent(object $object): ?int {
+  protected function getAggregateTimeSpent(AbstractModel $object): ?int {
     if ($object->getTaskType() !== DTaskTypes::NORMAL) {
       return null;
     }
@@ -236,9 +246,10 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param TaskWrapperDisplay $object
    * @throws HttpError
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     throw new HttpError("TaskWrapperDisplays cannot be deleted via API");
   }
   

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -24,6 +24,9 @@ use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\Util;
 use Hashtopolis\inc\utils\TaskUtils;
 
+/**
+ * @extends AbstractModelAPI<TaskWrapperDisplay>
+ */
 class TaskWrapperDisplayAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/taskwrapperdisplays";
@@ -54,6 +57,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
     return count($wrappers) > 0;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getFilterACL(): array {
     
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($this->getCurrentUser()));
@@ -120,6 +126,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
     return Util::showperc(TaskUtils::getTaskProgress($task), $keyspace);
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getAggregateStatus(object $object): int {
     // TODO: this could be optimized by only requesting taskId, keyspace and keyspaceProgress of all tasks of that wrapper (columnFilter)
     $tasks = TaskUtils::getTasksOfWrapper($object->getId());

--- a/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
+++ b/src/inc/apiv2/model/TaskWrapperDisplayAPI.php
@@ -41,6 +41,9 @@ class TaskWrapperDisplayAPI extends AbstractModelAPI {
     return TaskWrapperDisplay::class;
   }
   
+  /**
+   * @throws Exception
+   */
   protected function getSingleACL(User $user, object $object): bool {
     $accessGroupsUser = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     

--- a/src/inc/apiv2/model/UserAPI.php
+++ b/src/inc/apiv2/model/UserAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\inc\apiv2\error\InternalError;
 use Hashtopolis\inc\utils\AccountUtils;
 use BadFunctionCallException;
 use Hashtopolis\dba\Factory;
@@ -52,7 +53,7 @@ class UserAPI extends AbstractModelAPI {
     ];
   }
   
-  protected static function fetchExpandObjects(array $objects, string $expand): mixed {
+  protected static function fetchExpandObjects(array $objects, string $expand): array {
     array_walk($objects, function ($obj) {
       assert($obj instanceof User);
     });
@@ -83,6 +84,7 @@ class UserAPI extends AbstractModelAPI {
    * @throws HTException
    * @throws HttpConflict
    * @throws HttpError
+   * @throws InternalError
    */
   protected function createObject($data): int {
     $user = UserUtils::createUser(

--- a/src/inc/apiv2/model/UserAPI.php
+++ b/src/inc/apiv2/model/UserAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\apiv2\error\InternalError;
 use Hashtopolis\inc\utils\AccountUtils;
 use BadFunctionCallException;
@@ -111,9 +112,10 @@ class UserAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param User $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     UserUtils::deleteUser($object->getId(), $this->getCurrentUser());
   }
   

--- a/src/inc/apiv2/model/UserAPI.php
+++ b/src/inc/apiv2/model/UserAPI.php
@@ -18,6 +18,9 @@ use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\utils\UserUtils;
 
 
+/**
+ * @extends AbstractModelAPI<User>
+ */
 class UserAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/users";

--- a/src/inc/apiv2/model/VoucherAPI.php
+++ b/src/inc/apiv2/model/VoucherAPI.php
@@ -10,6 +10,9 @@ use Hashtopolis\inc\apiv2\error\HttpConflict;
 use Hashtopolis\inc\HTException;
 
 
+/**
+ * @extends AbstractModelAPI<RegVoucher>
+ */
 class VoucherAPI extends AbstractModelAPI {
   public static function getBaseUri(): string {
     return "/api/v2/ui/vouchers";

--- a/src/inc/apiv2/model/VoucherAPI.php
+++ b/src/inc/apiv2/model/VoucherAPI.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\apiv2\model;
 
+use Hashtopolis\dba\AbstractModel;
 use Hashtopolis\inc\utils\AgentUtils;
 
 use Hashtopolis\dba\models\RegVoucher;
@@ -31,9 +32,10 @@ class VoucherAPI extends AbstractModelAPI {
   }
   
   /**
+   * @param RegVoucher $object
    * @throws HTException
    */
-  protected function deleteObject(object $object): void {
+  protected function deleteObject(AbstractModel $object): void {
     AgentUtils::deleteVoucher($object->getId());
   }
 }

--- a/src/inc/apiv2/util/CorsHackMiddleware.php
+++ b/src/inc/apiv2/util/CorsHackMiddleware.php
@@ -34,12 +34,11 @@ class CorsHackMiddleware implements MiddlewareInterface {
 
     $response = CorsHackMiddleware::CheckCORS($request, $response);
     
-    $response = $response->withHeader('Access-Control-Allow-Methods', implode(',', $methods));
-    $response = $response->withHeader('Access-Control-Allow-Headers', $requestHeaders);
-    
     // Optional: Allow Ajax CORS requests with Authorization header
     // $response = $response->withHeader('Access-Control-Allow-Credentials', 'true');
-    return $response;
+    
+    $response = $response->withHeader('Access-Control-Allow-Methods', implode(',', $methods));
+    return $response->withHeader('Access-Control-Allow-Headers', $requestHeaders);
   }
   
   /**

--- a/src/inc/apiv2/util/CorsHackMiddleware.php
+++ b/src/inc/apiv2/util/CorsHackMiddleware.php
@@ -13,6 +13,9 @@ use Hashtopolis\inc\apiv2\error\HttpForbidden;
 
 /* This middleware will append the response header Access-Control-Allow-Methods with all allowed methods */
 class CorsHackMiddleware implements MiddlewareInterface {
+  /**
+   * @throws HttpForbidden
+   */
   public function process(Request $request, RequestHandler $handler): Response {
     $response = $handler->handle($request);
     

--- a/src/inc/apiv2/util/CorsHackMiddleware.php
+++ b/src/inc/apiv2/util/CorsHackMiddleware.php
@@ -19,6 +19,9 @@ class CorsHackMiddleware implements MiddlewareInterface {
     return CorsHackMiddleware::addCORSHeaders($request, $response);
   }
   
+  /**
+   * @throws HttpForbidden
+   */
   public static function addCORSHeaders(Request $request, $response) {
     $routeContext = RouteContext::fromRequest($request);
     $routingResults = $routeContext->getRoutingResults();
@@ -35,7 +38,10 @@ class CorsHackMiddleware implements MiddlewareInterface {
     // $response = $response->withHeader('Access-Control-Allow-Credentials', 'true');
     return $response;
   }
-
+  
+  /**
+   * @throws HttpForbidden
+   */
   public static function CheckCORS($request, $response): Response {
     $requestHttpOrigin = $request->getHeaderLine('HTTP_ORIGIN');
     
@@ -55,7 +61,7 @@ class CorsHackMiddleware implements MiddlewareInterface {
       
       if ($requestHttpOriginUrl === $envBackendUrl || (in_array($requestHttpOriginUrl, $localhostSynonyms) && in_array($envBackendUrl, $localhostSynonyms))) {
         //Origin URL matches, now check the port too
-        if (substr($requestHttpOrigin, -1) !== "]" && str_contains($requestHttpOrigin, ":")) {
+        if (!str_ends_with($requestHttpOrigin, "]") && str_contains($requestHttpOrigin, ":")) {
           $requestHttpOriginPort = substr($requestHttpOrigin, strrpos($requestHttpOrigin, ":") + 1); //Needs to use strrpos in case of ipv6 because of multiple ':' characters
           $envBackendPort = substr($envBackend, strrpos($envBackend, ":") + 1);
           
@@ -63,7 +69,7 @@ class CorsHackMiddleware implements MiddlewareInterface {
             $response = $response->withHeader('Access-Control-Allow-Origin', $request->getHeaderLine('HTTP_ORIGIN'));
           }
           else {
-            throw new HttpForbidden("CORS error: Allow-Origin port doesn't match: the value from the request is {$requestHttpOriginPort} but expected {$envFrontendPort} or {$envBackendPort}. Try switching the frontend port back to the default value (4200) in the docker-compose.");
+            throw new HttpForbidden("CORS error: Allow-Origin port doesn't match: the value from the request is $requestHttpOriginPort but expected $envFrontendPort or $envBackendPort. Try switching the frontend port back to the default value (4200) in the docker-compose.");
           }
         }
         else {
@@ -72,7 +78,7 @@ class CorsHackMiddleware implements MiddlewareInterface {
         }
       }
       else {
-        throw new HttpForbidden("CORS error: Allow-Origin URL doesn't match: the value from the request is {$requestHttpOriginUrl} but expected {$envBackendUrl}. Is the HASHTOPOLIS_BACKEND_URL in the .env file the correct one?");
+        throw new HttpForbidden("CORS error: Allow-Origin URL doesn't match: the value from the request is $requestHttpOriginUrl but expected $envBackendUrl. Is the HASHTOPOLIS_BACKEND_URL in the .env file the correct one?");
       }
     }
     else {

--- a/src/inc/apiv2/util/JsonBodyParserMiddleware.php
+++ b/src/inc/apiv2/util/JsonBodyParserMiddleware.php
@@ -3,6 +3,7 @@
 namespace Hashtopolis\inc\apiv2\util;
 
 use Hashtopolis\inc\apiv2\error\ErrorHandler;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -12,7 +13,7 @@ use Slim\Psr7\Response;
 
 /* Pre-parse incoming request body */
 class JsonBodyParserMiddleware implements MiddlewareInterface {
-  public function process(Request $request, RequestHandler $handler): \Psr\Http\Message\ResponseInterface {
+  public function process(Request $request, RequestHandler $handler): ResponseInterface {
     $contentType = $request->getHeaderLine('Content-Type');
     
     if (strstr($contentType, 'application/json') || strstr($contentType, 'application/vnd.api+json')) {

--- a/src/inc/apiv2/util/TokenAsParameterMiddleware.php
+++ b/src/inc/apiv2/util/TokenAsParameterMiddleware.php
@@ -13,7 +13,7 @@ class TokenAsParameterMiddleware implements MiddlewareInterface {
     $data = $request->getQueryParams();
     if (array_key_exists('token', $data)) {
       $request = $request->withHeader('Authorization', 'Bearer ' . $data['token']);
-    };
+    }
     
     return $handler->handle($request);
   }

--- a/src/inc/defines/DAccessControl.php
+++ b/src/inc/defines/DAccessControl.php
@@ -3,7 +3,6 @@
 namespace Hashtopolis\inc\defines;
 
 use ReflectionClass;
-use ReflectionException;
 
 class DAccessControl {
   const VIEW_HASHLIST_ACCESS        = array("viewHashlistAccess", DAccessControl::CREATE_HASHLIST_ACCESS, DAccessControl::MANAGE_HASHLIST_ACCESS);
@@ -36,16 +35,16 @@ class DAccessControl {
   const PUBLIC_ACCESS = "publicAccess";
   const LOGIN_ACCESS  = "loginAccess";
   
-  static function getConstants() {
+  static function getConstants(): array {
     $oClass = new ReflectionClass(__CLASS__);
     return $oClass->getConstants();
   }
   
   /**
-   * @param $access string
+   * @param mixed $access
    * @return string description
    */
-  public static function getDescription($access) {
+  public static function getDescription(mixed $access): string {
     if (is_array($access)) {
       $access = $access[0];
     }

--- a/src/inc/defines/DConfig.php
+++ b/src/inc/defines/DConfig.php
@@ -4,7 +4,6 @@ namespace Hashtopolis\inc\defines;
 
 use Hashtopolis\inc\DataSet;
 use ReflectionClass;
-use ReflectionException;
 
 class DConfig {
   // Section: Cracking/Tasks
@@ -82,7 +81,7 @@ class DConfig {
   const NOTIFICATIONS_PROXY_PORT   = "notificationsProxyPort";
   const NOTIFICATIONS_PROXY_TYPE   = "notificationsProxyType";
   
-  static function getConstants() {
+  static function getConstants(): array {
     $oClass = new ReflectionClass(__CLASS__);
     return $oClass->getConstants();
   }
@@ -92,7 +91,7 @@ class DConfig {
    * @param string $config
    * @return DataSet
    */
-  public static function getSelection($config) {
+  public static function getSelection(string $config): DataSet {
     return match ($config) {
       DConfig::NOTIFICATIONS_PROXY_TYPE => new DataSet([
           DProxyTypes::HTTP => DProxyTypes::HTTP,
@@ -119,7 +118,7 @@ class DConfig {
    * @param $config string
    * @return string
    */
-  public static function getConfigType($config) {
+  public static function getConfigType(string $config): string {
     return match ($config) {
       DConfig::BENCHMARK_TIME => DConfigType::NUMBER_INPUT,
       DConfig::CHUNK_DURATION => DConfigType::NUMBER_INPUT,
@@ -187,7 +186,7 @@ class DConfig {
    * @param $config string
    * @return string
    */
-  public static function getConfigDescription($config) {
+  public static function getConfigDescription(string $config): string {
     return match ($config) {
       DConfig::BENCHMARK_TIME => "Time in seconds an agent should benchmark a task.",
       DConfig::CHUNK_DURATION => "Time in seconds a client should be working on a single chunk.",

--- a/src/inc/defines/DNotificationType.php
+++ b/src/inc/defines/DNotificationType.php
@@ -21,7 +21,7 @@ class DNotificationType {
   const DELETE_HASHLIST       = "deleteHashlist";
   const DELETE_AGENT          = "deleteAgent";
   
-  public static function getAll() {
+  public static function getAll(): array {
     return array(
       DNotificationType::TASK_COMPLETE,
       DNotificationType::AGENT_ERROR,
@@ -47,7 +47,7 @@ class DNotificationType {
    * @param $notificationType string
    * @return string|array permission required
    */
-  public static function getRequiredPermission($notificationType) {
+  public static function getRequiredPermission(string $notificationType): array|string {
     return match ($notificationType) {
       DNotificationType::TASK_COMPLETE, DNotificationType::NEW_TASK, DNotificationType::DELETE_TASK => DAccessControl::VIEW_TASK_ACCESS,
       DNotificationType::AGENT_ERROR, DNotificationType::OWN_AGENT_ERROR, DNotificationType::DELETE_AGENT => DAccessControl::VIEW_AGENT_ACCESS,
@@ -58,7 +58,7 @@ class DNotificationType {
     };
   }
   
-  public static function getObjectType($notificationType) {
+  public static function getObjectType(string $notificationType): string {
     return match ($notificationType) {
       DNotificationType::TASK_COMPLETE, DNotificationType::DELETE_TASK => DNotificationObjectType::TASK,
       DNotificationType::AGENT_ERROR, DNotificationType::OWN_AGENT_ERROR, DNotificationType::DELETE_AGENT => DNotificationObjectType::AGENT,

--- a/src/inc/defines/DPlatforms.php
+++ b/src/inc/defines/DPlatforms.php
@@ -7,7 +7,7 @@ class DPlatforms {
   const WINDOWS = "win";
   const MAC_OSX = "osx";
   
-  public static function getName($type) {
+  public static function getName(string $type): string {
     return match ($type) {
       DPlatforms::LINUX => "Linux",
       DPlatforms::MAC_OSX => "Max OSX",

--- a/src/inc/defines/DServerLog.php
+++ b/src/inc/defines/DServerLog.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\defines;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\inc\utils\Lock;
 use Hashtopolis\inc\utils\LockUtils;
@@ -15,7 +16,10 @@ class DServerLog {
   const ERROR   = 40;
   const FATAL   = 50;
   
-  public static function log($level, $message, $data = []) {
+  /**
+   * @throws Exception
+   */
+  public static function log($level, $message, $data = []): void {
     if ($level >= SConfig::getInstance()->getVal(DConfig::SERVER_LOG_LEVEL)) {
       // log it
       LockUtils::get(Lock::LOG);
@@ -48,7 +52,7 @@ class DServerLog {
     }
   }
   
-  public static function getLevelName($level) {
+  public static function getLevelName(int $level): string {
     return match ($level) {
       DServerLog::TRACE => "TRACE",
       DServerLog::DEBUG => "DEBUG",

--- a/src/inc/defines/UApi.php
+++ b/src/inc/defines/UApi.php
@@ -8,12 +8,12 @@ use ReflectionException;
 abstract class UApi {
   abstract function describe($constant);
   
-  static function getConstants() {
+  static function getConstants(): array {
     $oClass = new ReflectionClass(static::class);
     return $oClass->getConstants();
   }
   
-  static function getSection($section) {
+  static function getSection($section): object {
     return match ($section) {
       USection::TEST => new USectionTest(),
       USection::AGENT => new USectionAgent(),
@@ -33,7 +33,7 @@ abstract class UApi {
     };
   }
   
-  static function getDescription($section, $constant) {
+  static function getDescription($section, $constant): string {
     $sectionObject = UApi::getSection($section);
     if ($sectionObject == null) {
       return "__" . $section . "_" . $constant . "__";

--- a/src/inc/defines/USectionAgent.php
+++ b/src/inc/defines/USectionAgent.php
@@ -19,7 +19,7 @@ class USectionAgent extends UApi {
   const SET_TRUSTED      = "setTrusted";
   const DELETE_AGENT     = "deleteAgent";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionAgent::CREATE_VOUCHER => "Creating new vouchers",
       USectionAgent::GET_BINARIES => "Get a list of available agent binaries",

--- a/src/inc/defines/USectionConfig.php
+++ b/src/inc/defines/USectionConfig.php
@@ -8,7 +8,7 @@ class USectionConfig extends UApi {
   const GET_CONFIG    = "getConfig";
   const SET_CONFIG    = "setConfig";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionConfig::LIST_SECTIONS => "List available sections in config",
       USectionConfig::LIST_CONFIG => "List config options of a given section",

--- a/src/inc/defines/USectionCracker.php
+++ b/src/inc/defines/USectionCracker.php
@@ -12,7 +12,7 @@ class USectionCracker extends UApi {
   const ADD_VERSION    = "addVersion";
   const UPDATE_VERSION = "updateVersion";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionCracker::LIST_CRACKERS => "List all crackers",
       USectionCracker::GET_CRACKER => "Get details of a cracker",

--- a/src/inc/defines/USectionFile.php
+++ b/src/inc/defines/USectionFile.php
@@ -12,7 +12,7 @@ class USectionFile extends UApi {
   const DELETE_FILE   = "deleteFile";
   const SET_FILE_TYPE = "setFileType";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionFile::LIST_FILES => "List all files",
       USectionFile::GET_FILE => "Get details of a file",

--- a/src/inc/defines/USectionGroup.php
+++ b/src/inc/defines/USectionGroup.php
@@ -14,7 +14,7 @@ class USectionGroup extends UApi {
   const REMOVE_AGENT = "removeAgent";
   const REMOVE_USER  = "removeUser";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionGroup::LIST_GROUPS => "List all groups",
       USectionGroup::GET_GROUP => "Get details of a group",

--- a/src/inc/defines/USectionHashlist.php
+++ b/src/inc/defines/USectionHashlist.php
@@ -19,7 +19,7 @@ class USectionHashlist extends UApi {
   const GET_HASH        = "getHash";
   const GET_CRACKED     = "getCracked";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionHashlist::LIST_HASLISTS => "List all hashlists",
       USectionHashlist::GET_HASHLIST => "Get details of a hashlist",

--- a/src/inc/defines/USectionPretask.php
+++ b/src/inc/defines/USectionPretask.php
@@ -16,7 +16,7 @@ class USectionPretask extends UApi {
   const SET_PRETASK_SMALL      = "setPretaskSmall";
   const DELETE_PRETASK         = "deletePretask";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionPretask::LIST_PRETASKS => "List all preconfigured tasks",
       USectionPretask::GET_PRETASK => "Get details about a preconfigured task",

--- a/src/inc/defines/USectionSuperhashlist.php
+++ b/src/inc/defines/USectionSuperhashlist.php
@@ -8,7 +8,7 @@ class USectionSuperhashlist extends UApi {
   const CREATE_SUPERHASHLIST = "createSuperhashlist";
   const DELETE_SUPERHASHLIST = "deleteSuperhashlist";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionSuperhashlist::LIST_SUPERHASHLISTS => "List all superhashlists",
       USectionSuperhashlist::GET_SUPERHASHLIST => "Get details about a superhashlist",

--- a/src/inc/defines/USectionSupertask.php
+++ b/src/inc/defines/USectionSupertask.php
@@ -11,7 +11,7 @@ class USectionSupertask extends UApi {
   const DELETE_SUPERTASK   = "deleteSupertask";
   const BULK_SUPERTASK     = "bulkSupertask";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionSupertask::LIST_SUPERTASKS => "List all supertasks",
       USectionSupertask::GET_SUPERTASK => "Get details of a supertask",

--- a/src/inc/defines/USectionTask.php
+++ b/src/inc/defines/USectionTask.php
@@ -34,7 +34,7 @@ class USectionTask extends UApi {
   const ARCHIVE_TASK      = "archiveTask";
   const ARCHIVE_SUPERTASK = "archiveSupertask";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionTask::LIST_TASKS => "List all tasks",
       USectionTask::GET_TASK => "Get details of a task",

--- a/src/inc/defines/USectionTest.php
+++ b/src/inc/defines/USectionTest.php
@@ -6,7 +6,7 @@ class USectionTest extends UApi {
   const CONNECTION = "connection";
   const ACCESS     = "access";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionTest::CONNECTION => "Connection testing",
       USectionTest::ACCESS => "Verifying the API key and test if user has access to the API",

--- a/src/inc/defines/USectionUser.php
+++ b/src/inc/defines/USectionUser.php
@@ -11,7 +11,7 @@ class USectionUser extends UApi {
   const SET_USER_PASSWORD    = "setUserPassword";
   const SET_USER_RIGHT_GROUP = "setUserRightGroup";
   
-  public function describe($constant) {
+  public function describe($constant): string {
     return match ($constant) {
       USectionUser::LIST_USERS => "List all users",
       USectionUser::GET_USER => "Get details of a user",

--- a/src/inc/handlers/AccessControlHandler.php
+++ b/src/inc/handlers/AccessControlHandler.php
@@ -13,7 +13,7 @@ class AccessControlHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle(string $action): void {
     try {
       switch ($action) {
         case DAccessControlAction::CREATE_GROUP:
@@ -23,11 +23,11 @@ class AccessControlHandler implements Handler {
           die();
         case DAccessControlAction::DELETE_GROUP:
           AccessControl::getInstance()->checkPermission(DAccessControlAction::DELETE_GROUP_PERM);
-          AccessControlUtils::deleteGroup($_POST['groupId']);
+          AccessControlUtils::deleteGroup(intval($_POST['groupId']));
           break;
         case DAccessControlAction::EDIT:
           AccessControl::getInstance()->checkPermission(DAccessControlAction::EDIT_PERM);
-          $changes = AccessControlUtils::updateGroupPermissions($_POST['groupId'], $_POST['perm']);
+          $changes = AccessControlUtils::updateGroupPermissions(intval($_POST['groupId']), $_POST['perm']);
           if ($changes) {
             UI::addMessage(UI::WARN, "NOTE: Some permissions were additionally allowed because of dependencies!");
           }

--- a/src/inc/handlers/AccessGroupHandler.php
+++ b/src/inc/handlers/AccessGroupHandler.php
@@ -13,7 +13,7 @@ class AccessGroupHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle(string $action): void {
     try {
       switch ($action) {
         case DAccessGroupAction::CREATE_GROUP:
@@ -23,23 +23,23 @@ class AccessGroupHandler implements Handler {
           die();
         case DAccessGroupAction::DELETE_GROUP:
           AccessControl::getInstance()->checkPermission(DAccessGroupAction::DELETE_GROUP_PERM);
-          AccessGroupUtils::deleteGroup($_POST['groupId']);
+          AccessGroupUtils::deleteGroup(intval($_POST['groupId']));
           break;
         case DAccessGroupAction::REMOVE_USER:
           AccessControl::getInstance()->checkPermission(DAccessGroupAction::REMOVE_USER_PERM);
-          AccessGroupUtils::removeUser($_POST['userId'], $_POST['groupId']);
+          AccessGroupUtils::removeUser(intval($_POST['userId']), intval($_POST['groupId']));
           break;
         case DAccessGroupAction::REMOVE_AGENT:
           AccessControl::getInstance()->checkPermission(DAccessGroupAction::REMOVE_AGENT_PERM);
-          AccessGroupUtils::removeAgent($_POST['agentId'], $_POST['groupId']);
+          AccessGroupUtils::removeAgent(intval($_POST['agentId']), intval($_POST['groupId']));
           break;
         case DAccessGroupAction::ADD_USER:
           AccessControl::getInstance()->checkPermission(DAccessGroupAction::ADD_USER_PERM);
-          AccessGroupUtils::addUser($_POST['userId'], $_POST['groupId']);
+          AccessGroupUtils::addUser(intval($_POST['userId']), intval($_POST['groupId']));
           break;
         case DAccessGroupAction::ADD_AGENT:
           AccessControl::getInstance()->checkPermission(DAccessGroupAction::ADD_AGENT_PERM);
-          AccessGroupUtils::addAgent($_POST['agentId'], $_POST['groupId']);
+          AccessGroupUtils::addAgent(intval($_POST['agentId']), intval($_POST['groupId']));
           break;
         default:
           UI::addMessage(UI::ERROR, "Invalid action!");

--- a/src/inc/handlers/AccountHandler.php
+++ b/src/inc/handlers/AccountHandler.php
@@ -25,7 +25,7 @@ class AccountHandler implements Handler {
     }
   }
   
-  public function handle($action) {
+  public function handle(string $action): void {
     try {
       switch ($action) {
         case DAccountAction::SET_EMAIL:

--- a/src/inc/handlers/AgentBinaryHandler.php
+++ b/src/inc/handlers/AgentBinaryHandler.php
@@ -15,7 +15,7 @@ class AgentBinaryHandler implements Handler {
     //nothing
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DAgentBinaryAction::NEW_BINARY:

--- a/src/inc/handlers/AgentHandler.php
+++ b/src/inc/handlers/AgentHandler.php
@@ -26,7 +26,7 @@ class AgentHandler implements Handler {
     }
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DAgentAction::CLEAR_ERRORS:

--- a/src/inc/handlers/ApiHandler.php
+++ b/src/inc/handlers/ApiHandler.php
@@ -12,7 +12,7 @@ class ApiHandler implements Handler {
     // nothing
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DApiAction::DELETE_GROUP:

--- a/src/inc/handlers/ConfigHandler.php
+++ b/src/inc/handlers/ConfigHandler.php
@@ -14,7 +14,7 @@ class ConfigHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DConfigAction::UPDATE_CONFIG:

--- a/src/inc/handlers/CrackerHandler.php
+++ b/src/inc/handlers/CrackerHandler.php
@@ -13,7 +13,7 @@ class CrackerHandler implements Handler {
     //nothing
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DCrackerBinaryAction::DELETE_BINARY_TYPE:

--- a/src/inc/handlers/FileHandler.php
+++ b/src/inc/handlers/FileHandler.php
@@ -13,7 +13,7 @@ class FileHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DFileAction::DELETE_FILE:

--- a/src/inc/handlers/ForgotHandler.php
+++ b/src/inc/handlers/ForgotHandler.php
@@ -12,7 +12,7 @@ class ForgotHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DForgotAction::RESET:

--- a/src/inc/handlers/Handler.php
+++ b/src/inc/handlers/Handler.php
@@ -5,5 +5,9 @@ namespace Hashtopolis\inc\handlers;
 interface Handler {
   public function __construct($id);
   
-  public function handle($action);
+  /**
+   * @param string $action
+   * @return void
+   */
+  public function handle(string $action): void;
 }

--- a/src/inc/handlers/HashlistHandler.php
+++ b/src/inc/handlers/HashlistHandler.php
@@ -30,7 +30,7 @@ class HashlistHandler implements Handler {
     }
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DHashlistAction::APPLY_PRECONFIGURED_TASKS:

--- a/src/inc/handlers/HashtypeHandler.php
+++ b/src/inc/handlers/HashtypeHandler.php
@@ -13,7 +13,7 @@ class HashtypeHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DHashtypeAction::DELETE_HASHTYPE:

--- a/src/inc/handlers/HealthHandler.php
+++ b/src/inc/handlers/HealthHandler.php
@@ -14,7 +14,7 @@ class HealthHandler implements Handler {
     //nothing to do
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DHealthCheckAction::CREATE:

--- a/src/inc/handlers/NotificationHandler.php
+++ b/src/inc/handlers/NotificationHandler.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\handlers;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\DataSet;
@@ -55,8 +56,9 @@ class NotificationHandler implements Handler {
   /**
    * @param $action
    * @param $payload DataSet
+   * @throws Exception
    */
-  public static function checkNotifications($action, $payload) {
+  public static function checkNotifications($action, DataSet $payload): void {
     $qF1 = new QueryFilter(NotificationSetting::ACTION, $action, "=");
     $qF2 = new QueryFilter(NotificationSetting::IS_ACTIVE, "1", "=");
     $notifications = Factory::getNotificationSettingFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);

--- a/src/inc/handlers/NotificationHandler.php
+++ b/src/inc/handlers/NotificationHandler.php
@@ -27,7 +27,7 @@ class NotificationHandler implements Handler {
     // nothing required here
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DNotificationAction::CREATE_NOTIFICATION:

--- a/src/inc/handlers/PreprocessorHandler.php
+++ b/src/inc/handlers/PreprocessorHandler.php
@@ -13,7 +13,7 @@ class PreprocessorHandler implements Handler {
     //nothing
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DPreprocessorAction::ADD_PREPROCESSOR:

--- a/src/inc/handlers/PretaskHandler.php
+++ b/src/inc/handlers/PretaskHandler.php
@@ -59,7 +59,7 @@ class PretaskHandler implements Handler {
           break;
         case DPretaskAction::CREATE_TASK:
           AccessControl::getInstance()->checkPermission(DPretaskAction::CREATE_TASK_PERM);
-          PretaskUtils::createPretask($_POST['name'], $_POST['cmdline'], $_POST['chunk'], $_POST['status'], $_POST['color'], $_POST['cpuOnly'], $_POST['isSmall'], $_POST['benchType'], $_POST['adfile'], $_POST['crackerBinaryTypeId'], $_POST['maxAgents']);
+          PretaskUtils::createPretask($_POST['name'], $_POST['cmdline'], $_POST['chunk'], $_POST['status'], $_POST['color'], $_POST['cpuOnly'], $_POST['isSmall'], $_POST['benchType'], @$_POST['adfile'], $_POST['crackerBinaryTypeId'], 0);
           header("Location: pretasks.php");
           die();
         case DPretaskAction::CHANGE_ATTACK:

--- a/src/inc/handlers/PretaskHandler.php
+++ b/src/inc/handlers/PretaskHandler.php
@@ -13,7 +13,7 @@ class PretaskHandler implements Handler {
     //we need nothing to load
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DPretaskAction::DELETE_PRETASK:

--- a/src/inc/handlers/SearchHandler.php
+++ b/src/inc/handlers/SearchHandler.php
@@ -53,7 +53,7 @@ class SearchHandler implements Handler {
     $query = explode("\n", $query);
     $resultEntries = array();
     $hashlists = new DataSet();
-    $userHashlists = HashlistUtils::getHashlists(Login::getInstance()->getUser(), false);
+    $userHashlists = HashlistUtils::getHashlists(Login::getInstance()->getUser());
     $userHashlists += HashlistUtils::getHashlists(Login::getInstance()->getUser(), true);
     foreach ($query as $queryEntry) {
       if (strlen($queryEntry) == 0) {

--- a/src/inc/handlers/SearchHandler.php
+++ b/src/inc/handlers/SearchHandler.php
@@ -108,7 +108,7 @@ class SearchHandler implements Handler {
           /** @var Hash $hash */
           $hash = $joined[Factory::getHashFactory()->getModelName()][$i];
           $matches[] = $hash;
-          if ($hashlists->getVal($hash->getHashlistId()) == false) {
+          if ($hashlists->getVal($hash->getHashlistId()) == null) {
             $hashlists->addValue($hash->getHashlistId(), $joined[Factory::getHashlistFactory()->getModelName()][$i]);
           }
         }

--- a/src/inc/handlers/SearchHandler.php
+++ b/src/inc/handlers/SearchHandler.php
@@ -24,7 +24,7 @@ class SearchHandler implements Handler {
     // nothing
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DSearchAction::SEARCH:

--- a/src/inc/handlers/SupertaskHandler.php
+++ b/src/inc/handlers/SupertaskHandler.php
@@ -14,7 +14,7 @@ class SupertaskHandler implements Handler {
     //nothing
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DSupertaskAction::DELETE_SUPERTASK:

--- a/src/inc/handlers/TaskHandler.php
+++ b/src/inc/handlers/TaskHandler.php
@@ -42,7 +42,7 @@ class TaskHandler implements Handler {
     }
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DTaskAction::SET_BENCHMARK:

--- a/src/inc/handlers/TaskHandler.php
+++ b/src/inc/handlers/TaskHandler.php
@@ -237,10 +237,6 @@ class TaskHandler implements Handler {
       UI::addMessage(UI::ERROR, "Non-matching cracker binary selection!");
       return;
     }
-    else if ($hashlist == null) {
-      UI::addMessage(UI::ERROR, "Invalid hashlist selected!");
-      return;
-    }
     else if ($chunk < 0 || $status < 0 || $chunk < $status) {
       UI::addMessage(UI::ERROR, "Chunk time must be higher than status timer!");
       return;
@@ -275,7 +271,7 @@ class TaskHandler implements Handler {
       $name = "HL" . $hashlistId . "_" . date("Ymd_Hi");
     }
     $forward = "tasks.php";
-    if ($hashlistId != null && $hashlist->getHexSalt() == 1 && strpos($cmdline, "--hex-salt") === false) {
+    if ($hashlistId != null && $hashlist->getHexSalt() == 1 && !str_contains($cmdline, "--hex-salt")) {
       $cmdline = "--hex-salt $cmdline"; // put the --hex-salt if the user was not clever enough to put it there :D
     }
     

--- a/src/inc/handlers/TaskHandler.php
+++ b/src/inc/handlers/TaskHandler.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\handlers;
 
+use Exception;
 use Hashtopolis\inc\utils\AccessControl;
 use Hashtopolis\inc\DataSet;
 use Throwable;
@@ -157,6 +158,7 @@ class TaskHandler implements Handler {
   
   /**
    * @throws HTException
+   * @throws Exception
    */
   private function create() {
     // new task creator
@@ -199,7 +201,7 @@ class TaskHandler implements Handler {
       PreprocessorUtils::getPreprocessor($usePreprocessor);
     }
     
-    if (strpos($cmdline, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
+    if (!str_contains($cmdline, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS) ?? "")) {
       UI::addMessage(UI::ERROR, "Command line must contain hashlist (" . SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS) . ")!");
       return;
     }

--- a/src/inc/handlers/UsersHandler.php
+++ b/src/inc/handlers/UsersHandler.php
@@ -14,7 +14,7 @@ class UsersHandler implements Handler {
     //nothing to do
   }
   
-  public function handle($action) {
+  public function handle($action): void {
     try {
       switch ($action) {
         case DUserAction::DELETE_USER:

--- a/src/inc/notifications/HashtopolisNotification.php
+++ b/src/inc/notifications/HashtopolisNotification.php
@@ -13,12 +13,12 @@ use Hashtopolis\inc\UI;
 use Hashtopolis\inc\Util;
 
 abstract class HashtopolisNotification {
-  public static $name;
-  protected     $receiver;
+  public static string $name;
+  protected     string $receiver;
   
   protected NotificationSetting $notification;
   
-  private static $instances = [];
+  private static array $instances = [];
   
   private static function loadInstances(): void {
     // TODO: find a better way to load these automatically, failed to do it with the classloader and scanning
@@ -56,7 +56,7 @@ abstract class HashtopolisNotification {
    * @param $payload DataSet
    * @param $notification NotificationSetting
    */
-  public function execute($notificationType, $payload, $notification) {
+  public function execute(string $notificationType, DataSet $payload, NotificationSetting $notification): void {
     $this->receiver = $notification->getReceiver();
     $this->notification = $notification;
     $template = new Template($this->getTemplateName());
@@ -139,7 +139,7 @@ abstract class HashtopolisNotification {
       case DNotificationType::USER_LOGIN_FAILED:
         $user = $payload->getVal(DPayloadKeys::USER);
         $obj['message'] = "User '" . $user->getUsername() . "' (" . $user->getId() . ") failed to login due to wrong password";
-        $obj['html'] = "User <a href='" . Util::buildServerUrl() . SConfig::getInstance()->getVal(DConfig::BASE_URL) . "/users.php?id=" . $user->getId() . "'>" . $user->getUsername() . "</a> failed to login due to wrong password";
+        $obj['html'] = "User <a href='" . Util::buildServerUrl() . SConfig::getInstance()->getVal(DConfig::BASE_URL) . "/users.php?id=" . $user->getId() . "'>" . $user->getUsername() . "</a> failed to log in due to wrong password";
         $obj['simplified'] = "User <" . Util::buildServerUrl() . SConfig::getInstance()->getVal(DConfig::BASE_URL) . "/users.php?id=" . $user->getId() . "|" . $user->getUsername() . "> failed to login due to wrong password";
         $subject .= "user failed to log in";
         break;

--- a/src/inc/notifications/HashtopolisNotification.php
+++ b/src/inc/notifications/HashtopolisNotification.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\notifications;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\dba\models\NotificationSetting;
 use Hashtopolis\inc\defines\DConfig;
@@ -55,6 +56,7 @@ abstract class HashtopolisNotification {
    * @param $notificationType string
    * @param $payload DataSet
    * @param $notification NotificationSetting
+   * @throws Exception
    */
   public function execute(string $notificationType, DataSet $payload, NotificationSetting $notification): void {
     $this->receiver = $notification->getReceiver();

--- a/src/inc/notifications/HashtopolisNotificationChatBot.php
+++ b/src/inc/notifications/HashtopolisNotificationChatBot.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\notifications;
 
+use Exception;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
@@ -18,6 +19,9 @@ class HashtopolisNotificationChatBot extends HashtopolisNotification {
     return array();
   }
   
+  /**
+   * @throws Exception
+   */
   function sendMessage($message, $subject = ""): bool|string {
     $username = APP_NAME;
     $data = "payload=" . json_encode(array(

--- a/src/inc/notifications/HashtopolisNotificationChatBot.php
+++ b/src/inc/notifications/HashtopolisNotificationChatBot.php
@@ -7,18 +7,18 @@ use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
 
 class HashtopolisNotificationChatBot extends HashtopolisNotification {
-  protected     $receiver;
-  public static $name = "ChatBot";
+  protected string     $receiver;
+  public static string $name = "ChatBot";
   
-  function getTemplateName() {
+  function getTemplateName(): string {
     return "notifications/chatbot";
   }
   
-  function getObjects() {
+  function getObjects(): array {
     return array();
   }
   
-  function sendMessage($message, $subject = "") {
+  function sendMessage($message, $subject = ""): bool|string {
     $username = APP_NAME;
     $data = "payload=" . json_encode(array(
           "username" => $username,

--- a/src/inc/notifications/HashtopolisNotificationDiscordWebhook.php
+++ b/src/inc/notifications/HashtopolisNotificationDiscordWebhook.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\notifications;
 
+use Exception;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
@@ -18,6 +19,9 @@ class HashtopolisNotificationDiscordWebhook extends HashtopolisNotification {
     return array();
   }
   
+  /**
+   * @throws Exception
+   */
   function sendMessage($message, $subject = ""): bool|string {
     $json_data = array(
       "content" => $message

--- a/src/inc/notifications/HashtopolisNotificationDiscordWebhook.php
+++ b/src/inc/notifications/HashtopolisNotificationDiscordWebhook.php
@@ -7,18 +7,18 @@ use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
 
 class HashtopolisNotificationDiscordWebhook extends HashtopolisNotification {
-  protected     $receiver;
-  public static $name = "Discord Webhook";
+  protected string     $receiver;
+  public static string $name = "Discord Webhook";
   
-  function getTemplateName() {
+  function getTemplateName(): string {
     return "notifications/discord";
   }
   
-  function getObjects() {
+  function getObjects(): array {
     return array();
   }
   
-  function sendMessage($message, $subject = "") {
+  function sendMessage($message, $subject = ""): bool|string {
     $json_data = array(
       "content" => $message
     );

--- a/src/inc/notifications/HashtopolisNotificationEmail.php
+++ b/src/inc/notifications/HashtopolisNotificationEmail.php
@@ -6,20 +6,20 @@ use Hashtopolis\inc\Util;
 use RuntimeException;
 
 class HashtopolisNotificationEmail extends HashtopolisNotification {
-  protected     $receiver;
-  public static $name = "Email";
+  protected string     $receiver;
+  public static string $name = "Email";
   
-  function getTemplateName() {
+  function getTemplateName(): string {
     return "notifications/email";
   }
   
-  function getObjects() {
+  function getObjects(): array {
     $obj = array();
     $obj['username'] = Util::getUsernameById($this->notification->getUserId());
     return $obj;
   }
   
-  function sendMessage($message, $subject) {
+  function sendMessage($message, $subject): void {
     $message = explode("##########", $message);
     if (Util::isMailConfigured() && !Util::sendMail($this->receiver, $subject, $message[0], $message[1])) {
       throw new RuntimeException("Unable to send notification mail with subject: " . $subject);

--- a/src/inc/notifications/HashtopolisNotificationEmail.php
+++ b/src/inc/notifications/HashtopolisNotificationEmail.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\notifications;
 
+use Exception;
 use Hashtopolis\inc\Util;
 use RuntimeException;
 
@@ -13,12 +14,18 @@ class HashtopolisNotificationEmail extends HashtopolisNotification {
     return "notifications/email";
   }
   
+  /**
+   * @throws Exception
+   */
   function getObjects(): array {
     $obj = array();
     $obj['username'] = Util::getUsernameById($this->notification->getUserId());
     return $obj;
   }
   
+  /**
+   * @throws Exception
+   */
   function sendMessage($message, $subject): void {
     $message = explode("##########", $message);
     if (Util::isMailConfigured() && !Util::sendMail($this->receiver, $subject, $message[0], $message[1])) {

--- a/src/inc/notifications/HashtopolisNotificationExample.php
+++ b/src/inc/notifications/HashtopolisNotificationExample.php
@@ -3,18 +3,18 @@
 namespace Hashtopolis\inc\notifications;
 
 class HashtopolisNotificationExample extends HashtopolisNotification {
-  protected     $receiver;
-  public static $name = "Example";
+  protected string     $receiver;
+  public static string $name = "Example";
   
-  function getTemplateName() {
+  function getTemplateName(): string {
     return "notifications/example";
   }
   
-  function getObjects() {
+  function getObjects(): array {
     return array();
   }
   
-  function sendMessage($message, $subject = "") {
+  function sendMessage($message, $subject = ""): void {
     file_put_contents(dirname(__FILE__) . "/notification.log", "MSG TO " . $this->receiver . ": " . $message . "\n", FILE_APPEND);
   }
 }

--- a/src/inc/notifications/HashtopolisNotificationSlack.php
+++ b/src/inc/notifications/HashtopolisNotificationSlack.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\notifications;
 
+use Exception;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
@@ -18,6 +19,9 @@ class HashtopolisNotificationSlack extends HashtopolisNotification {
     return array();
   }
   
+  /**
+   * @throws Exception
+   */
   function sendMessage($message, $subject = ""): bool|string {
     $data = json_encode(array("text" => $message));
     

--- a/src/inc/notifications/HashtopolisNotificationSlack.php
+++ b/src/inc/notifications/HashtopolisNotificationSlack.php
@@ -7,18 +7,18 @@ use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
 
 class HashtopolisNotificationSlack extends HashtopolisNotification {
-  protected     $receiver;
-  public static $name = "Slack";
+  protected string     $receiver;
+  public static string $name = "Slack";
   
-  function getTemplateName() {
+  function getTemplateName(): string {
     return "notifications/slack";
   }
   
-  function getObjects() {
+  function getObjects(): array {
     return array();
   }
   
-  function sendMessage($message, $subject = "") {
+  function sendMessage($message, $subject = ""): bool|string {
     $data = json_encode(array("text" => $message));
     
     $ch = curl_init($this->receiver);

--- a/src/inc/notifications/HashtopolisNotificationTelegram.php
+++ b/src/inc/notifications/HashtopolisNotificationTelegram.php
@@ -7,25 +7,25 @@ use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
 
 class HashtopolisNotificationTelegram extends HashtopolisNotification {
-  protected     $receiver;
-  public static $name = "Telegram";
+  protected string     $receiver;
+  public static string $name = "Telegram";
   
-  function getTemplateName() {
+  function getTemplateName(): string {
     return "notifications/telegram";
   }
   
-  function getObjects() {
+  function getObjects(): array {
     return array();
   }
   
-  function sendMessage($message, $subject = "") {
+  function sendMessage($message, $subject = ""): bool|string {
     $botToken = SConfig::getInstance()->getVal(DConfig::TELEGRAM_BOT_TOKEN);
     $data = array(
       "chat_id" => $this->receiver,
       "text" => $message
     );
     
-    $ch = curl_init("https://api.telegram.org/bot{$botToken}/sendMessage");
+    $ch = curl_init("https://api.telegram.org/bot$botToken/sendMessage");
     
     if (SConfig::getInstance()->getVal(DConfig::NOTIFICATIONS_PROXY_ENABLE) == 1) {
       curl_setopt($ch, CURLOPT_PROXY, SConfig::getInstance()->getVal(DConfig::NOTIFICATIONS_PROXY_SERVER));

--- a/src/inc/notifications/HashtopolisNotificationTelegram.php
+++ b/src/inc/notifications/HashtopolisNotificationTelegram.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\notifications;
 
+use Exception;
 use Hashtopolis\inc\defines\DConfig;
 use Hashtopolis\inc\defines\DProxyTypes;
 use Hashtopolis\inc\SConfig;
@@ -18,6 +19,9 @@ class HashtopolisNotificationTelegram extends HashtopolisNotification {
     return array();
   }
   
+  /**
+   * @throws Exception
+   */
   function sendMessage($message, $subject = ""): bool|string {
     $botToken = SConfig::getInstance()->getVal(DConfig::TELEGRAM_BOT_TOKEN);
     $data = array(

--- a/src/inc/templating/Template.php
+++ b/src/inc/templating/Template.php
@@ -309,9 +309,9 @@ class Template {
     return array($statements, strlen($content));
   }
   
-  private function resolveDependencies() {
+  private function resolveDependencies(): bool {
     //include all templates
-    preg_match_all('/\{\%(.*?)\%\}/mis', $this->content, $matches, PREG_PATTERN_ORDER);
+    preg_match_all('/\{%(.*?)%}/mis', $this->content, $matches, PREG_PATTERN_ORDER);
     
     for ($x = 0; $x < sizeof($matches[0]); $x++) {
       $command = explode("->", $matches[1][$x]); //just the command

--- a/src/inc/user_api/UserAPIAgent.php
+++ b/src/inc/user_api/UserAPIAgent.php
@@ -278,7 +278,7 @@ class UserAPIAgent extends UserAPIBasic {
     $binaries = Factory::getAgentBinaryFactory()->filter([]);
     foreach ($binaries as $binary) {
       $arr[] = array(
-        UResponseAgent::BINARIES_NAME => $binary->getBinayType(),
+        UResponseAgent::BINARIES_NAME => $binary->getBinaryType(),
         UResponseAgent::BINARIES_OS => $binary->getOperatingSystems(),
         UResponseAgent::BINARIES_URL => $baseUrl . $binary->getId(),
         UResponseAgent::BINARIES_VERSION => $binary->getVersion(),

--- a/src/inc/user_api/UserAPIAgent.php
+++ b/src/inc/user_api/UserAPIAgent.php
@@ -2,8 +2,10 @@
 
 namespace Hashtopolis\inc\user_api;
 
+use Hashtopolis\inc\apiv2\error\HttpConflict;
 use Hashtopolis\inc\utils\AccessUtils;
 use Hashtopolis\inc\utils\AgentUtils;
+use Random\RandomException;
 use Throwable;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\ContainFilter;

--- a/src/inc/utils/AccessControl.php
+++ b/src/inc/utils/AccessControl.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\RightGroup;
@@ -10,15 +11,16 @@ use Hashtopolis\inc\Login;
 use Hashtopolis\inc\UI;
 
 class AccessControl {
-  private ?User $user = null;
+  private ?User $user;
   private ?RightGroup $rightGroup = null;
   
   private static ?self $instance = null;
   
   /**
-   * @param User $user
+   * @param ?User $user
    * @param int $groupId
    * @return AccessControl
+   * @throws Exception
    */
   public static function getInstance(?User $user = null, int $groupId = 0): self {
     if ($user != null || $groupId != 0) {
@@ -31,7 +33,7 @@ class AccessControl {
   }
   
   /**
-   * @return User
+   * @return ?User
    */
   public function getUser(): ?User {
     return $this->user;
@@ -39,8 +41,9 @@ class AccessControl {
   
   /**
    * AccessControl constructor.
-   * @param $user User
+   * @param $user ?User
    * @param $groupId int
+   * @throws Exception
    */
   private function __construct(?User $user = null, int $groupId = 0) {
     $this->user = $user;
@@ -54,6 +57,7 @@ class AccessControl {
   
   /**
    * Force a reload of the permissions from the database
+   * @throws Exception
    */
   public function reload(): void {
     if ($this->user != null) {
@@ -110,7 +114,7 @@ class AccessControl {
     }
     $json = json_decode($this->rightGroup->getPermissions(), true);
     foreach ($perm as $p) {
-      if (isset($json[$p]) && $json[$p] == true) {
+      if (isset($json[$p]) && $json[$p]) {
         return true;
       }
     }

--- a/src/inc/utils/AccessControlUtils.php
+++ b/src/inc/utils/AccessControlUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\models\RightGroup;
@@ -16,6 +17,7 @@ class AccessControlUtils {
   /**
    * @param int $groupId
    * @return User[]
+   * @throws Exception
    */
   public static function getMembers(int $groupId): array {
     $qF = new QueryFilter(User::RIGHT_GROUP_ID, $groupId, "=");
@@ -24,6 +26,7 @@ class AccessControlUtils {
   
   /**
    * @return RightGroup[]
+   * @throws Exception
    */
   public static function getGroups(): array {
     return Factory::getRightGroupFactory()->filter([]);
@@ -31,6 +34,7 @@ class AccessControlUtils {
   
   /**
    * @throws HTException
+   * @throws Exception
    */
   public static function addToPermissions(int $groupId, array $perm): void {
     $group = AccessControlUtils::getGroup($groupId);
@@ -49,6 +53,7 @@ class AccessControlUtils {
    * @param array $perm - Array of strings, permission-1|0
    * @return boolean
    * @throws HTException
+   * @throws Exception
    */
   public static function updateGroupPermissions(int $groupId, array $perm): bool {
     $group = AccessControlUtils::getGroup($groupId);
@@ -96,6 +101,7 @@ class AccessControlUtils {
    * @return RightGroup
    * @throws HttpError
    * @throws HttpConflict
+   * @throws Exception
    */
   public static function createGroup(string $groupName): RightGroup {
     if (strlen($groupName) == 0 || strlen($groupName) > DLimits::ACCESS_GROUP_MAX_LENGTH) {
@@ -115,6 +121,7 @@ class AccessControlUtils {
    * @param int $groupId
    * @throws HttpError
    * @throws HTException
+   * @throws Exception
    */
   public static function deleteGroup(int $groupId): void {
     $group = AccessControlUtils::getGroup($groupId);
@@ -132,6 +139,7 @@ class AccessControlUtils {
    * @param int $groupId
    * @return RightGroup
    * @throws HTException
+   * @throws Exception
    */
   public static function getGroup(int $groupId): RightGroup {
     $group = Factory::getRightGroupFactory()->get($groupId);

--- a/src/inc/utils/AccessGroupUtils.php
+++ b/src/inc/utils/AccessGroupUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\AccessGroup;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\dba\ContainFilter;
@@ -25,6 +26,7 @@ class AccessGroupUtils {
   /**
    * @param int $groupId
    * @return AccessGroupUser[]
+   * @throws Exception
    */
   public static function getUsers(int $groupId): array {
     $qF = new QueryFilter(AccessGroupUser::ACCESS_GROUP_ID, $groupId, "=");
@@ -34,6 +36,7 @@ class AccessGroupUtils {
   /**
    * @param int $groupId
    * @return AccessGroupAgent[]
+   * @throws Exception
    */
   public static function getAgents(int $groupId): array {
     $qF = new QueryFilter(AccessGroupAgent::ACCESS_GROUP_ID, $groupId, "=");
@@ -42,6 +45,7 @@ class AccessGroupUtils {
   
   /**
    * @return AccessGroup[]
+   * @throws Exception
    */
   public static function getGroups(): array {
     return Factory::getAccessGroupFactory()->filter([]);
@@ -52,6 +56,7 @@ class AccessGroupUtils {
    * @return AccessGroup
    * @throws HttpError
    * @throws HttpConflict
+   * @throws Exception
    */
   public static function createGroup(string $groupName): AccessGroup {
     if (strlen($groupName) == 0 || strlen($groupName) > DLimits::ACCESS_GROUP_MAX_LENGTH) {
@@ -64,12 +69,12 @@ class AccessGroupUtils {
       throw new HttpConflict("There is already an access group with the same name!");
     }
     $group = new AccessGroup(null, $groupName);
-    $group = Factory::getAccessGroupFactory()->save($group);
-    return $group;
+    return Factory::getAccessGroupFactory()->save($group);
   }
   
   /**
    * @throws HTException
+   * @throws Exception
    */
   public static function rename(int $accessGroupId, string $newname): void {
     $accessGroup = AccessGroupUtils::getGroup($accessGroupId);
@@ -82,8 +87,9 @@ class AccessGroupUtils {
   
   /**
    * @param int $groupId
-   * @param $user
+   * @param User $user
    * @throws HTException
+   * @throws Exception
    */
   public static function abortChunksGroup(int $groupId, User $user): void {
     $accessGroups = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
@@ -107,6 +113,7 @@ class AccessGroupUtils {
    * @param int $agentId
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
   public static function addAgent(int $agentId, int $groupId): void {
     $group = AccessGroupUtils::getGroup($groupId);
@@ -127,6 +134,7 @@ class AccessGroupUtils {
    * @param int $userId
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
   public static function addUser(int $userId, int $groupId): void {
     $group = AccessGroupUtils::getGroup($groupId);
@@ -147,6 +155,7 @@ class AccessGroupUtils {
    * @param int $agentId
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
   public static function removeAgent(int $agentId, int $groupId): void {
     $group = AccessGroupUtils::getGroup($groupId);
@@ -165,6 +174,7 @@ class AccessGroupUtils {
    * @param int $userId
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
   public static function removeUser(int $userId, int $groupId): void {
     $group = AccessGroupUtils::getGroup($groupId);
@@ -182,6 +192,7 @@ class AccessGroupUtils {
   /**
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
   public static function deleteGroup(int $groupId): void {
     $group = AccessGroupUtils::getGroup($groupId);
@@ -221,6 +232,7 @@ class AccessGroupUtils {
    * @param int $groupId
    * @return AccessGroup
    * @throws HTException
+   * @throws Exception
    */
   public static function getGroup(int $groupId): AccessGroup {
     $group = Factory::getAccessGroupFactory()->get($groupId);

--- a/src/inc/utils/AccessUtils.php
+++ b/src/inc/utils/AccessUtils.php
@@ -23,6 +23,7 @@ class AccessUtils {
    * @param Hashlist[]|Hashlist $hashlists
    * @param User $user
    * @return boolean
+   * @throws Exception
    */
   public static function userCanAccessHashlists(Hashlist|array $hashlists, User $user): bool {
     if (!is_array($hashlists)) {
@@ -95,6 +96,7 @@ class AccessUtils {
    * @param TaskWrapper $taskWrapper
    * @param User $user
    * @return boolean
+   * @throws Exception
    */
   public static function userCanAccessTask(TaskWrapper $taskWrapper, User $user): bool {
     $accessGroupIds = Util::getAccessGroupIds($user->getId());
@@ -108,6 +110,7 @@ class AccessUtils {
    * @param File $file
    * @param User $user
    * @return boolean
+   * @throws Exception
    */
   public static function userCanAccessFile(File $file, User $user): bool {
     $accessGroupIds = Util::getAccessGroupIds($user->getId());

--- a/src/inc/utils/AccessUtils.php
+++ b/src/inc/utils/AccessUtils.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
-use Hashtopolis\dba\AbstractModel;
+use Exception;
 use Hashtopolis\dba\models\AccessGroup;
 use Hashtopolis\dba\models\AccessGroupAgent;
 use Hashtopolis\dba\models\AccessGroupUser;
@@ -73,6 +73,7 @@ class AccessUtils {
    * @param $agent Agent
    * @param $user User
    * @return bool true if user has access to agent
+   * @throws Exception
    */
   public static function userCanAccessAgent(Agent $agent, User $user): bool {
     $qF = new QueryFilter(AccessGroupAgent::AGENT_ID, $agent->getId(), "=", Factory::getAccessGroupAgentFactory());
@@ -140,6 +141,7 @@ class AccessUtils {
   /**
    * @param $user User
    * @return AccessGroup[]
+   * @throws Exception
    */
   public static function getAccessGroupsOfUser(User $user): array {
     $qF = new QueryFilter(AccessGroupUser::USER_ID, $user->getId(), "=", Factory::getAccessGroupUserFactory());
@@ -151,6 +153,7 @@ class AccessUtils {
   /**
    * @param Agent $agent
    * @return AccessGroup[]
+   * @throws Exception
    */
   public static function getAccessGroupsOfAgent(Agent $agent): array {
     $qF = new QueryFilter(AccessGroupAgent::AGENT_ID, $agent->getId(), "=", Factory::getAccessGroupAgentFactory());
@@ -163,6 +166,7 @@ class AccessUtils {
    * Gets the first access group (which is the default access group. If it does not exist, it created the default access group.
    *
    * @return AccessGroup
+   * @throws Exception
    */
   public static function getOrCreateDefaultAccessGroup(): AccessGroup {
     $accessGroup = Factory::getAccessGroupFactory()->get(1);
@@ -178,6 +182,7 @@ class AccessUtils {
    * @param $agent Agent
    * @param $task Task
    * @return bool true if agent is allowed to access task
+   * @throws Exception
    */
   public static function agentCanAccessTask(Agent $agent, Task $task): bool {
     // load access groups of agent

--- a/src/inc/utils/AccountUtils.php
+++ b/src/inc/utils/AccountUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\Encryption;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\Factory;
@@ -16,6 +17,7 @@ use Hashtopolis\inc\Util;
 class AccountUtils {
   /**
    * @param User $user
+   * @throws Exception
    */
   public static function checkOTP(User $user): void {
     $isValid = false;
@@ -39,11 +41,12 @@ class AccountUtils {
   }
   
   /**
-   * @param $num
-   * @param $action
-   * @param $user User
-   * @param $otpArr
+   * @param int $num
+   * @param string $action
+   * @param User $user
+   * @param array $otpArr
    * @throws HTException
+   * @throws Exception
    */
   public static function setOTP(int $num, string $action, User $user, array $otpArr): void {
     if ($action == DAccountAction::YUBIKEY_ENABLE) {
@@ -103,6 +106,7 @@ class AccountUtils {
    * @param string $email
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
   public static function setEmail(string $email, User $user): void {
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -117,9 +121,9 @@ class AccountUtils {
    * @param int $lifetime
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
   public static function updateSessionLifetime(int $lifetime, User $user): void {
-    $lifetime = intval($lifetime);
     if ($lifetime < 60 || $lifetime > SConfig::getInstance()->getVal(DConfig::MAX_SESSION_LENGTH) * 3600) {
       throw new HTException("Lifetime must be larger than 1 minute and smaller than " . SConfig::getInstance()->getVal(DConfig::MAX_SESSION_LENGTH) . " hours!");
     }
@@ -133,6 +137,7 @@ class AccountUtils {
    * @param string $repeatedPassword
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
   public static function changePassword(string $oldPassword, string $newPassword, string $repeatedPassword, User $user): void {
     if (!Encryption::passwordVerify($oldPassword, $user->getPasswordSalt(), $user->getPasswordHash())) {

--- a/src/inc/utils/AgentBinaryUtils.php
+++ b/src/inc/utils/AgentBinaryUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\AgentBinary;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\models\User;
@@ -23,6 +24,7 @@ class AgentBinaryUtils {
    * @param User $user
    * @return AgentBinary
    * @throws HttpError
+   * @throws Exception
    */
   public static function newBinary(string $type, string $os, string $filename, string $version, string $updateTrack, User $user): AgentBinary {
     if (strlen($version) == 0) {
@@ -52,8 +54,9 @@ class AgentBinaryUtils {
    * @param string $updateTrack
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function editBinary($binaryId, $type, $os, $filename, $version, $updateTrack, $user) {
+  public static function editBinary(int $binaryId, string $type, string $os, string $filename, string $version, string $updateTrack, User $user): void {
     if (strlen($version) == 0) {
       throw new HTException("Version cannot be empty!");
     }
@@ -84,7 +87,11 @@ class AgentBinaryUtils {
     Util::createLogEntry(DLogEntryIssuer::USER, $user->getId(), DLogEntry::INFO, "Binary " . $agentBinary->getFilename() . " was updated!");
   }
   
-  public static function editUpdateTracker($binaryId, $updateTracker, $user) {
+  /**
+   * @throws HTException
+   * @throws Exception
+   */
+  public static function editUpdateTracker($binaryId, $updateTracker, $user): void {
     $binary = AgentBinaryUtils::getBinary($binaryId);
     if ($updateTracker != $binary->getUpdateTrack()) {
       $binary = Factory::getAgentBinaryFactory()->mset($binary, [
@@ -99,7 +106,11 @@ class AgentBinaryUtils {
     Util::createLogEntry(DLogEntryIssuer::USER, $user->getId(), DLogEntry::INFO, "Binary " . $binary->getFilename() . " was updated!");
   }
   
-  public static function editName($binaryId, $filename, $user) {
+  /**
+   * @throws HTException
+   * @throws Exception
+   */
+  public static function editName($binaryId, $filename, $user): void {
     if (!file_exists(dirname(__FILE__) . "/../../bin/" . basename($filename))) {
       throw new HTException("Provided filename does not exist!");
     }
@@ -108,7 +119,11 @@ class AgentBinaryUtils {
     Util::createLogEntry(DLogEntryIssuer::USER, $user->getId(), DLogEntry::INFO, "Binary " . $agentBinary->getFilename() . " was updated!");
   }
   
-  public static function editType($binaryId, $type, $user) {
+  /**
+   * @throws HTException
+   * @throws Exception
+   */
+  public static function editType($binaryId, $type, $user): void {
     $agentBinary = AgentBinaryUtils::getBinary($binaryId);
     
     $qF1 = new QueryFilter(AgentBinary::BINARY_TYPE, $type, "=");
@@ -124,8 +139,9 @@ class AgentBinaryUtils {
   /**
    * @param int $binaryId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteBinary($binaryId) {
+  public static function deleteBinary(int $binaryId): void {
     $agentBinary = AgentBinaryUtils::getBinary($binaryId);
     Factory::getAgentBinaryFactory()->delete($agentBinary);
     unlink(dirname(__FILE__) . "/../../bin/" . $agentBinary->getFilename());
@@ -135,8 +151,9 @@ class AgentBinaryUtils {
    * @param int $binaryId
    * @return AgentBinary
    * @throws HTException
+   * @throws Exception
    */
-  public static function getBinary($binaryId) {
+  public static function getBinary(int $binaryId): AgentBinary {
     $agentBinary = Factory::getAgentBinaryFactory()->get($binaryId);
     if ($agentBinary == null) {
       throw new HTException("Binary does not exist!");
@@ -147,8 +164,9 @@ class AgentBinaryUtils {
   /**
    * @param int $binaryId
    * @throws HTException
+   * @throws Exception
    */
-  public static function executeUpgrade($binaryId) {
+  public static function executeUpgrade(int $binaryId): void {
     $agentBinary = AgentBinaryUtils::getBinary($binaryId);
     // check if there is really an update available
     if (!AgentBinaryUtils::checkUpdate($binaryId)) {
@@ -179,18 +197,19 @@ class AgentBinaryUtils {
     }
     
     // update version number of agent and reset flag
-    $agentBinary = Factory::getAgentBinaryFactory()->mset($agentBinary, [AgentBinary::VERSION => $agentBinary->getUpdateAvailable(), AgentBinary::UPDATE_AVAILABLE => '']);
+    Factory::getAgentBinaryFactory()->mset($agentBinary, [AgentBinary::VERSION => $agentBinary->getUpdateAvailable(), AgentBinary::UPDATE_AVAILABLE => '']);
   }
   
   /**
    * @param int $binaryId
    * @return boolean|string
    * @throws HTException
+   * @throws Exception
    */
-  public static function checkUpdate($binaryId) {
+  public static function checkUpdate(int $binaryId): bool|string {
     $agentBinary = AgentBinaryUtils::getBinary($binaryId);
     $update = AgentBinaryUtils::getAgentUpdate($agentBinary->getBinaryType(), $agentBinary->getUpdateTrack());
-    Factory::getAgentBinaryFactory()->set($agentBinary, AgentBinary::UPDATE_AVAILABLE, ($update) ? $update : '');
+    Factory::getAgentBinaryFactory()->set($agentBinary, AgentBinary::UPDATE_AVAILABLE, ($update) ?: '');
     return $update;
   }
   
@@ -202,7 +221,7 @@ class AgentBinaryUtils {
    * @return string
    * @throws HTException
    */
-  public static function getLatestVersion($agent, $track) {
+  public static function getLatestVersion(string $agent, string $track): string {
     $curl = curl_init();
     curl_setopt_array($curl, array(
         CURLOPT_RETURNTRANSFER => 1,
@@ -223,8 +242,9 @@ class AgentBinaryUtils {
    * @param string $track
    * @return boolean|string
    * @throws HTException
+   * @throws Exception
    */
-  public static function getAgentUpdate($agent, $track) {
+  public static function getAgentUpdate(string $agent, string $track): bool|string {
     $qF = new QueryFilter(AgentBinary::BINARY_TYPE, $agent, "=");
     $agent = Factory::getAgentBinaryFactory()->filter([Factory::FILTER => $qF], true);
     if ($agent == null) {

--- a/src/inc/utils/AgentUtils.php
+++ b/src/inc/utils/AgentUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\QueryFilter;
@@ -37,12 +38,12 @@ use Hashtopolis\inc\Util;
 
 class AgentUtils {
   /**
-   * @param AgentStat $deviceUtil
+   * @param ?AgentStat $deviceUtil
    * @param Agent $agent
    * @return string
    */
-  public static function getDeviceUtilStatusColor($deviceUtil, $agent) {
-    if ($deviceUtil === false) {
+  public static function getDeviceUtilStatusColor(?AgentStat $deviceUtil, Agent $agent): string {
+    if ($deviceUtil === null) {
       if (($agent->getIsActive() == 1) && (time() - $agent->getLastTime() < SConfig::getInstance()->getVal(DConfig::AGENT_TIMEOUT))) {
         return "#42d4f4";
       }
@@ -52,7 +53,7 @@ class AgentUtils {
     $deviceUtil = explode(",", $deviceUtil);
     $sum = 0;
     foreach ($deviceUtil as $u) {
-      $sum += $u;
+      $sum += intval($u);
     }
     if ($sum == 0) {
       return "#FF0000"; // either util 0 for all or an error occurred
@@ -70,12 +71,12 @@ class AgentUtils {
   }
   
   /**
-   * @param AgentStat $deviceTemp
+   * @param ?AgentStat $deviceTemp
    * @param Agent $agent
    * @return string
    */
-  public static function getDeviceTempStatusColor($deviceTemp, $agent) {
-    if ($deviceTemp === false) {
+  public static function getDeviceTempStatusColor(?AgentStat $deviceTemp, Agent $agent): string {
+    if ($deviceTemp === null) {
       if (($agent->getIsActive() == 1) && (time() - $agent->getLastTime() < SConfig::getInstance()->getVal(DConfig::AGENT_TIMEOUT))) {
         return "#42d4f4";
       }
@@ -102,12 +103,12 @@ class AgentUtils {
   }
   
   /**
-   * @param AgentStat $cpuUtil
+   * @param ?AgentStat $cpuUtil
    * @param Agent $agent
    * @return string
    */
-  public static function getCpuUtilStatusColor($cpuUtil, $agent) {
-    if ($cpuUtil === false) {
+  public static function getCpuUtilStatusColor(?AgentStat $cpuUtil, Agent $agent): string {
+    if ($cpuUtil === null) {
       if (($agent->getIsActive() == 1) && (time() - $agent->getLastTime() < SConfig::getInstance()->getVal(DConfig::AGENT_TIMEOUT))) {
         return "#42d4f4";
       }
@@ -117,7 +118,7 @@ class AgentUtils {
     $cpuUtil = explode(",", $cpuUtil);
     $sum = 0;
     foreach ($cpuUtil as $u) {
-      $sum += $u;
+      $sum += intval($u);
     }
     if ($sum == 0) {
       return "#FF0000"; // either util 0 for all or an error occurred
@@ -135,11 +136,11 @@ class AgentUtils {
   }
   
   /**
-   * @param AgentStat $deviceUtil
+   * @param ?AgentStat $deviceUtil
    * @return string
    */
-  public static function getDeviceUtilStatusValue($deviceUtil) {
-    if ($deviceUtil === false) {
+  public static function getDeviceUtilStatusValue(?AgentStat $deviceUtil): string {
+    if ($deviceUtil === null) {
       return "No data";
     }
     $deviceUtil = $deviceUtil->getValue();
@@ -149,18 +150,18 @@ class AgentUtils {
     $deviceUtil = explode(",", $deviceUtil);
     $sum = 0;
     foreach ($deviceUtil as $u) {
-      $sum += $u;
+      $sum += intval($u);
     }
     $avg = $sum / sizeof($deviceUtil);
     return round($avg, 1) . "%";
   }
   
   /**
-   * @param AgentStat $deviceTemp
+   * @param ?AgentStat $deviceTemp
    * @return string
    */
-  public static function getDeviceTempStatusValue($deviceTemp) {
-    if ($deviceTemp === false) {
+  public static function getDeviceTempStatusValue(?AgentStat $deviceTemp): string {
+    if ($deviceTemp === null) {
       return 'No data';
     }
     $deviceTemp = $deviceTemp->getValue();
@@ -176,11 +177,11 @@ class AgentUtils {
   }
   
   /**
-   * @param AgentStat $cpuUtil
+   * @param ?AgentStat $cpuUtil
    * @return string
    */
-  public static function getCpuUtilStatusValue($cpuUtil) {
-    if ($cpuUtil === false) {
+  public static function getCpuUtilStatusValue(?AgentStat $cpuUtil): string {
+    if ($cpuUtil === null) {
       return "No data";
     }
     $cpuUtil = $cpuUtil->getValue();
@@ -190,7 +191,7 @@ class AgentUtils {
     $cpuUtil = explode(",", $cpuUtil);
     $sum = 0;
     foreach ($cpuUtil as $u) {
-      $sum += $u;
+      $sum += intval($u);
     }
     $avg = $sum / sizeof($cpuUtil);
     return round($avg, 1) . "%";
@@ -200,8 +201,9 @@ class AgentUtils {
    * @param Agent $agent
    * @param mixed $types
    * @return array
+   * @throws Exception
    */
-  public static function getGraphData($agent, $types) {
+  public static function getGraphData(Agent $agent, mixed $types): array {
     $limit = intval(SConfig::getInstance()->getVal(DConfig::AGENT_STAT_LIMIT));
     if ($limit <= 0) {
       $limit = 100;
@@ -274,8 +276,9 @@ class AgentUtils {
    * @param boolean $isCpuOnly
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setAgentCpu($agentId, $isCpuOnly, $user) {
+  public static function setAgentCpu(int $agentId, bool $isCpuOnly, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     Factory::getAgentFactory()->set($agent, Agent::CPU_ONLY, ($isCpuOnly) ? 1 : 0);
   }
@@ -284,8 +287,9 @@ class AgentUtils {
    * @param int $agentId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function clearErrors($agentId, $user) {
+  public static function clearErrors(int $agentId, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     
     $qF = new QueryFilter(AgentError::AGENT_ID, $agent->getId(), "=");
@@ -298,7 +302,7 @@ class AgentUtils {
    * @param User $user
    * @throws HTException
    */
-  public static function rename($agentId, $newname, $user) {
+  public static function rename(int $agentId, string $newname, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     $name = htmlentities($newname, ENT_QUOTES, "UTF-8");
     if (strlen($name) == 0) {
@@ -309,10 +313,11 @@ class AgentUtils {
   
   /**
    * @param int $agentId
-   * @param User $user
+   * @param ?User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function delete($agentId, $user) {
+  public static function delete(int $agentId, ?User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     
     Factory::getAgentFactory()->getDB()->beginTransaction();
@@ -334,8 +339,9 @@ class AgentUtils {
   /**
    * @param Agent $agent
    * @return boolean
+   * @throws Exception
    */
-  public static function deleteDependencies($agent) {
+  public static function deleteDependencies(Agent $agent): bool {
     $qF = new QueryFilter(Assignment::AGENT_ID, $agent->getId(), "=");
     Factory::getAssignmentFactory()->massDeletion([Factory::FILTER => $qF]);
     $qF = new QueryFilter(NotificationSetting::OBJECT_ID, $agent->getId(), "=");
@@ -367,15 +373,10 @@ class AgentUtils {
     $qF = new QueryFilter(AccessGroupAgent::AGENT_ID, $agent->getId(), "=");
     Factory::getAccessGroupAgentFactory()->massDeletion([Factory::FILTER => $qF]);
     
-    $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => $qF]);
-    $chunkIds = array();
-    foreach ($chunks as $chunk) {
-      $chunkIds[] = $chunk->getId();
-    }
-    if (sizeof($chunks) > 0) {
-      $uS = new UpdateSet(Chunk::AGENT_ID, null);
-      Factory::getChunkFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);
-    }
+    $qF = new QueryFilter(Chunk::AGENT_ID, $agent->getId(), "=");
+    $uS = new UpdateSet(Chunk::AGENT_ID, null);
+    Factory::getChunkFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);
+    
     Factory::getAgentFactory()->delete($agent);
     return true;
   }
@@ -384,8 +385,10 @@ class AgentUtils {
    * @param int $agentId
    * @param int $taskId
    * @param User $user
+   * @return ?Assignment
    * @throws HTException
    * @throws HttpError
+   * @throws Exception
    */
   public static function assign(int $agentId, int $taskId, User $user): ?Assignment {
     $agent = AgentUtils::getAgent($agentId, $user);
@@ -400,7 +403,7 @@ class AgentUtils {
       return null;
     }
     
-    $task = Factory::getTaskFactory()->get(intval($taskId));
+    $task = Factory::getTaskFactory()->get($taskId);
     if ($task == null) {
       throw new HttpError("Invalid task!");
     }
@@ -449,8 +452,9 @@ class AgentUtils {
    * @param int $ignoreErrors
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeIgnoreErrors($agentId, $ignoreErrors, $user) {
+  public static function changeIgnoreErrors(int $agentId, int $ignoreErrors, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     $ignore = intval($ignoreErrors);
     if ($ignore != 0 && $ignore != 1 && $ignore != 2) {
@@ -461,11 +465,12 @@ class AgentUtils {
   
   /**
    * @param int $agentId
-   * @param User $user
+   * @param ?User $user
    * @return Agent
    * @throws HTException
+   * @throws Exception
    */
-  public static function getAgent($agentId, $user = null) {
+  public static function getAgent(int $agentId, ?User $user = null): Agent {
     $agent = Factory::getAgentFactory()->get($agentId);
     if ($agent == null) {
       throw new HTException("Invalid agent!");
@@ -481,8 +486,9 @@ class AgentUtils {
    * @param boolean $trusted
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setTrusted($agentId, $trusted, $user) {
+  public static function setTrusted(int $agentId, bool $trusted, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     Factory::getAgentFactory()->set($agent, Agent::IS_TRUSTED, ($trusted) ? 1 : 0);
   }
@@ -492,8 +498,9 @@ class AgentUtils {
    * @param int|string $ownerId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeOwner($agentId, $ownerId, $user) {
+  public static function changeOwner(int $agentId, int|string $ownerId, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     if ($ownerId == 0) {
       $username = "NONE";
@@ -521,8 +528,9 @@ class AgentUtils {
    * @param string $cmdParameters
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeCmdParameters($agentId, $cmdParameters, $user) {
+  public static function changeCmdParameters(int $agentId, string $cmdParameters, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
     if (Util::containsBlacklistedChars($cmdParameters)) {
       throw new HTException("Parameters must contain no blacklisted characters!");
@@ -536,8 +544,9 @@ class AgentUtils {
    * @param User $user
    * @param boolean $toggle
    * @throws HTException
+   * @throws Exception
    */
-  public static function setActive($agentId, $active, $user, $toggle = false) {
+  public static function setActive(int $agentId, bool $active, User $user, bool $toggle = false): void {
     $agent = Factory::getAgentFactory()->get($agentId);
     if ($agent == null) {
       throw new HTException("Invalid agent!");
@@ -559,6 +568,7 @@ class AgentUtils {
    * @param string $newVoucher
    * @return RegVoucher
    * @throws HttpConflict
+   * @throws Exception
    */
   public static function createVoucher(string $newVoucher): RegVoucher {
     $qF = new QueryFilter(RegVoucher::VOUCHER, $newVoucher, "=");
@@ -575,8 +585,9 @@ class AgentUtils {
   /**
    * @param int|string $voucher
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteVoucher($voucher) {
+  public static function deleteVoucher(int|string $voucher): void {
     if (is_numeric($voucher)) {
       $voucher = Factory::getRegVoucherFactory()->get($voucher);
     }

--- a/src/inc/utils/AgentUtils.php
+++ b/src/inc/utils/AgentUtils.php
@@ -41,6 +41,7 @@ class AgentUtils {
    * @param ?AgentStat $deviceUtil
    * @param Agent $agent
    * @return string
+   * @throws Exception
    */
   public static function getDeviceUtilStatusColor(?AgentStat $deviceUtil, Agent $agent): string {
     if ($deviceUtil === null) {
@@ -74,6 +75,7 @@ class AgentUtils {
    * @param ?AgentStat $deviceTemp
    * @param Agent $agent
    * @return string
+   * @throws Exception
    */
   public static function getDeviceTempStatusColor(?AgentStat $deviceTemp, Agent $agent): string {
     if ($deviceTemp === null) {
@@ -106,6 +108,7 @@ class AgentUtils {
    * @param ?AgentStat $cpuUtil
    * @param Agent $agent
    * @return string
+   * @throws Exception
    */
   public static function getCpuUtilStatusColor(?AgentStat $cpuUtil, Agent $agent): string {
     if ($cpuUtil === null) {
@@ -173,7 +176,7 @@ class AgentUtils {
     foreach ($deviceTemp as $t) {
       $max = ($t > $max) ? $t : $max;
     }
-    return strval($max) . "°";
+    return $max . "°";
   }
   
   /**
@@ -301,6 +304,7 @@ class AgentUtils {
    * @param string $newname
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
   public static function rename(int $agentId, string $newname, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
@@ -456,11 +460,10 @@ class AgentUtils {
    */
   public static function changeIgnoreErrors(int $agentId, int $ignoreErrors, User $user): void {
     $agent = AgentUtils::getAgent($agentId, $user);
-    $ignore = intval($ignoreErrors);
-    if ($ignore != 0 && $ignore != 1 && $ignore != 2) {
+    if ($ignoreErrors != 0 && $ignoreErrors != 1 && $ignoreErrors != 2) {
       throw new HTException("Invalid Ignore state!");
     }
-    Factory::getAgentFactory()->set($agent, Agent::IGNORE_ERRORS, $ignore);
+    Factory::getAgentFactory()->set($agent, Agent::IGNORE_ERRORS, $ignoreErrors);
   }
   
   /**

--- a/src/inc/utils/AgentUtils.php
+++ b/src/inc/utils/AgentUtils.php
@@ -144,7 +144,7 @@ class AgentUtils {
       return "No data";
     }
     $deviceUtil = $deviceUtil->getValue();
-    if ($deviceUtil === false) {
+    if ($deviceUtil === null) {
       return "No valid data";
     }
     $deviceUtil = explode(",", $deviceUtil);
@@ -165,7 +165,7 @@ class AgentUtils {
       return 'No data';
     }
     $deviceTemp = $deviceTemp->getValue();
-    if ($deviceTemp === false) {
+    if ($deviceTemp === null) {
       return 'No valid data';
     }
     $deviceTemp = explode(",", $deviceTemp);
@@ -185,7 +185,7 @@ class AgentUtils {
       return "No data";
     }
     $cpuUtil = $cpuUtil->getValue();
-    if ($cpuUtil === false) {
+    if ($cpuUtil === null) {
       return "No valid data";
     }
     $cpuUtil = explode(",", $cpuUtil);

--- a/src/inc/utils/ApiUtils.php
+++ b/src/inc/utils/ApiUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\models\ApiKey;
 use Hashtopolis\dba\models\ApiGroup;
@@ -16,8 +17,9 @@ class ApiUtils {
    * @param array $perm
    * @param string $sectionName
    * @throws HTException
+   * @throws Exception
    */
-  public static function update($groupId, $perm, $sectionName) {
+  public static function update(int $groupId, array $perm, string $sectionName): void {
     $group = Factory::getApiGroupFactory()->get($groupId);
     if ($group == null) {
       throw new HTException("Invalid API group!");
@@ -39,7 +41,7 @@ class ApiUtils {
           $constant = $constant[0];
         }
         if ($split[0] == $constant) {
-          $newArr[$sectionName][$constant] = ($split[1] == "1") ? true : false;
+          $newArr[$sectionName][$constant] = $split[1] == "1";
         }
       }
     }
@@ -53,8 +55,9 @@ class ApiUtils {
    * @param string $startValid
    * @param string $endValid
    * @throws HTException
+   * @throws Exception
    */
-  public static function editKey($keyId, $userId, $groupId, $startValid, $endValid) {
+  public static function editKey(int $keyId, int $userId, int $groupId, string $startValid, string $endValid): void {
     $key = Factory::getApiKeyFactory()->get($keyId);
     $user = Factory::getUserFactory()->get($userId);
     $group = Factory::getApiGroupFactory()->get($groupId);
@@ -71,7 +74,7 @@ class ApiUtils {
       throw new HTException("Can't change key owner!");
     }
     
-    $key = Factory::getApiKeyFactory()->mset($key, [
+    Factory::getApiKeyFactory()->mset($key, [
         ApiKey::USER_ID => $user->getId(),
         ApiKey::API_GROUP_ID => $group->getId(),
         ApiKey::START_VALID => strtotime($startValid),
@@ -84,8 +87,9 @@ class ApiUtils {
    * @param int $userId
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
-  public static function createKey($userId, $groupId) {
+  public static function createKey(int $userId, int $groupId): void {
     $user = Factory::getUserFactory()->get($userId);
     $group = Factory::getApiGroupFactory()->get($groupId);
     if ($user == null) {
@@ -109,8 +113,9 @@ class ApiUtils {
   /**
    * @param int $keyId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteKey($keyId) {
+  public static function deleteKey(int $keyId): void {
     $key = Factory::getApiKeyFactory()->get($keyId);
     if ($key == null) {
       throw new HTException("Invalid API key ID!");
@@ -120,8 +125,9 @@ class ApiUtils {
   
   /**
    * @param string $name
+   * @throws Exception
    */
-  public static function createGroup($name) {
+  public static function createGroup(string $name): void {
     $name = htmlentities($name, ENT_QUOTES, "UTF-8");
     $group = new ApiGroup(null, '{}', $name);
     Factory::getApiGroupFactory()->save($group);
@@ -130,8 +136,9 @@ class ApiUtils {
   /**
    * @param int $groupId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteGroup($groupId) {
+  public static function deleteGroup(int $groupId): void {
     $group = Factory::getApiGroupFactory()->get($groupId);
     if ($group == null) {
       throw new HTException("Invalid group ID!");

--- a/src/inc/utils/AssignmentUtils.php
+++ b/src/inc/utils/AssignmentUtils.php
@@ -10,18 +10,20 @@ use Hashtopolis\inc\HTException;
 class AssignmentUtils {
   
   /**
+   * @param int $assignmentId
    * @param string $benchmark
    * @param User $user
    * @throws HTException
+   * @throws \Exception
    */
-  public static function setBenchmark($assignmentId, $benchmark, $user) {
+  public static function setBenchmark(int $assignmentId, string $benchmark, User $user): void {
     // adjust agent benchmark
     $assignment = Factory::getAssignmentFactory()->get($assignmentId);
-    $agent = Factory::getAgentFactory()->get($assignment->getAgentId());
     if ($assignment == null) {
       throw new HTException("No assignment found with this id to change benchmark of");
     }
-    else if (!AccessUtils::userCanAccessAgent($agent, $user)) {
+    $agent = Factory::getAgentFactory()->get($assignment->getAgentId());
+    if (!AccessUtils::userCanAccessAgent($agent, $user)) {
       throw new HTException("No access to this agent!");
     }
     // TODO: check benchmark validity

--- a/src/inc/utils/AssignmentUtils.php
+++ b/src/inc/utils/AssignmentUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\Assignment;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\User;
@@ -14,7 +15,7 @@ class AssignmentUtils {
    * @param string $benchmark
    * @param User $user
    * @throws HTException
-   * @throws \Exception
+   * @throws Exception
    */
   public static function setBenchmark(int $assignmentId, string $benchmark, User $user): void {
     // adjust agent benchmark

--- a/src/inc/utils/ChunkUtils.php
+++ b/src/inc/utils/ChunkUtils.php
@@ -132,7 +132,6 @@ class ChunkUtils {
       $length = $remaining;
     }
     Factory::getTaskFactory()->inc($task, Task::KEYSPACE_PROGRESS, $length);
-    assert($task instanceof Task);
     $initialProgress = ($task->getUsePreprocessor() || $task->getForcePipe()) ? null : 0;
     $chunk = new Chunk(null, $task->getId(), $start, $length, $assignment->getAgentId(), time(), 0, $start, $initialProgress, DHashcatStatus::INIT, 0, 0);
     $chunk = Factory::getChunkFactory()->save($chunk);

--- a/src/inc/utils/ChunkUtils.php
+++ b/src/inc/utils/ChunkUtils.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
-use Hashtopolis;
+use Exception;
 use Hashtopolis\dba\models\Chunk;
 use Hashtopolis\dba\models\Task;
 use Hashtopolis\dba\models\Assignment;
@@ -25,8 +25,9 @@ class ChunkUtils {
    * @param $assignment Assignment
    * @return Chunk|null
    * @throws HTException
+   * @throws Exception
    */
-  public static function handleExistingChunk($chunk, $task, $assignment) {
+  public static function handleExistingChunk(Chunk $chunk, Task $task, Assignment $assignment): ?Chunk {
     $disptolerance = 1 + SConfig::getInstance()->getVal(DConfig::DISP_TOLERANCE) / 100;
     
     DServerLog::log(DServerLog::TRACE, "Handling existing chunk...", [$task, $chunk, $assignment]);
@@ -112,8 +113,9 @@ class ChunkUtils {
    * @param Assignment $assignment
    * @return Chunk|null
    * @throws HTException
+   * @throws Exception
    */
-  public static function createNewChunk($task, $assignment) {
+  public static function createNewChunk(Task $task, Assignment $assignment): ?Chunk {
     $disptolerance = 1 + SConfig::getInstance()->getVal(DConfig::DISP_TOLERANCE) / 100;
     
     // if we have set a skip keyspace we set the the current progress to the skip which was set initially
@@ -148,8 +150,9 @@ class ChunkUtils {
    * @param int $chunkSize
    * @return int
    * @throws HTException
+   * @throws Exception
    */
-  public static function calculateChunkSize($keyspace, $benchmark, $chunkTime, $tolerance = 1.0, $staticChunking = DTaskStaticChunking::NORMAL, $chunkSize = 0) {
+  public static function calculateChunkSize(int $keyspace, string $benchmark, int $chunkTime, float $tolerance = 1.0, int $staticChunking = DTaskStaticChunking::NORMAL, int $chunkSize = 0): int {
     global $QUERY;
     
     if ($chunkTime <= 0) {
@@ -175,7 +178,7 @@ class ChunkUtils {
       }
     }
     
-    if (strpos($benchmark, ":") === false) {
+    if (!str_contains($benchmark, ":")) {
       // old benchmarking method
       if ($benchmark == 0) {
         // special case on small tasks, so we just create a chunk with the size of the keyspace

--- a/src/inc/utils/ConfigUtils.php
+++ b/src/inc/utils/ConfigUtils.php
@@ -121,6 +121,7 @@ class ConfigUtils {
   /**
    * @param array $arr id => [attributes]
    * @throws HTException
+   * @throws Exception
    *
    *  This is a new updateConfigs function that unlike the updateConfig is compliant
    *  for the APIv2

--- a/src/inc/utils/ConfigUtils.php
+++ b/src/inc/utils/ConfigUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\dba\models\TaskWrapper;
 use Hashtopolis\dba\models\User;
@@ -29,8 +30,9 @@ class ConfigUtils {
    * @param Config $config
    * @param boolean $new
    * @throws HTException
+   * @throws Exception
    */
-  public static function set($config, $new) {
+  public static function set(Config $config, bool $new): void {
     if ($config->getItem() == DConfig::MULTICAST_ENABLE && $config->getValue()) {
       // multicast was ticked to enable -> start runner
       RunnerUtils::startService();
@@ -52,8 +54,9 @@ class ConfigUtils {
    * @param string $item
    * @return Config
    * @throws HTException
+   * @throws Exception
    */
-  public static function get($item) {
+  public static function get(string $item): Config {
     $qF = new QueryFilter(Config::ITEM, $item, "=");
     $config = Factory::getConfigFactory()->filter([Factory::FILTER => $qF], true);
     if ($config == null) {
@@ -64,21 +67,27 @@ class ConfigUtils {
   
   /**
    * @return ConfigSection[]
+   * @throws Exception
    */
-  public static function getSections() {
+  public static function getSections(): array {
     return Factory::getConfigSectionFactory()->filter([]);
   }
   
   /**
    * @return Config[]
+   * @throws Exception
    */
-  public static function getAll() {
+  public static function getAll(): array {
     return Factory::getConfigFactory()->filter([]);
   }
   
   const DEFAULT_CONFIG_SECTION = 5;
   
-  public static function updateSingleConfig($id, $attributes) {
+  /**
+   * @throws HTException
+   * @throws Exception
+   */
+  public static function updateSingleConfig($id, $attributes): void {
     $currentConfig = Factory::getConfigFactory()->get($id);
     if (is_null($currentConfig)) {
       throw new HTException("No config with this ID!");
@@ -100,7 +109,7 @@ class ConfigUtils {
     if (isset($lengthLimits[$name])) {
       $limit = intval($newValue);
       if (!Util::{$lengthLimits[$name]}($limit)) {
-        throw new HTException("Failed to update {$name}!");
+        throw new HTException("Failed to update $name!");
       }
     }
     
@@ -116,7 +125,7 @@ class ConfigUtils {
    *  This is a new updateConfigs function that unlike the updateConfig is compliant
    *  for the APIv2
    */
-  public static function updateConfigs($arr) {
+  public static function updateConfigs(array $arr): void {
     foreach ($arr as $id => $attributes) {
       self::updateSingleConfig($id, $attributes);
     }
@@ -127,10 +136,11 @@ class ConfigUtils {
   /**
    * @param array $arr
    * @throws HTException
+   * @throws Exception
    */
-  public static function updateConfig($arr) {
+  public static function updateConfig(array $arr): void {
     foreach ($arr as $item => $val) {
-      if (substr($item, 0, 7) == "config_") {
+      if (str_starts_with($item, "config_")) {
         $name = substr($item, 7);
         if (SConfig::getInstance()->getVal($name) == $val) {
           continue; // the value was not changed, so we don't need to update it
@@ -167,6 +177,7 @@ class ConfigUtils {
   
   /**
    * @return int[]
+   * @throws Exception
    */
   public static function rebuildCache(): array {
     $correctedChunks = 0;
@@ -193,7 +204,7 @@ class ConfigUtils {
         $total_cracked += $count;
         if ($count != $chunk->getCracked()) {
           $correctedChunks++;
-          $chunk = Factory::getChunkFactory()->set($chunk, Chunk::CRACKED, $count);
+          Factory::getChunkFactory()->set($chunk, Chunk::CRACKED, $count);
         }
       }
       if ($total_cracked != $taskWrapper->getCracked()) {
@@ -252,8 +263,9 @@ class ConfigUtils {
   
   /**
    * @throws HTMessages
+   * @throws Exception
    */
-  public static function scanFiles() {
+  public static function scanFiles(): void {
     $allOk = true;
     $messages = [];
     $files = Factory::getFileFactory()->filter([]);
@@ -282,8 +294,9 @@ class ConfigUtils {
   
   /**
    * @param User $user
+   * @throws Exception
    */
-  public static function clearAll($user) {
+  public static function clearAll(User $user): void {
     Factory::getAgentFactory()->getDB()->beginTransaction();
     Factory::getHashFactory()->massDeletion([]);
     Factory::getHashBinaryFactory()->massDeletion([]);

--- a/src/inc/utils/CrackerBinaryUtils.php
+++ b/src/inc/utils/CrackerBinaryUtils.php
@@ -2,7 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
-use Hashtopolis;
+use Exception;
 use Hashtopolis\dba\models\CrackerBinary;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\Factory;
@@ -14,8 +14,9 @@ class CrackerBinaryUtils {
    * @param int $crackerBinaryTypeId
    * @return CrackerBinary|null
    * @throws HTException
+   * @throws Exception
    */
-  public static function getNewestVersion($crackerBinaryTypeId) {
+  public static function getNewestVersion(int $crackerBinaryTypeId): ?CrackerBinary {
     $qF = new QueryFilter(CrackerBinary::CRACKER_BINARY_TYPE_ID, $crackerBinaryTypeId, "=");
     $binaries = Factory::getCrackerBinaryFactory()->filter([Factory::FILTER => $qF]);
     /** @var ?CrackerBinary $newest */

--- a/src/inc/utils/CrackerUtils.php
+++ b/src/inc/utils/CrackerUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\CrackerBinary;
 use Hashtopolis\dba\models\CrackerBinaryType;
 use Hashtopolis\dba\QueryFilter;
@@ -18,16 +19,18 @@ class CrackerUtils {
   /**
    * @param CrackerBinaryType $cracker
    * @return CrackerBinary[]
+   * @throws Exception
    */
-  public static function getBinaries($cracker) {
+  public static function getBinaries(CrackerBinaryType $cracker): array {
     $qF = new QueryFilter(CrackerBinary::CRACKER_BINARY_TYPE_ID, $cracker->getId(), "=");
     return Factory::getCrackerBinaryFactory()->filter([Factory::FILTER => $qF]);
   }
   
   /**
    * @return CrackerBinaryType[]
+   * @throws Exception
    */
-  public static function getBinaryTypes() {
+  public static function getBinaryTypes(): array {
     return Factory::getCrackerBinaryTypeFactory()->filter([]);
   }
   
@@ -36,6 +39,7 @@ class CrackerUtils {
    * @return CrackerBinaryType
    * @throws HttpConflict
    * @throws HttpError
+   * @throws Exception
    */
   public static function createBinaryType(string $typeName): CrackerBinaryType {
     $qF = new QueryFilter(CrackerBinaryType::TYPE_NAME, $typeName, "=");
@@ -58,6 +62,7 @@ class CrackerUtils {
    * @return CrackerBinary
    * @throws HttpError
    * @throws HTException
+   * @throws Exception
    */
   public static function createBinary(string $version, string $name, string $url, int $binaryTypeId): CrackerBinary {
     $binaryType = CrackerUtils::getBinaryType($binaryTypeId);
@@ -71,8 +76,9 @@ class CrackerUtils {
   /**
    * @param int $binaryId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteBinary($binaryId) {
+  public static function deleteBinary(int $binaryId): void {
     $binary = CrackerUtils::getBinary($binaryId);
     $qF = new QueryFilter(Task::CRACKER_BINARY_ID, $binary->getId(), "=");
     $check = Factory::getTaskFactory()->filter([Factory::FILTER => $qF]);
@@ -85,8 +91,9 @@ class CrackerUtils {
   /**
    * @param int $binaryTypeId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteBinaryType($binaryTypeId) {
+  public static function deleteBinaryType(int $binaryTypeId): void {
     $binaryType = CrackerUtils::getBinaryType($binaryTypeId);
     
     $qF = new QueryFilter(CrackerBinary::CRACKER_BINARY_TYPE_ID, $binaryType->getId(), "=");
@@ -119,8 +126,9 @@ class CrackerUtils {
    * @param int $binaryId
    * @return CrackerBinaryType
    * @throws HTException
+   * @throws Exception
    */
-  public static function updateBinary($version, $name, $url, $binaryId) {
+  public static function updateBinary(string $version, string $name, string $url, int $binaryId): CrackerBinaryType {
     $binary = CrackerUtils::getBinary($binaryId);
     if (strlen($version) == 0 || strlen($name) == 0 || strlen($url) == 0) {
       throw new HTException("Please provide all information!");
@@ -138,8 +146,9 @@ class CrackerUtils {
    * @param int $binaryTypeId
    * @return CrackerBinaryType
    * @throws HTException
+   * @throws Exception
    */
-  public static function getBinaryType($binaryTypeId) {
+  public static function getBinaryType(int $binaryTypeId): CrackerBinaryType {
     $binaryType = Factory::getCrackerBinaryTypeFactory()->get($binaryTypeId);
     if ($binaryType === null) {
       throw new HTException("Invalid binary type!");
@@ -151,8 +160,9 @@ class CrackerUtils {
    * @param int $binaryId
    * @return CrackerBinary
    * @throws HTException
+   * @throws Exception
    */
-  public static function getBinary($binaryId) {
+  public static function getBinary(int $binaryId): CrackerBinary {
     $binary = Factory::getCrackerBinaryFactory()->get($binaryId);
     if ($binary === null) {
       throw new HTException("Invalid cracker binary!");

--- a/src/inc/utils/FileDownloadUtils.php
+++ b/src/inc/utils/FileDownloadUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\models\FileDownload;
 use Hashtopolis\dba\ContainFilter;
@@ -13,8 +14,9 @@ class FileDownloadUtils {
    * Adds a file to the download list if it's not already pending
    * @param int $fileId
    * @return void
+   * @throws Exception
    */
-  public static function addDownload($fileId) {
+  public static function addDownload(int $fileId): void {
     $qF1 = new QueryFilter(FileDownload::FILE_ID, $fileId, "=");
     $qF2 = new ContainFilter(FileDownload::STATUS, [DFileDownloadStatus::FAILED, DFileDownloadStatus::PENDING]);
     $check = Factory::getFileDownloadFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
@@ -28,8 +30,9 @@ class FileDownloadUtils {
   /**
    * Removes a file from the download list
    * @param int $fileId
+   * @throws Exception
    */
-  public static function removeFile($fileId) {
+  public static function removeFile(int $fileId): void {
     $qF = new QueryFilter(FileDownload::FILE_ID, $fileId, "=");
     Factory::getFileDownloadFactory()->massDeletion([Factory::FILTER => $qF]);
   }

--- a/src/inc/utils/FileUtils.php
+++ b/src/inc/utils/FileUtils.php
@@ -116,14 +116,14 @@ class FileUtils {
   
   /**
    * @param string $source
-   * @param array $file
+   * @param array|string $file
    * @param array $post
    * @param string $view
    * @return integer
    * @throws HttpError
    * @throws Exception
    */
-  public static function add(string $source, array $file, array $post, string $view): int {
+  public static function add(string $source, array|string $file, array $post, string $view): int {
     $fileCount = 0;
     
     $accessGroup = Factory::getAccessGroupFactory()->get($post['accessGroupId']);

--- a/src/inc/utils/FileUtils.php
+++ b/src/inc/utils/FileUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\dba\models\File;
 use Hashtopolis\dba\QueryFilter;
@@ -26,8 +27,9 @@ class FileUtils {
    * @param User $user
    * @param int[] $checkedFilesIds
    * @return array
+   * @throws Exception
    */
-  public static function loadFilesByCategory($user, $checkedFilesIds) {
+  public static function loadFilesByCategory(User $user, array $checkedFilesIds): array {
     $accessGroupIds = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     $oF = new OrderFilter(File::FILENAME, "ASC");
     $qF = new ContainFilter(File::ACCESS_GROUP_ID, $accessGroupIds);
@@ -61,8 +63,9 @@ class FileUtils {
    * @param int $fileType
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setFileType($fileId, $fileType, $user) {
+  public static function setFileType(int $fileId, int $fileType, User $user): void {
     $file = FileUtils::getFile($fileId, $user);
     if ($fileType < DFileType::WORDLIST || $fileType > DFileType::OTHER) {
       throw new HTException("Invalid file type!");
@@ -73,8 +76,9 @@ class FileUtils {
   /**
    * @param User $user
    * @return File[]
+   * @throws Exception
    */
-  public static function getFiles($user) {
+  public static function getFiles(User $user): array {
     $accessGroupIds = Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user));
     
     $oF = new OrderFilter(File::FILE_ID, "ASC");
@@ -87,8 +91,9 @@ class FileUtils {
    * @param int $fileId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function delete($fileId, $user) {
+  public static function delete(int $fileId, User $user): void {
     $file = FileUtils::getFile($fileId, $user);
     
     $qF = new QueryFilter(FileTask::FILE_ID, $file->getId(), "=");
@@ -115,9 +120,10 @@ class FileUtils {
    * @param array $post
    * @param string $view
    * @return integer
-   * @throws HTException
+   * @throws HttpError
+   * @throws Exception
    */
-  public static function add($source, $file, $post, $view) {
+  public static function add(string $source, array $file, array $post, string $view): int {
     $fileCount = 0;
     
     $accessGroup = Factory::getAccessGroupFactory()->get($post['accessGroupId']);
@@ -157,10 +163,9 @@ class FileUtils {
             continue;
           }
           
-          $toMove = array();
-          foreach ($uploaded as $key => $upload) {
-            $toMove[$key] = $upload[$i];
-          }
+          $toMove = array_map(function ($upload) use ($i) {
+            return $upload[$i];
+          }, $uploaded);
           if ($realname[0] == '.') {
             $realname[0] = "_";
           }
@@ -249,11 +254,12 @@ class FileUtils {
    * @param int $isSecret
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function switchSecret($fileId, $isSecret, $user) {
+  public static function switchSecret(int $fileId, int $isSecret, User $user): void {
     // switch global file secret state
     $file = FileUtils::getFile($fileId, $user);
-    Factory::getFileFactory()->set($file, File::IS_SECRET, intval($isSecret));
+    Factory::getFileFactory()->set($file, File::IS_SECRET, $isSecret);
   }
   
   /**
@@ -262,8 +268,9 @@ class FileUtils {
    * @param int $accessGroupId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function saveChanges($fileId, $filename, $accessGroupId, $user) {
+  public static function saveChanges(int $fileId, string $filename, int $accessGroupId, User $user): void {
     $file = FileUtils::getFile($fileId, $user);
     $newName = str_replace(" ", "_", htmlentities($filename, ENT_QUOTES, "UTF-8"));
     $newName = str_replace("/", "_", str_replace("\\", "_", $newName));
@@ -282,9 +289,6 @@ class FileUtils {
     
     if ($accessGroupId > 0) {
       $accessGroup = AccessGroupUtils::getGroup($accessGroupId);
-      if ($accessGroup == null) {
-        throw new HTException("Invalid access group Id!");
-      }
       $file = Factory::getFileFactory()->set($file, File::ACCESS_GROUP_ID, $accessGroup->getId());
     }
     
@@ -331,8 +335,9 @@ class FileUtils {
    * @param User $user
    * @return File
    * @throws HTException
+   * @throws Exception
    */
-  public static function getFile($fileId, $user) {
+  public static function getFile(int $fileId, User $user): File {
     $accessGroups = AccessUtils::getAccessGroupsOfUser($user);
     $accessGroupIds = Util::arrayOfIds($accessGroups);
     
@@ -349,8 +354,9 @@ class FileUtils {
   /**
    * @param $fileId
    * @throws HTException
+   * @throws Exception
    */
-  public static function fileCountLines($fileId) {
+  public static function fileCountLines($fileId): void {
     $file = Factory::getFileFactory()->get($fileId);
     $fileName = $file->getFilename();
     $filePath = Factory::getStoredValueFactory()->get(DDirectories::FILES)->getVal() . "/" . $fileName;

--- a/src/inc/utils/HashlistUtils.php
+++ b/src/inc/utils/HashlistUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\dba\models\Hash;
 use Hashtopolis\dba\QueryFilter;
@@ -48,8 +49,9 @@ class HashlistUtils {
    * @param string $notes
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function editNotes($hashlistId, $notes, $user) {
+  public static function editNotes(int $hashlistId, string $notes, User $user): void {
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
       throw new HTException("No access to hashlist!");
@@ -62,8 +64,9 @@ class HashlistUtils {
    * @param User $user
    * @return ?Hash
    * @throws HTException
+   * @throws Exception
    */
-  public static function getHash($hash, $user) {
+  public static function getHash(string $hash, User $user): ?Hash {
     $qF = new QueryFilter(Hash::HASH, $hash, "=");
     $hashes = Factory::getHashFactory()->filter([Factory::FILTER => $qF]);
     foreach ($hashes as $hash) {
@@ -81,9 +84,11 @@ class HashlistUtils {
   
   /**
    * @param User $user
+   * @param bool $archived
    * @return Hashlist[]
+   * @throws Exception
    */
-  public static function getHashlists($user, $archived = false) {
+  public static function getHashlists(User $user, bool $archived = false): array {
     $qF1 = new QueryFilter(Hashlist::FORMAT, DHashlistFormat::SUPERHASHLIST, "<>");
     $qF2 = new ContainFilter(Hashlist::ACCESS_GROUP_ID, Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user)));
     $qF3 = new QueryFilter(Hashlist::IS_ARCHIVED, $archived ? 1 : 0, "=");
@@ -93,8 +98,9 @@ class HashlistUtils {
   /**
    * @param User $user
    * @return Hashlist[]
+   * @throws Exception
    */
-  public static function getSuperhashlists($user) {
+  public static function getSuperhashlists(User $user): array {
     $qF1 = new QueryFilter(Hashlist::FORMAT, DHashlistFormat::SUPERHASHLIST, "=");
     $qF2 = new ContainFilter(Hashlist::ACCESS_GROUP_ID, Util::arrayOfIds(AccessUtils::getAccessGroupsOfUser($user)));
     return Factory::getHashlistFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
@@ -106,8 +112,9 @@ class HashlistUtils {
    * @param User $user
    * @return int
    * @throws HTException
+   * @throws Exception
    */
-  public static function applyPreconfTasks($hashlistId, $pretasks, $user) {
+  public static function applyPreconfTasks(int $hashlistId, array $pretasks, User $user): int {
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
       throw new HTException("No access to hashlist!");
@@ -124,7 +131,7 @@ class HashlistUtils {
     foreach ($pretasks as $pretask) {
       $task = Factory::getPretaskFactory()->get($pretask);
       if ($task != null) {
-        if ($hashlist->getHexSalt() == 1 && strpos($task->getAttackCmd(), "--hex-salt") === false) {
+        if ($hashlist->getHexSalt() == 1 && !str_contains($task->getAttackCmd(), "--hex-salt")) {
           $task->setAttackCmd("--hex-salt " . $task->getAttackCmd());
         }
         $taskPriority = 0;
@@ -182,8 +189,9 @@ class HashlistUtils {
    * @param User $user
    * @return array
    * @throws HTException
+   * @throws Exception
    */
-  public static function createWordlists($hashlistId, $user) {
+  public static function createWordlists(int $hashlistId, User $user): array {
     // create wordlist from hashlist cracked hashes
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     $lists = Util::checkSuperHashlist($hashlist);
@@ -221,7 +229,7 @@ class HashlistUtils {
         $hashes = $hashFactory->filter([Factory::FILTER => [$qF1, $qF2], Factory::ORDER => $oF, Factory::LIMIT => $lF]);
         foreach ($hashes as $hash) {
           $plain = $hash->getPlaintext();
-          if (strlen($plain) >= 8 && substr($plain, 0, 5) == "\$HEX[" && substr($plain, strlen($plain) - 1, 1) == "]") {
+          if (strlen($plain) >= 8 && str_starts_with($plain, "\$HEX[") && str_ends_with($plain, "]")) {
             $plain = Util::hextobin(substr($plain, 5, strlen($plain) - 6));
           }
           $buffer .= $plain . "\n";
@@ -244,15 +252,16 @@ class HashlistUtils {
    * @param int $isSecret
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setSecret($hashlistId, $isSecret, $user) {
+  public static function setSecret(int $hashlistId, int $isSecret, User $user): void {
     // switch hashlist secret state
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
       throw new HTException("No access to hashlist!");
     }
-    Factory::getHashlistFactory()->set($hashlist, Hashlist::IS_SECRET, intval($isSecret));
-    if (intval($isSecret) == 1) {
+    Factory::getHashlistFactory()->set($hashlist, Hashlist::IS_SECRET, $isSecret);
+    if ($isSecret == 1) {
       //handle agents which are assigned to hashlists which are secret now
       $jF1 = new JoinFilter(Factory::getTaskFactory(), Task::TASK_ID, Assignment::TASK_ID, Factory::getAssignmentFactory());
       $jF2 = new JoinFilter(Factory::getTaskWrapperFactory(), Task::TASK_WRAPPER_ID, TaskWrapper::TASK_WRAPPER_ID, Factory::getTaskWrapperFactory());
@@ -261,9 +270,9 @@ class HashlistUtils {
       /** @var Assignment[] $assignments */
       $assignments = $joined[Factory::getAssignmentFactory()->getModelName()];
       for ($x = 0; $x < sizeof($assignments); $x++) {
-        /** @var Hashlist $hashlist */
-        $hashlist = $joined[Factory::getHashlistFactory()->getModelName()][$x];
-        if ($hashlist->getId() == $hashlist->getId()) {
+        /** @var Hashlist $check */
+        $check = $joined[Factory::getHashlistFactory()->getModelName()][$x];
+        if ($hashlist->getId() == $check->getId()) {
           Factory::getAssignmentFactory()->delete($joined[Factory::getAssignmentFactory()->getModelName()][$x]);
         }
       }
@@ -272,11 +281,12 @@ class HashlistUtils {
   
   /**
    * @param int $hashlistId
-   * @param $isArchived
+   * @param int $isArchived
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setArchived($hashlistId, $isArchived, $user) {
+  public static function setArchived(int $hashlistId, int $isArchived, User $user): void {
     // switch hashlist archived state
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
@@ -298,7 +308,7 @@ class HashlistUtils {
       throw new HTException("Hashlist cannot be archived as it is part of an existing superhashlist!");
     }
     
-    Factory::getHashlistFactory()->set($hashlist, Hashlist::IS_ARCHIVED, intval($isArchived));
+    Factory::getHashlistFactory()->set($hashlist, Hashlist::IS_ARCHIVED, $isArchived);
   }
   
   /**
@@ -306,8 +316,9 @@ class HashlistUtils {
    * @param string $name
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function rename($hashlistId, $name, $user) {
+  public static function rename(int $hashlistId, string $name, User $user): void {
     // change hashlist name
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
@@ -326,8 +337,9 @@ class HashlistUtils {
    * @param boolean $overwritePlaintext
    * @return int[]
    * @throws HTException
+   * @throws Exception
    */
-  public static function processZap($hashlistId, $separator, $source, $post, $files, $user, $overwritePlaintext) {
+  public static function processZap(int $hashlistId, string $separator, string $source, array $post, array $files, User $user, bool $overwritePlaintext): array {
     // pre-crack hashes processor
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
@@ -375,7 +387,7 @@ class HashlistUtils {
     while (!feof($file)) {
       $buffer = fread($file, 1024);
       foreach ($lineSeparators as $ls) {
-        if (strpos($buffer, $ls) !== false) {
+        if (str_contains($buffer, $ls)) {
           $lineSeparator = $ls;
           break;
         }
@@ -388,8 +400,8 @@ class HashlistUtils {
     Factory::getAgentFactory()->getDB()->beginTransaction();
     $hashlists = Util::checkSuperHashlist($hashlist);
     $inSuperHashlists = array();
-    $hashlist = $hashlists[0];
-    if (sizeof($hashlists) == 1 && $hashlist->getId() == $hashlist->getId()) {
+    $check = $hashlists[0];
+    if (sizeof($hashlists) == 1 && $hashlist->getId() == $check->getId()) {
       $qF = new QueryFilter(HashlistHashlist::HASHLIST_ID, $hashlist->getId(), "=");
       $inSuperHashlists = Factory::getHashlistHashlistFactory()->filter([Factory::FILTER => $qF]);
     }
@@ -576,8 +588,9 @@ class HashlistUtils {
    * @param User $user
    * @return int
    * @throws HTException
+   * @throws Exception
    */
-  public static function delete($hashlistId, $user) {
+  public static function delete(int $hashlistId, User $user): int {
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if (!AccessUtils::userCanAccessHashlists($hashlist, $user)) {
       throw new HTException("No access to this hashlist!");
@@ -635,7 +648,6 @@ class HashlistUtils {
     
     switch ($hashlist->getFormat()) {
       case 0:
-        $count = Factory::getHashlistFactory()->countFilter([]);
         $qF = new QueryFilter(Hash::HASHLIST_ID, $hashlist->getId(), "=");
         Factory::getHashFactory()->massDeletion([Factory::FILTER => $qF]);
         break;
@@ -685,8 +697,9 @@ class HashlistUtils {
    * @param int $hashlistId
    * @return Hashlist
    * @throws HTException
+   * @throws Exception
    */
-  public static function getHashlist($hashlistId) {
+  public static function getHashlist(int $hashlistId): Hashlist {
     $hashlist = Factory::getHashlistFactory()->get($hashlistId);
     if ($hashlist == null) {
       throw new HTException("Invalid hashlist!");
@@ -699,8 +712,9 @@ class HashlistUtils {
    * @param User $user
    * @return File
    * @throws HTException
+   * @throws Exception
    */
-  public static function export($hashlistId, $user) {
+  public static function export(int $hashlistId, User $user): File {
     // export cracked hashes to a file
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     $hashlists = Util::checkSuperHashlist($hashlist);
@@ -724,8 +738,8 @@ class HashlistUtils {
     }
     
     $hashlistIds = array();
-    foreach ($hashlists as $hashlist) {
-      $hashlistIds[] = $hashlist->getId();
+    foreach ($hashlists as $hl) {
+      $hashlistIds[] = $hl->getId();
     }
     $qF1 = new ContainFilter(Hash::HASHLIST_ID, $hashlistIds);
     $qF2 = new QueryFilter(Hash::IS_CRACKED, "1", "=");
@@ -766,8 +780,7 @@ class HashlistUtils {
     usleep(1000000);
     
     $file = new File(null, $tmpname, Util::filesize($tmpfile), $hashlist->getIsSecret(), DFileType::OTHER, $hashlist->getAccessGroupId(), $numEntries);
-    $file = Factory::getFileFactory()->save($file);
-    return $file;
+    return Factory::getFileFactory()->save($file);
   }
   
   /**
@@ -788,16 +801,15 @@ class HashlistUtils {
    * @param int $brainFeatures
    * @return Hashlist
    * @throws HTException
+   * @throws HttpError
+   * @throws Exception
    */
-  public static function createHashlist($name, $isSalted, $isSecret, $isHexSalted, $separator, $format, $hashtype, $saltSeparator, $accessGroupId, $source, $post, $files, $user, $brainId, $brainFeatures) {
+  public static function createHashlist(string $name, bool $isSalted, bool $isSecret, bool $isHexSalted, string $separator, int $format, int $hashtype, string $saltSeparator, int $accessGroupId, string $source, array $post, array $files, User $user, int $brainId, int $brainFeatures): Hashlist {
     $salted = ($isSalted) ? "1" : "0";
     $secret = ($isSecret) ? "1" : "0";
     $hexsalted = ($isHexSalted) ? "1" : "0";
     $brainId = ($brainId) ? "1" : "0";
-    $format = intval($format);
-    $hashtype = intval($hashtype);
     $accessGroup = Factory::getAccessGroupFactory()->get($accessGroupId);
-    $brainFeatures = intval($brainFeatures);
     
     if ($format < DHashlistFormat::PLAIN || $format > DHashlistFormat::BINARY) {
       throw new HttpError("Invalid hashlist format!");
@@ -869,7 +881,7 @@ class HashlistUtils {
           // find out if the first line contains field separator
           rewind($file);
           $bufline = stream_get_line($file, 1024);
-          if (strpos($bufline, $saltSeparator) === false) {
+          if (!str_contains($bufline, $saltSeparator)) {
             throw new HttpError("Salted hashes separator not found in file!");
           }
         }
@@ -937,8 +949,6 @@ class HashlistUtils {
         NotificationHandler::checkNotifications(DNotificationType::NEW_HASHLIST, new DataSet(array(DPayloadKeys::HASHLIST => $hashlist)));
         break;
       case DHashlistFormat::WPA:
-        $added = 0;
-        $values = [];
         while (!feof($file)) {
           if ($hashlist->getHashTypeId() == 2500) { // HCCAPX hashes
             $data = fread($file, 393);
@@ -980,7 +990,7 @@ class HashlistUtils {
             if (strlen($line) == 0) {
               continue;
             }
-            if (strpos($line, "*") !== false) {
+            if (str_contains($line, "*")) {
               // in case the other format with * as separator was used, we convert it to : to be consistent with the newest format
               $line = str_replace("*", ":", $line);
             }
@@ -1030,10 +1040,11 @@ class HashlistUtils {
    * @param string $name
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function createSuperhashlist($hashlists, $name, $user) {
+  public static function createSuperhashlist(array $hashlists, string $name, User $user): void {
     for ($i = 0; $i < sizeof($hashlists); $i++) {
-      if (intval($hashlists[$i]) <= 0) {
+      if ($hashlists[$i] <= 0) {
         unset($hashlists[$i]);
       }
     }
@@ -1061,7 +1072,6 @@ class HashlistUtils {
     foreach ($lists as $list) {
       if ($accessGroupId == null) {
         $accessGroupId = $list->getAccessGroupId();
-        continue;
       }
       else if ($list->getFormat() == DHashlistFormat::SUPERHASHLIST) {
         throw new HTException("You cannot create a new superhashlist containing a superhashlist!");
@@ -1089,8 +1099,9 @@ class HashlistUtils {
    * @param User $user
    * @return File
    * @throws HTException
+   * @throws Exception
    */
-  public static function leftlist($hashlistId, $user) {
+  public static function leftlist(int $hashlistId, User $user): File {
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     if ($hashlist->getFormat() == DHashlistFormat::WPA || $hashlist->getFormat() == DHashlistFormat::BINARY) {
       throw new HTException("You cannot create left lists for binary hashes!");
@@ -1151,8 +1162,9 @@ class HashlistUtils {
    * @param $user User
    * @return array
    * @throws HTException
+   * @throws Exception
    */
-  public static function getCrackedHashes($hashlistId, $user) {
+  public static function getCrackedHashes(int $hashlistId, User $user): array {
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     $lists = Util::checkSuperHashlist($hashlist);
     if (!AccessUtils::userCanAccessHashlists($lists, $user)) {
@@ -1186,8 +1198,9 @@ class HashlistUtils {
    * @param $accessGroupId int
    * @param $user User
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeAccessGroup($hashlistId, $accessGroupId, $user) {
+  public static function changeAccessGroup(int $hashlistId, int $accessGroupId, User $user): void {
     $hashlist = HashlistUtils::getHashlist($hashlistId);
     $accessGroup = AccessGroupUtils::getGroup($accessGroupId);
     

--- a/src/inc/utils/HashlistUtils.php
+++ b/src/inc/utils/HashlistUtils.php
@@ -982,8 +982,6 @@ class HashlistUtils {
             }
             $mac_cli = Util::bintohex($mac_cli);
             $hash = new HashBinary(null, $hashlist->getId(), $mac_ap . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $mac_cli . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . Util::bintohex($network), Util::bintohex($data), null, 0, null, 0, 0);
-            Factory::getHashBinaryFactory()->save($hash);
-            $added++;
           }
           else { // PMKID hashes
             $line = trim(fgets($file));
@@ -1005,9 +1003,9 @@ class HashlistUtils {
               $identification = $mac_ap . SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR) . $mac_cli;
             }
             $hash = new HashBinary(null, $hashlist->getId(), $identification, Util::bintohex($line . "\n"), null, 0, null, 0, 0);
-            Factory::getHashBinaryFactory()->save($hash);
-            $added++;
           }
+          Factory::getHashBinaryFactory()->save($hash);
+          $added++;
         }
         fclose($file);
         unlink($tmpfile);

--- a/src/inc/utils/HashlistUtils.php
+++ b/src/inc/utils/HashlistUtils.php
@@ -210,7 +210,7 @@ class HashlistUtils {
     }
     $wordCount = 0;
     $pagingSize = 5000;
-    if (SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE) !== false) {
+    if (SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE) !== null) {
       $pagingSize = SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE);
     }
     foreach ($lists as $list) {
@@ -745,7 +745,7 @@ class HashlistUtils {
     $qF2 = new QueryFilter(Hash::IS_CRACKED, "1", "=");
     $count = $factory->countFilter([Factory::FILTER => [$qF1, $qF2]]);
     $pagingSize = 5000;
-    if (SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE) !== false) {
+    if (SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE) !== null) {
       $pagingSize = SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE);
     }
     $separator = SConfig::getInstance()->getVal(DConfig::FIELD_SEPARATOR);
@@ -1131,7 +1131,7 @@ class HashlistUtils {
     $qF2 = new QueryFilter(Hash::IS_CRACKED, "0", "=");
     $count = Factory::getHashFactory()->countFilter([Factory::FILTER => [$qF1, $qF2]]);
     $pagingSize = 5000;
-    if (SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE) !== false) {
+    if (SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE) !== null) {
       $pagingSize = SConfig::getInstance()->getVal(DConfig::HASHES_PAGE_SIZE);
     }
     $numEntries = 0;

--- a/src/inc/utils/HashtypeUtils.php
+++ b/src/inc/utils/HashtypeUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\HashType;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\models\Hashlist;
@@ -16,8 +17,9 @@ class HashtypeUtils {
   /**
    * @param int $hashtypeId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteHashtype($hashtypeId) {
+  public static function deleteHashtype(int $hashtypeId): void {
     $hashtype = Factory::getHashTypeFactory()->get($hashtypeId);
     if ($hashtype == null) {
       throw new HTException("Invalid hashtype!");
@@ -40,6 +42,7 @@ class HashtypeUtils {
    * @param User $user
    * @return HashType
    * @throws HttpError
+   * @throws Exception
    */
   public static function addHashtype(int $hashtypeId, string $description, int $isSalted, bool $isSlowHash, User $user): HashType {
     $hashtype = Factory::getHashTypeFactory()->get($hashtypeId);

--- a/src/inc/utils/HealthUtils.php
+++ b/src/inc/utils/HealthUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\Agent;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\models\HealthCheckAgent;
@@ -22,8 +23,9 @@ class HealthUtils {
   /**
    * @param int $checkAgentId
    * @throws HTException
+   * @throws Exception
    */
-  public static function resetAgentCheck($checkAgentId) {
+  public static function resetAgentCheck(int $checkAgentId): void {
     $checkAgent = Factory::getHealthCheckAgentFactory()->get($checkAgentId);
     if ($checkAgent == null) {
       throw new HTException("Invalid health check agent ID!");
@@ -54,8 +56,9 @@ class HealthUtils {
    * Checks if there is a running health check which the agent has not completed yet.
    * @param Agent $agent
    * @return HealthCheckAgent|bool
+   * @throws Exception
    */
-  public static function checkNeeded($agent) {
+  public static function checkNeeded(Agent $agent): bool|HealthCheckAgent {
     $qF1 = new QueryFilter(HealthCheckAgent::AGENT_ID, $agent->getId(), "=");
     $qF2 = new QueryFilter(HealthCheckAgent::STATUS, DHealthCheckAgentStatus::PENDING, "=");
     $check = Factory::getHealthCheckAgentFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
@@ -75,8 +78,9 @@ class HealthUtils {
   /**
    * Check if the health check is completed (all agents sent a response)
    * @param HealthCheck $healthCheck
+   * @throws Exception
    */
-  public static function checkCompletion($healthCheck) {
+  public static function checkCompletion(HealthCheck $healthCheck): void {
     $qF = new QueryFilter(HealthCheckAgent::HEALTH_CHECK_ID, $healthCheck->getId(), "=");
     $checks = Factory::getHealthCheckAgentFactory()->filter([Factory::FILTER => $qF]);
     foreach ($checks as $check) {
@@ -92,10 +96,9 @@ class HealthUtils {
    * @return string
    * @throws HTException
    */
-  private static function getAttackMode($type) {
-    switch ($type) {
-      case DHealthCheckType::BRUTE_FORCE:
-        return " -a 3";
+  private static function getAttackMode(int $type): string {
+    if ($type == DHealthCheckType::BRUTE_FORCE) {
+      return " -a 3";
     }
     throw new HTException("Not able to get attack mode for this type!");
   }
@@ -106,7 +109,7 @@ class HealthUtils {
    * @return string
    * @throws HTException
    */
-  private static function getAttackInput($hashtypeId, $type) {
+  private static function getAttackInput(int $hashtypeId, int $type): string {
     if ($type == DHealthCheckType::BRUTE_FORCE && $hashtypeId == DHealthCheckMode::MD5) {
       return " -1 ?l?u?d ?1?1?1?1?1";
     }
@@ -123,7 +126,7 @@ class HealthUtils {
    * @return string
    * @throws HTException
    */
-  private static function getAttackPlain($hashtypeId, $type, $crackable) {
+  private static function getAttackPlain(int $hashtypeId, int $type, bool $crackable): string {
     if ($type == DHealthCheckType::BRUTE_FORCE && $hashtypeId == DHealthCheckMode::MD5) {
       return Util::randomString(($crackable) ? 5 : 8);
     }
@@ -137,14 +140,12 @@ class HealthUtils {
    * @param int $hashtypeId
    * @return integer
    */
-  private static function getAttackNumHashes($hashtypeId) {
-    switch ($hashtypeId) {
-      case DHealthCheckMode::MD5:
-        return 100;
-      case DHealthCheckMode::BCRYPT:
-        return 10;
-    }
-    return DHealthCheck::NUM_HASHES;
+  private static function getAttackNumHashes(int $hashtypeId): int {
+    return match ($hashtypeId) {
+      DHealthCheckMode::MD5 => 100,
+      DHealthCheckMode::BCRYPT => 10,
+      default => DHealthCheck::NUM_HASHES,
+    };
   }
   
   /**
@@ -153,8 +154,10 @@ class HealthUtils {
    * @param int $crackerBinaryId
    * @return HealthCheck
    * @throws HttpError
+   * @throws HTException
+   * @throws Exception
    */
-  public static function createHealthCheck($hashtypeId, $type, $crackerBinaryId) {
+  public static function createHealthCheck(int $hashtypeId, int $type, int $crackerBinaryId): HealthCheck {
     $crackerBinary = Factory::getCrackerBinaryFactory()->get($crackerBinaryId);
     if ($crackerBinary == null) {
       throw new HttpError("Invalid cracker binary selected!");
@@ -211,22 +214,20 @@ class HealthUtils {
    * @return string
    * @throws HTException
    */
-  public static function generateHash($hashtypeId, $plain) {
-    switch ($hashtypeId) {
-      case DHealthCheckMode::MD5:
-        return md5($plain);
-      case DHealthCheckMode::BCRYPT:
-        return password_hash($plain, PASSWORD_BCRYPT, ["cost" => 5]);
-      default:
-        throw new HTException("No implementation for this hash type available to generate hashes!");
-    }
+  public static function generateHash(int $hashtypeId, string $plain): string {
+    return match ($hashtypeId) {
+      DHealthCheckMode::MD5 => md5($plain),
+      DHealthCheckMode::BCRYPT => password_hash($plain, PASSWORD_BCRYPT, ["cost" => 5]),
+      default => throw new HTException("No implementation for this hash type available to generate hashes!"),
+    };
   }
   
   /**
    * @param int $healthCheckId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteHealthCheck($healthCheckId) {
+  public static function deleteHealthCheck(int $healthCheckId): void {
     $healthCheck = Factory::getHealthCheckFactory()->get($healthCheckId);
     if ($healthCheck === null) {
       throw new HTException("Invalid health check!");

--- a/src/inc/utils/HealthUtils.php
+++ b/src/inc/utils/HealthUtils.php
@@ -18,6 +18,7 @@ use Hashtopolis\inc\defines\DHealthCheckType;
 use Hashtopolis\inc\HTException;
 use Hashtopolis\inc\SConfig;
 use Hashtopolis\inc\Util;
+use Random\RandomException;
 
 class HealthUtils {
   /**
@@ -125,6 +126,7 @@ class HealthUtils {
    * @param bool $crackable
    * @return string
    * @throws HTException
+   * @throws RandomException
    */
   private static function getAttackPlain(int $hashtypeId, int $type, bool $crackable): string {
     if ($type == DHealthCheckType::BRUTE_FORCE && $hashtypeId == DHealthCheckMode::MD5) {

--- a/src/inc/utils/JwtTokenUtils.php
+++ b/src/inc/utils/JwtTokenUtils.php
@@ -2,14 +2,23 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\JwtApiKey;
 use Hashtopolis\inc\apiv2\error\HttpError;
 use Hashtopolis\inc\apiv2\error\HttpForbidden;
 
 class JwtTokenUtils {
-
-  public static function createKey(int $userId, int $startValid, int $endValid) {
+  
+  /**
+   * @param int $userId
+   * @param int $startValid
+   * @param int $endValid
+   * @return JwtApiKey
+   * @throws HttpError
+   * @throws Exception
+   */
+  public static function createKey(int $userId, int $startValid, int $endValid): JwtApiKey {
     $user = Factory::getUserFactory()->get($userId);
     if ($user == null) {
       throw new HttpError("Invalid user ID");
@@ -19,8 +28,14 @@ class JwtTokenUtils {
     Factory::getJwtApiKeyFactory()->save($key);
     return $key;
   }
-
-  public static function deleteKey(JwtApiKey $JwtToken) {
+  
+  /**
+   * @param JwtApiKey $JwtToken
+   * @return void
+   * @throws HttpForbidden
+   * @throws Exception
+   */
+  public static function deleteKey(JwtApiKey $JwtToken): void {
     $expireTime = $JwtToken->getEndValid();
     if (time() < $expireTime) {
       throw new HttpForbidden("Cannot delete API key before it expires; revoke it instead.");

--- a/src/inc/utils/Lock.php
+++ b/src/inc/utils/Lock.php
@@ -8,8 +8,8 @@ class Lock {
   const CHUNKING = "chunking.lock";
   const LOG      = "log.lock";
   
-  private $lockFile;
-  private $lock;
+  private string $lockFile;
+  private        $lock;
   
   /**
    * Lock constructor.
@@ -29,7 +29,7 @@ class Lock {
   /**
    * @throws Exception
    */
-  public function getLock() {
+  public function getLock(): void {
     // Get exclusive lock (blocking)
     $ret = flock($this->lock, LOCK_EX);
     if ($ret === false) {
@@ -40,7 +40,7 @@ class Lock {
   /**
    * @throws Exception
    */
-  public function release() {
+  public function release(): void {
     /* Release the lock */
     $ret = flock($this->lock, LOCK_UN);
     if ($ret === false) {

--- a/src/inc/utils/LockUtils.php
+++ b/src/inc/utils/LockUtils.php
@@ -13,7 +13,6 @@ class LockUtils {
    * @throws Exception
    */
   public static function get(string $lockFile): void {
-    $lock = null;
     if (isset(self::$locks[$lockFile])) {
       $lock = self::$locks[$lockFile];
     }

--- a/src/inc/utils/LockUtils.php
+++ b/src/inc/utils/LockUtils.php
@@ -6,13 +6,13 @@ use Exception;
 
 class LockUtils {
   /** @var Lock[] $locks */
-  private static $locks = array();
+  private static array $locks = [];
   
   /**
    * @param string $lockFile
    * @throws Exception
    */
-  public static function get($lockFile) {
+  public static function get(string $lockFile): void {
     $lock = null;
     if (isset(self::$locks[$lockFile])) {
       $lock = self::$locks[$lockFile];
@@ -34,7 +34,7 @@ class LockUtils {
   /**
    * @param string $lockFile
    */
-  public static function release($lockFile) {
+  public static function release(string $lockFile): void {
     if (isset(self::$locks[$lockFile])) {
       $lock = self::$locks[$lockFile];
       try {
@@ -53,7 +53,7 @@ class LockUtils {
    *
    * @return void
    */
-  public static function deleteLockFile($taskId) {
+  public static function deleteLockFile(int $taskId): void {
     $lockFile = dirname(__FILE__) . "/locks/" . Lock::CHUNKING . $taskId;
     if (file_exists($lockFile)) {
       unlink($lockFile);

--- a/src/inc/utils/NotificationUtils.php
+++ b/src/inc/utils/NotificationUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\NotificationSetting;
 use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\Factory;
@@ -23,12 +24,13 @@ class NotificationUtils {
    * @return NotificationSetting
    * @throws HTException
    * @throws HttpError
+   * @throws Exception
    */
   
   public static function createNotification(string $actionType, string $notification, string $receiver, array $post, ?User $user = null): NotificationSetting {
     if ($user == null) {
       $user = Login::getInstance()->getUser();
-    };
+    }
     
     $receiver = trim($receiver);
     if (!isset(HashtopolisNotification::getInstances()[$notification])) {
@@ -88,8 +90,9 @@ class NotificationUtils {
    * @param boolean $doToggle
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setActive($notification, $isActive, $doToggle, $user) {
+  public static function setActive(int $notification, bool $isActive, bool $doToggle, User $user): void {
     $notification = NotificationUtils::getNotification($notification);
     if ($notification->getUserId() != $user->getId()) {
       throw new HTException("You have no access to this notification!");
@@ -112,8 +115,9 @@ class NotificationUtils {
    * @param int $notification
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function delete($notification, $user) {
+  public static function delete(int $notification, User $user): void {
     $notification = NotificationUtils::getNotification($notification);
     if ($notification->getUserId() != $user->getId()) {
       throw new HTException("You are not allowed to delete this notification!");
@@ -125,8 +129,9 @@ class NotificationUtils {
    * @param int $notification
    * @return NotificationSetting
    * @throws HTException
+   * @throws Exception
    */
-  public static function getNotification($notification) {
+  public static function getNotification(int $notification): NotificationSetting {
     $notification = Factory::getNotificationSettingFactory()->get($notification);
     if ($notification == null) {
       throw new HTException("Notification not found!");

--- a/src/inc/utils/PreprocessorUtils.php
+++ b/src/inc/utils/PreprocessorUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\Preprocessor;
 use Hashtopolis\dba\QueryFilter;
@@ -23,6 +24,7 @@ class PreprocessorUtils {
    * @return Preprocessor
    * @throws HttpConflict
    * @throws HttpError
+   * @throws Exception
    */
   public static function addPreprocessor(string $name, string $binaryName, string $url, string $keyspaceCommand, string $skipCommand, string $limitCommand): Preprocessor {
     $qF = new QueryFilter(Preprocessor::NAME, $name, "=");
@@ -67,10 +69,12 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
+   * @param int $preprocessorId
+   * @throws HTException
    * @throws HttpError
+   * @throws Exception
    */
-  public static function delete($preprocessorId) {
+  public static function delete(int $preprocessorId): void {
     $preprocessor = PreprocessorUtils::getPreprocessor($preprocessorId);
     $qF = new QueryFilter(Task::USE_PREPROCESSOR, $preprocessor->getId(), "=");
     $check = Factory::getTaskFactory()->filter([Factory::FILTER => [$qF]]);
@@ -81,11 +85,12 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
+   * @param int $preprocessorId
    * @return Preprocessor
    * @throws HTException
+   * @throws Exception
    */
-  public static function getPreprocessor($preprocessorId) {
+  public static function getPreprocessor(int $preprocessorId): Preprocessor {
     $preprocessor = Factory::getPreprocessorFactory()->get($preprocessorId);
     if ($preprocessor === null) {
       throw new HTException("Invalid preprocessor!");
@@ -94,12 +99,13 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
-   * @param $name
+   * @param int $preprocessorId
+   * @param string $name
    * Edits the name of the preprocessor
    * @throws HTException when name already exists
+   * @throws Exception
    */
-  public static function editName($preprocessorId, $name) {
+  public static function editName(int $preprocessorId, string $name): void {
     $qF1 = new QueryFilter(Preprocessor::NAME, $name, "=");
     $qF2 = new QueryFilter(Preprocessor::PREPROCESSOR_ID, $preprocessorId, "<>");
     $check = Factory::getPreprocessorFactory()->filter([Factory::FILTER => [$qF1, $qF2]], true);
@@ -112,12 +118,13 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
-   * @param $binaryName
+   * @param int $preprocessorId
+   * @param string $binaryName
    * Edits the binaryName of the preprocessor
    * @throws HTException when BinaryName is empty or contains blacklisted characters
+   * @throws Exception
    */
-  public static function editBinaryName($preprocessorId, $binaryName) {
+  public static function editBinaryName(int $preprocessorId, string $binaryName): void {
     
     if (strlen($binaryName) == 0) {
       throw new HTException("Binary basename cannot be empty!");
@@ -130,12 +137,13 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
-   * @param $keyspaceCommand
+   * @param int $preprocessorId
+   * @param string $keyspaceCommand
    * Edits the keyspaceCommand of the preprocessor
    * @throws HTException when keyspaceCommand is empty or contains blacklisted characters
+   * @throws Exception
    */
-  public static function editKeyspaceCommand($preprocessorId, $keyspaceCommand) {
+  public static function editKeyspaceCommand(int $preprocessorId, string $keyspaceCommand): void {
     
     if (strlen($keyspaceCommand) == 0) {
       $keyspaceCommand = null;
@@ -148,12 +156,13 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
-   * @param $skipCommand
+   * @param int $preprocessorId
+   * @param string $skipCommand
    * Edits the skipCommand of the preprocessor
    * @throws HTException when skipCommand is empty or contains blacklisted characters
+   * @throws Exception
    */
-  public static function editSkipCommand($preprocessorId, $skipCommand) {
+  public static function editSkipCommand(int $preprocessorId, string $skipCommand): void {
     
     if (strlen($skipCommand) == 0) {
       $skipCommand = null;
@@ -166,12 +175,13 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
-   * @param $limitCommand
+   * @param int $preprocessorId
+   * @param string $limitCommand
    * Edits the limitCommand of the preprocessor
    * @throws HTException when limitCommand is empty or contains blacklisted characters
+   * @throws Exception
    */
-  public static function editLimitCommand($preprocessorId, $limitCommand) {
+  public static function editLimitCommand(int $preprocessorId, string $limitCommand): void {
     
     if (strlen($limitCommand) == 0) {
       $limitCommand = null;
@@ -184,16 +194,17 @@ class PreprocessorUtils {
   }
   
   /**
-   * @param $preprocessorId
-   * @param $name
-   * @param $binaryName
-   * @param $url
-   * @param $keyspaceCommand
-   * @param $skipCommand
-   * @param $limitCommand
+   * @param int $preprocessorId
+   * @param string $name
+   * @param string $binaryName
+   * @param string $url
+   * @param string $keyspaceCommand
+   * @param string $skipCommand
+   * @param string $limitCommand
    * @throws HTException
+   * @throws Exception
    */
-  public static function editPreprocessor($preprocessorId, $name, $binaryName, $url, $keyspaceCommand, $skipCommand, $limitCommand) {
+  public static function editPreprocessor(int $preprocessorId, string $name, string $binaryName, string $url, string $keyspaceCommand, string $skipCommand, string $limitCommand): void {
     $preprocessor = PreprocessorUtils::getPreprocessor($preprocessorId);
     
     $qF1 = new QueryFilter(Preprocessor::NAME, $name, "=");

--- a/src/inc/utils/PretaskUtils.php
+++ b/src/inc/utils/PretaskUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\dba\models\Pretask;
 use Hashtopolis\dba\models\FilePretask;
@@ -26,10 +27,11 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param string $attackCmd
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeAttack($pretaskId, $attackCmd) {
+  public static function changeAttack(int $pretaskId, string $attackCmd): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (strpos($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
+    if (!str_contains($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS))) {
       throw new HTException("The attack command does not contain the hashlist alias!");
     }
     else if (Util::containsBlacklistedChars($attackCmd)) {
@@ -42,7 +44,7 @@ class PretaskUtils {
    * @param Task $copy
    * @return Pretask
    */
-  public static function getFromTask($copy) {
+  public static function getFromTask(Task $copy): Pretask {
     return new Pretask(
       null,
       $copy->getTaskName(),
@@ -63,7 +65,7 @@ class PretaskUtils {
   /**
    * @return Pretask
    */
-  public static function getDefault() {
+  public static function getDefault(): Pretask {
     return new Pretask(
       null,
       '',
@@ -85,12 +87,10 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param int $isCpuOnly
    * @throws HTException
+   * @throws Exception
    */
-  public static function setCpuOnlyTask($pretaskId, $isCpuOnly) {
+  public static function setCpuOnlyTask(int $pretaskId, int $isCpuOnly): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (is_bool($isCpuOnly)) {
-      $isCpuOnly = ($isCpuOnly) ? 1 : 0;
-    }
     if (!is_numeric($isCpuOnly) || $isCpuOnly < 0 || $isCpuOnly > 1) {
       throw new HTException("Invalid boolean value!");
     }
@@ -101,12 +101,10 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param int $isSmall
    * @throws HTException
+   * @throws Exception
    */
-  public static function setSmallTask($pretaskId, $isSmall) {
+  public static function setSmallTask(int $pretaskId, int $isSmall): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (is_bool($isSmall)) {
-      $isSmall = ($isSmall) ? 1 : 0;
-    }
     if (!is_numeric($isSmall) || $isSmall < 0 || $isSmall > 1) {
       throw new HTException("Invalid boolean value!");
     }
@@ -117,8 +115,9 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param int $priority
    * @throws HTException
+   * @throws Exception
    */
-  public static function setPriority($pretaskId, $priority) {
+  public static function setPriority(int $pretaskId, int $priority): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
     if (!is_numeric($priority)) {
       throw new HTException("Priority needs to be a number!");
@@ -130,8 +129,9 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param int $maxAgents
    * @throws HTException
+   * @throws Exception
    */
-  public static function setMaxAgents($pretaskId, $maxAgents) {
+  public static function setMaxAgents(int $pretaskId, int $maxAgents): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
     if (!is_numeric($maxAgents)) {
       throw new HTException("Max agents needs to be a number!");
@@ -147,8 +147,9 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param string $color
    * @throws HTException
+   * @throws Exception
    */
-  public static function setColor($pretaskId, $color) {
+  public static function setColor(int $pretaskId, string $color): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
     if (strlen($color) > 0 && preg_match("/[0-9A-Fa-f]{6}/", $color) == 0) {
       throw new HTException("Invalid color!");
@@ -160,10 +161,10 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param int $chunkTime
    * @throws HTException
+   * @throws Exception
    */
-  public static function setChunkTime($pretaskId, $chunkTime) {
+  public static function setChunkTime(int $pretaskId, int $chunkTime): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    $chunkTime = intval($chunkTime);
     if ($chunkTime <= 0) {
       throw new HTException("Invalid chunk time!");
     }
@@ -174,8 +175,9 @@ class PretaskUtils {
    * @param int $pretaskId
    * @param string $newName
    * @throws HTException
+   * @throws Exception
    */
-  public static function renamePretask($pretaskId, $newName) {
+  public static function renamePretask(int $pretaskId, string $newName): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
     if (strlen($newName) == 0) {
       throw new HTException("Name cannot be empty!");
@@ -186,8 +188,9 @@ class PretaskUtils {
   /**
    * @param int $pretaskId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deletePretask($pretaskId) {
+  public static function deletePretask(int $pretaskId): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
     
     // delete connections to supertasks
@@ -204,8 +207,9 @@ class PretaskUtils {
   /**
    * @param boolean $includeMaskImports
    * @return Pretask[]
+   * @throws Exception
    */
-  public static function getPretasks($includeMaskImports = false) {
+  public static function getPretasks(bool $includeMaskImports = false): array {
     $oF = new OrderFilter(Pretask::PRIORITY, "DESC");
     if ($includeMaskImports) {
       $pretasks = Factory::getPretaskFactory()->filter([Factory::ORDER => $oF]);
@@ -221,8 +225,9 @@ class PretaskUtils {
    * @param int $pretaskId
    * @return Pretask
    * @throws HTException
+   * @throws Exception
    */
-  public static function getPretask($pretaskId) {
+  public static function getPretask(int $pretaskId): Pretask {
     $pretask = Factory::getPretaskFactory()->get($pretaskId);
     if ($pretask == null) {
       throw new HTException("Invalid preconfigured task!");
@@ -236,8 +241,9 @@ class PretaskUtils {
    * @param string $name
    * @param int $crackerBinaryId
    * @throws HTException
+   * @throws Exception
    */
-  public static function runPretask($pretaskId, $hashlistId, $name, $crackerBinaryId) {
+  public static function runPretask(int $pretaskId, int $hashlistId, string $name, int $crackerBinaryId): void {
     $pretask = Factory::getPretaskFactory()->get($pretaskId);
     if ($pretask == null) {
       throw new HTException("Invalid preconfigured task ID!");
@@ -311,6 +317,7 @@ class PretaskUtils {
    * @param int $priority
    * @return Pretask
    * @throws HttpError
+   * @throws Exception
    */
   public static function createPretask(string $name, string $cmdLine, int $chunkTime, int $statusTimer, string $color, int $cpuOnly, int $isSmall, int $benchmarkType, array|null $files, int $crackerBinaryTypeId, int|null $maxAgents, int $priority = 0): Pretask {
     $crackerBinaryType = Factory::getCrackerBinaryTypeFactory()->get($crackerBinaryTypeId);
@@ -330,8 +337,6 @@ class PretaskUtils {
     else if ($crackerBinaryType == null) {
       throw new HttpError("Invalid cracker binary type!");
     }
-    $chunkTime = intval($chunkTime);
-    $statusTimer = intval($statusTimer);
     $maxAgents = intval($maxAgents);
     if (strlen($color) > 0 && preg_match("/[0-9A-Fa-f]{6}/", $color) == 0) {
       $color = "";

--- a/src/inc/utils/PretaskUtils.php
+++ b/src/inc/utils/PretaskUtils.php
@@ -367,6 +367,7 @@ class PretaskUtils {
     $pretask = Factory::getPretaskFactory()->save($pretask);
     
     // handle files
+    $files = $files ?? [];
     foreach ($files as $fileId) {
       $file = Factory::getFileFactory()->get($fileId);
       if ($file !== null) {

--- a/src/inc/utils/PretaskUtils.php
+++ b/src/inc/utils/PretaskUtils.php
@@ -91,8 +91,8 @@ class PretaskUtils {
    */
   public static function setCpuOnlyTask(int $pretaskId, int $isCpuOnly): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (!is_numeric($isCpuOnly) || $isCpuOnly < 0 || $isCpuOnly > 1) {
-      throw new HTException("Invalid boolean value!");
+    if ($isCpuOnly < 0 || $isCpuOnly > 1) {
+      throw new HTException("Invalid cpuOnly value!");
     }
     Factory::getPretaskFactory()->set($pretask, Pretask::IS_CPU_TASK, $isCpuOnly);
   }
@@ -105,8 +105,8 @@ class PretaskUtils {
    */
   public static function setSmallTask(int $pretaskId, int $isSmall): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (!is_numeric($isSmall) || $isSmall < 0 || $isSmall > 1) {
-      throw new HTException("Invalid boolean value!");
+    if ($isSmall < 0 || $isSmall > 1) {
+      throw new HTException("Invalid cpuOnly value!");
     }
     Factory::getPretaskFactory()->set($pretask, Pretask::IS_SMALL, $isSmall);
   }
@@ -119,10 +119,7 @@ class PretaskUtils {
    */
   public static function setPriority(int $pretaskId, int $priority): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (!is_numeric($priority)) {
-      throw new HTException("Priority needs to be a number!");
-    }
-    Factory::getPretaskFactory()->set($pretask, Pretask::PRIORITY, intval($priority));
+    Factory::getPretaskFactory()->set($pretask, Pretask::PRIORITY, $priority);
   }
   
   /**
@@ -133,10 +130,6 @@ class PretaskUtils {
    */
   public static function setMaxAgents(int $pretaskId, int $maxAgents): void {
     $pretask = PretaskUtils::getPretask($pretaskId);
-    if (!is_numeric($maxAgents)) {
-      throw new HTException("Max agents needs to be a number!");
-    }
-    $maxAgents = intval($maxAgents);
     if ($maxAgents < 0) {
       throw new HTException("Max agents cannot be negative!");
     }

--- a/src/inc/utils/PretaskUtils.php
+++ b/src/inc/utils/PretaskUtils.php
@@ -64,6 +64,7 @@ class PretaskUtils {
   
   /**
    * @return Pretask
+   * @throws Exception
    */
   public static function getDefault(): Pretask {
     return new Pretask(

--- a/src/inc/utils/SupertaskUtils.php
+++ b/src/inc/utils/SupertaskUtils.php
@@ -344,7 +344,7 @@ class SupertaskUtils {
    * @throws Exception
    */
   public static function createSupertask(string $name, array|null $pretasks): Supertask {
-    if (sizeof($pretasks) == 0) {
+    if ($pretasks == null || sizeof($pretasks) == 0) {
       throw new HttpError("Cannot create empty supertask!");
     }
     $tasks = [];

--- a/src/inc/utils/SupertaskUtils.php
+++ b/src/inc/utils/SupertaskUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\models\CrackerBinaryType;
 use Hashtopolis\dba\models\Supertask;
 use Hashtopolis\dba\models\SupertaskPretask;
@@ -27,15 +28,18 @@ class SupertaskUtils {
    * @param string $name
    * @param string $command
    * @param bool $isCpuOnly
+   * @param int $maxAgents
    * @param bool $isSmall
    * @param int $crackerBinaryTypeId
    * @param string $benchtype
    * @param string[] $basefiles
    * @param string[] $iterfiles
    * @param User $user
+   * @return Supertask
    * @throws HTException
+   * @throws Exception
    */
-  public static function bulkSupertask($name, $command, $isCpuOnly, $maxAgents, $isSmall, $crackerBinaryTypeId, $benchtype, $basefiles, $iterfiles, $user): Supertask {
+  public static function bulkSupertask(string $name, string $command, bool $isCpuOnly, int $maxAgents, bool $isSmall, int $crackerBinaryTypeId, string $benchtype, array $basefiles, array $iterfiles, User $user): Supertask {
     $isCpuOnly = ($isCpuOnly) ? 1 : 0;
     $isSmall = ($isSmall) ? 1 : 0;
     $benchtype = ($benchtype == 'speed') ? 1 : 0;
@@ -43,21 +47,17 @@ class SupertaskUtils {
     if ($crackerBinaryType == null) {
       throw new HTException("Invalid cracker type ID!");
     }
-    else if (strpos($command, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
+    else if (!str_contains($command, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS))) {
       throw new HTException("Command line must contain hashlist alias (" . SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS) . ")!");
     }
     else if (Util::containsBlacklistedChars($command)) {
       throw new HTException("The command must contain no blacklisted characters!");
     }
-    else if (!is_array($iterfiles) || sizeof($iterfiles) == 0) {
+    else if (sizeof($iterfiles) == 0) {
       throw new HTException("At least one file needs to be selected to iterate over!");
     }
-    else if (strpos($command, "FILE") === false) {
+    else if (!str_contains($command, "FILE")) {
       throw new HTException("No placeholder (FILE) for the iteration!");
-    }
-    
-    if (!is_array($basefiles)) {
-      $basefiles = [];
     }
     
     $basefilesChecked = [];
@@ -103,12 +103,14 @@ class SupertaskUtils {
    * @param File[] $basefiles
    * @param File[] $iterfiles
    * @param int $isSmall
+   * @param int $maxAgents
    * @param int $isCpuOnly
    * @param CrackerBinaryType $crackerBinaryType
    * @param int $benchtype
    * @return Pretask[]
+   * @throws Exception
    */
-  public static function createIterationPretasks($command, $name, $basefiles, $iterfiles, $isSmall, $maxAgents, $isCpuOnly, $crackerBinaryType, $benchtype) {
+  public static function createIterationPretasks(string $command, string $name, array $basefiles, array $iterfiles, int $isSmall, int $maxAgents, int $isCpuOnly, CrackerBinaryType $crackerBinaryType, int $benchtype): array {
     // create the preconf tasks
     $preTasks = array();
     $priority = sizeof($iterfiles) + 1;
@@ -151,8 +153,9 @@ class SupertaskUtils {
    * @param int $supertaskId
    * @param string $newName
    * @throws HTException
+   * @throws Exception
    */
-  public static function renameSupertask($supertaskId, $newName) {
+  public static function renameSupertask(int $supertaskId, string $newName): void {
     $supertask = SupertaskUtils::getSupertask($supertaskId);
     Factory::getSupertaskFactory()->set($supertask, Supertask::SUPERTASK_NAME, $newName);
   }
@@ -160,8 +163,9 @@ class SupertaskUtils {
   /**
    * @param int $supertaskId
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteSupertask($supertaskId) {
+  public static function deleteSupertask(int $supertaskId): void {
     $supertask = SupertaskUtils::getSupertask($supertaskId);
     Factory::getAgentFactory()->getDB()->beginTransaction();
     
@@ -186,8 +190,9 @@ class SupertaskUtils {
   /**
    * @param int $taskWrapperId
    * @return Task[]
+   * @throws Exception
    */
-  public static function getRunningSubtasks($taskWrapperId) {
+  public static function getRunningSubtasks(int $taskWrapperId): array {
     $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $taskWrapperId, "=");
     $oF = new OrderFilter(Task::PRIORITY, "DESC");
     return Factory::getTaskFactory()->filter([Factory::FILTER => $qF, Factory::ORDER => $oF]);
@@ -198,8 +203,9 @@ class SupertaskUtils {
    * @param User $user
    * @return TaskWrapper
    * @throws HTException
+   * @throws Exception
    */
-  public static function getRunningSupertask($taskWrapperId, $user) {
+  public static function getRunningSupertask(int $taskWrapperId, User $user): TaskWrapper {
     $supertask = Factory::getTaskWrapperFactory()->get($taskWrapperId);
     if ($supertask == null) {
       throw new HTException("Invalid taskwrapper ID!");
@@ -212,8 +218,9 @@ class SupertaskUtils {
   
   /**
    * @return Supertask[]
+   * @throws Exception
    */
-  public static function getAllSupertasks() {
+  public static function getAllSupertasks(): array {
     $oF = new OrderFilter(Supertask::SUPERTASK_ID, "ASC");
     return Factory::getSupertaskFactory()->filter([Factory::ORDER => $oF]);
   }
@@ -221,8 +228,9 @@ class SupertaskUtils {
   /**
    * @param int $supertaskId
    * @return Pretask[]
+   * @throws Exception
    */
-  public static function getPretasksOfSupertask($supertaskId) {
+  public static function getPretasksOfSupertask(int $supertaskId): array {
     $oF = new OrderFilter(Pretask::PRIORITY, "DESC", Factory::getPretaskFactory());
     $qF = new QueryFilter(SupertaskPretask::SUPERTASK_ID, $supertaskId, "=", Factory::getSupertaskPretaskFactory());
     $jF = new JoinFilter(Factory::getSupertaskPretaskFactory(), Pretask::PRETASK_ID, SupertaskPretask::PRETASK_ID);
@@ -234,8 +242,9 @@ class SupertaskUtils {
    * @param int $supertaskId
    * @return Supertask
    * @throws HTException
+   * @throws Exception
    */
-  public static function getSupertask($supertaskId) {
+  public static function getSupertask(int $supertaskId): Supertask {
     $supertask = Factory::getSupertaskFactory()->get($supertaskId);
     if ($supertask == null) {
       throw new HTException("Invalid supertask ID!");
@@ -248,8 +257,9 @@ class SupertaskUtils {
    * @param int $hashlistId
    * @param int $crackerId
    * @throws HTException
+   * @throws Exception
    */
-  public static function runSupertask($supertaskId, $hashlistId, $crackerId) {
+  public static function runSupertask(int $supertaskId, int $hashlistId, int $crackerId): void {
     $supertask = Factory::getSupertaskFactory()->get($supertaskId);
     if ($supertask == null) {
       throw new HTException("Invalid supertask ID!");
@@ -316,7 +326,7 @@ class SupertaskUtils {
         0,
         ''
       );
-      if ($hashlist->getHexSalt() == 1 && strpos($task->getAttackCmd(), "--hex-salt") === false) {
+      if ($hashlist->getHexSalt() == 1 && !str_contains($task->getAttackCmd(), "--hex-salt")) {
         $task->setAttackCmd("--hex-salt " . $task->getAttackCmd());
       }
       $task = Factory::getTaskFactory()->save($task);
@@ -331,6 +341,7 @@ class SupertaskUtils {
    * @param int[] $pretasks
    * @return Supertask
    * @throws HttpError
+   * @throws Exception
    */
   public static function createSupertask(string $name, array|null $pretasks): Supertask {
     if (sizeof($pretasks) == 0) {
@@ -361,24 +372,23 @@ class SupertaskUtils {
   /**
    * @param string $name
    * @param boolean $isCpuOnly
+   * @param int $maxAgents
    * @param boolean $isSmall
    * @param boolean $useOptimized
    * @param int $crackerBinaryTypeId
    * @param array $masks
    * @param string $benchtype
+   * @return Supertask
    * @throws HTException
+   * @throws Exception
    */
-  public static function importSupertask($name, $isCpuOnly, $maxAgents, $isSmall, $useOptimized, $crackerBinaryTypeId, $masks, $benchtype): Supertask {
+  public static function importSupertask(string $name, bool $isCpuOnly, int $maxAgents, bool $isSmall, bool $useOptimized, int $crackerBinaryTypeId, array $masks, string $benchtype): Supertask {
     $isCpuOnly = ($isCpuOnly) ? 1 : 0;
     $isSmall = ($isSmall) ? 1 : 0;
-    $useOptimized = ($useOptimized) ? true : false;
     $benchtype = ($benchtype == 'speed') ? 1 : 0;
     $crackerBinaryType = Factory::getCrackerBinaryTypeFactory()->get($crackerBinaryTypeId);
     if ($crackerBinaryType == null) {
       throw new HTException("Invalid cracker type ID!");
-    }
-    else if (!is_array($masks)) {
-      throw new HTException("Masks need to be provided as array!");
     }
     SupertaskUtils::prepareImportMasks($masks);
     if (sizeof($masks) == 0) {
@@ -399,15 +409,17 @@ class SupertaskUtils {
   }
   
   /**
-   * @param $masks
-   * @param $isSmall
-   * @param $isCpu
-   * @param $crackerBinaryType CrackerBinaryType
+   * @param array $masks
+   * @param bool $isSmall
+   * @param int $maxAgents
+   * @param bool $isCpu
+   * @param CrackerBinaryType $crackerBinaryType
    * @param bool $useOptimized
    * @param int $newBench
    * @return array
+   * @throws Exception
    */
-  private static function createImportPretasks($masks, $isSmall, $maxAgents, $isCpu, $crackerBinaryType, $useOptimized = false, $newBench = 1) {
+  private static function createImportPretasks(array $masks, bool $isSmall, int $maxAgents, bool $isCpu, CrackerBinaryType $crackerBinaryType, bool $useOptimized = false, int $newBench = 1): array {
     // create the preconf tasks
     $preTasks = array();
     $priority = sizeof($masks) + 1;
@@ -460,7 +472,7 @@ class SupertaskUtils {
   /**
    * @param array $masks
    */
-  private static function prepareImportMasks(&$masks) {
+  private static function prepareImportMasks(array &$masks): void {
     for ($i = 0; $i < sizeof($masks); $i++) {
       if (strlen($masks[$i]) == 0) {
         unset($masks[$i]);
@@ -468,7 +480,7 @@ class SupertaskUtils {
       }
       $mask = str_replace("\\,", "COMMA_PLACEHOLDER", $masks[$i]);
       $mask = str_replace("\\#", "HASH_PLACEHOLDER", $mask);
-      if (strpos($mask, "#") !== false) {
+      if (str_contains($mask, "#")) {
         $mask = substr($mask, 0, strpos($mask, "#"));
       }
       $mask = explode(",", $mask);
@@ -481,11 +493,12 @@ class SupertaskUtils {
   }
   
   /**
-   * @param $supertaskId
-   * @param $pretaskId
+   * @param int $supertaskId
+   * @param int $pretaskId
    * @throws HTException
+   * @throws Exception
    */
-  public static function removePretaskFromSupertask($supertaskId, $pretaskId) {
+  public static function removePretaskFromSupertask(int $supertaskId, int $pretaskId): void {
     if ($supertaskId == null) {
       throw new HTException("Invalid supertask ID!");
     }
@@ -505,11 +518,12 @@ class SupertaskUtils {
   }
   
   /**
-   * @param $supertaskId
-   * @param $pretaskId
+   * @param int $supertaskId
+   * @param int $pretaskId
    * @throws HTException
+   * @throws Exception
    */
-  public static function addPretaskToSupertask($supertaskId, $pretaskId) {
+  public static function addPretaskToSupertask(int $supertaskId, int $pretaskId): void {
     if ($supertaskId == null) {
       throw new HTException("Invalid supertask ID!");
     }

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -54,7 +54,7 @@ class TaskUtils {
    * @param Pretask $copy
    * @return Task
    */
-  public static function getFromPretask($copy) {
+  public static function getFromPretask(Pretask $copy): Task {
     return new Task(
       null,
       $copy->getTaskName(),
@@ -86,7 +86,7 @@ class TaskUtils {
   /**
    * @return Task
    */
-  public static function getDefault() {
+  public static function getDefault(): Task {
     return new Task(
       null,
       "",
@@ -120,18 +120,21 @@ class TaskUtils {
    * @param string $notes
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function editNotes($taskId, $notes, $user) {
+  public static function editNotes(int $taskId, string $notes, User $user): void {
     $task = TaskUtils::getTask($taskId, $user);
     Factory::getTaskFactory()->set($task, Task::NOTES, $notes);
   }
   
-  // Function for taskwrapper api to determine based on the chunks if a task is running, idle or completed.
-  // Status 1 is running, 2 is idle and 3 is completed.
   /**
+   * Function for taskwrapper api to determine based on the chunks if a task is running, idle or completed.
+   *
    * @param Task $task
+   * @return int Status 1 is running, 2 is idle and 3 is completed.
+   * @throws Exception
    */
-  public static function getStatus($task) {
+  public static function getStatus(Task $task): int {
     $qF1 = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     $qF2 = new QueryFilter(Chunk::PROGRESS, 10000, "<");
     $chunks = Factory::getChunkFactory()->filter([Factory::FILTER => [$qF1, $qF2]]);
@@ -157,8 +160,9 @@ class TaskUtils {
   
   /**
    * @param User $user
+   * @throws Exception
    */
-  public static function deleteArchived($user) {
+  public static function deleteArchived(User $user): void {
     $accessGroups = AccessUtils::getAccessGroupsOfUser($user);
     $qF1 = new QueryFilter(TaskWrapper::IS_ARCHIVED, 1, "=");
     $qF2 = new ContainFilter(TaskWrapper::ACCESS_GROUP_ID, Util::arrayOfIds($accessGroups));
@@ -180,12 +184,13 @@ class TaskUtils {
    * @param User $user
    * @return void
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeAttackCmd($taskId, $attackCmd, $user) {
+  public static function changeAttackCmd(int $taskId, string $attackCmd, User $user): void {
     if (strlen($attackCmd) == 0) {
       throw new HTException("Attack command cannot be empty!");
     }
-    else if (strpos($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
+    else if (!str_contains($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS))) {
       throw new HTException("Attack command must contain the hashlist alias!");
     }
     else if (Util::containsBlacklistedChars($attackCmd)) {
@@ -206,8 +211,9 @@ class TaskUtils {
    * @param int $supertaskId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function archiveSupertask($supertaskId, $user) {
+  public static function archiveSupertask(int $supertaskId, User $user): void {
     $taskWrapper = TaskUtils::getTaskWrapper($supertaskId, $user);
     $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $taskWrapper->getId(), "=");
     $uS = new UpdateSet(Task::IS_ARCHIVED, 1);
@@ -219,8 +225,9 @@ class TaskUtils {
    * @param int $taskId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function archiveTask($taskId, $user) {
+  public static function archiveTask(int $taskId, User $user): void {
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
     if ($taskWrapper->getTaskType() == DTaskTypes::NORMAL) {
@@ -234,8 +241,9 @@ class TaskUtils {
    * @param bool $taskState
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function toggleArchiveTask($taskId, $taskState, $user) {
+  public static function toggleArchiveTask(int $taskId, bool $taskState, User $user): void {
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
     switch ($taskWrapper->getTaskType()) {
@@ -258,8 +266,9 @@ class TaskUtils {
    * @param string $newName
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function renameSupertask($taskWrapperId, $newName, $user) {
+  public static function renameSupertask(int $taskWrapperId, string $newName, User $user): void {
     $taskWrapper = TaskUtils::getTaskWrapper($taskWrapperId, $user);
     Factory::getTaskWrapperFactory()->set($taskWrapper, TaskWrapper::TASK_WRAPPER_NAME, $newName);
   }
@@ -267,8 +276,9 @@ class TaskUtils {
   /**
    * @param int $taskWrapperId
    * @return Task
+   * @throws Exception
    */
-  public static function getTaskOfWrapper($taskWrapperId) {
+  public static function getTaskOfWrapper(int $taskWrapperId): Task {
     $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $taskWrapperId, "=");
     return Factory::getTaskFactory()->filter([Factory::FILTER => $qF], true);
   }
@@ -276,8 +286,9 @@ class TaskUtils {
   /**
    * @param int $taskWrapperId
    * @return Task[]
+   * @throws Exception
    */
-  public static function getTasksOfWrapper($taskWrapperId) {
+  public static function getTasksOfWrapper(int $taskWrapperId): array {
     $qF = new QueryFilter(Task::TASK_WRAPPER_ID, $taskWrapperId, "=");
     return Factory::getTaskFactory()->filter([Factory::FILTER => $qF]);
   }
@@ -285,8 +296,9 @@ class TaskUtils {
   /**
    * @param User $user
    * @return TaskWrapper[]
+   * @throws Exception
    */
-  public static function getTaskWrappersForUser($user) {
+  public static function getTaskWrappersForUser(User $user): array {
     $accessGroupIds = Util::getAccessGroupIds($user->getId());
     
     $qF = new ContainFilter(TaskWrapper::ACCESS_GROUP_ID, $accessGroupIds);
@@ -298,8 +310,9 @@ class TaskUtils {
   /**
    * @param int $taskId
    * @return Assignment[]
+   * @throws Exception
    */
-  public static function getAssignments($taskId) {
+  public static function getAssignments(int $taskId): array {
     $qF = new QueryFilter(Assignment::TASK_ID, $taskId, "=");
     return Factory::getAssignmentFactory()->filter([Factory::FILTER => $qF]);
   }
@@ -307,8 +320,9 @@ class TaskUtils {
   /**
    * @param int $taskId
    * @return Chunk[]
+   * @throws Exception
    */
-  public static function getChunks($taskId) {
+  public static function getChunks(int $taskId): array {
     $qF = new QueryFilter(Chunk::TASK_ID, $taskId, "=");
     $oF = new OrderFilter(Chunk::DISPATCH_TIME, "DESC");
     return Factory::getChunkFactory()->filter([Factory::FILTER => $qF, Factory::ORDER => $oF]);
@@ -319,8 +333,9 @@ class TaskUtils {
    * @param User $user
    * @return TaskWrapper
    * @throws HTException
+   * @throws Exception
    */
-  public static function getTaskWrapper($taskWrapperId, $user) {
+  public static function getTaskWrapper(int $taskWrapperId, User $user): TaskWrapper {
     $taskWrapper = Factory::getTaskWrapperFactory()->get($taskWrapperId);
     if ($taskWrapper == null) {
       throw new HTException("Invalid taskWrapper ID!");
@@ -336,8 +351,9 @@ class TaskUtils {
    * @param User $user
    * @return Task
    * @throws HTException
+   * @throws Exception
    */
-  public static function getTask($taskId, $user) {
+  public static function getTask(int $taskId, User $user): Task {
     $task = Factory::getTaskFactory()->get($taskId);
     if ($task == null) {
       throw new HTException("Invalid task ID!");
@@ -352,11 +368,11 @@ class TaskUtils {
   /**
    * @param Pretask $pretask
    * @param Task $task
+   * @throws Exception
    */
-  public static function copyPretaskFiles($pretask, $task) {
+  public static function copyPretaskFiles(Pretask $pretask, Task $task): void {
     $qF = new QueryFilter(FilePretask::PRETASK_ID, $pretask->getId(), "=");
     $pretaskFiles = Factory::getFilePretaskFactory()->filter([Factory::FILTER => $qF]);
-    $subTasks[] = $task;
     foreach ($pretaskFiles as $pretaskFile) {
       $fileTask = new FileTask(null, $pretaskFile->getFileId(), $task->getId());
       Factory::getFileTaskFactory()->save($fileTask);
@@ -370,14 +386,12 @@ class TaskUtils {
    * @param User $user
    * @param bool $topPriority
    * @throws HTException
+   * @throws Exception
    */
-  public static function setSupertaskPriority($supertaskId, $priority, $user, $topPriority = false) {
+  public static function setSupertaskPriority(int $supertaskId, int $priority, User $user, bool $topPriority = false): void {
     // note that supertaskId here corresponds with the taskwrapper Id of the underlying subtasks of the running supertask
     $supertaskWrapper = TaskUtils::getTaskWrapper($supertaskId, $user);
-    if ($supertaskWrapper === null) {
-      throw new HTException("Invalid supertask!");
-    }
-    else if (!AccessUtils::userCanAccessTask($supertaskWrapper, $user)) {
+    if (!AccessUtils::userCanAccessTask($supertaskWrapper, $user)) {
       throw new HTException("No access to this task!");
     }
     $priority = self::getIntegerPriorityValue($priority, $topPriority, $user, $supertaskWrapper);
@@ -387,17 +401,18 @@ class TaskUtils {
   /**
    * @param int $priority
    * @param bool $topPriority
-   * @param $user
-   * @param $taskWrapper
+   * @param User $user
+   * @param TaskWrapper $taskWrapper
    * @return int
+   * @throws Exception
    */
-  public static function getIntegerPriorityValue($priority, $topPriority, $user, $taskWrapper) {
+  public static function getIntegerPriorityValue(int $priority, bool $topPriority, User $user, TaskWrapper $taskWrapper): int {
     if ($topPriority) {
       // determine the current highest priority of all tasks this user has access to
       $auxTaskWrappers = TaskUtils::getTaskWrappersForUser($user);
       $highestPriority = 0;
       foreach ($auxTaskWrappers as $auxTaskWrapper) {
-        if ($auxTaskWrapper != $taskWrapper) {
+        if ($auxTaskWrapper->getId() != $taskWrapper->getId()) {
           if ($auxTaskWrapper->getPriority() > $highestPriority) {
             $highestPriority = $auxTaskWrapper->getPriority();
           }
@@ -407,7 +422,6 @@ class TaskUtils {
       $priority = $highestPriority + 100;
     }
     else {
-      $priority = intval($priority);
       $priority = ($priority < 0) ? 0 : $priority;
     }
     return $priority;
@@ -415,11 +429,12 @@ class TaskUtils {
   
   /**
    * @param int $taskId
-   * @param int $isCpuOnly
+   * @param bool $isCpuOnly
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setCpuTask($taskId, $isCpuOnly, $user) {
+  public static function setCpuTask(int $taskId, bool $isCpuOnly, User $user): void {
     $task = Factory::getTaskFactory()->get($taskId);
     if ($task == null) {
       throw new HTException("No such task!");
@@ -437,8 +452,9 @@ class TaskUtils {
   
   /**
    * @param User $user
+   * @throws Exception
    */
-  public static function deleteFinished($user) {
+  public static function deleteFinished(User $user): void {
     // check every task wrapper (non-archived ones)
     $qF = new QueryFilter(TaskWrapper::IS_ARCHIVED, 0, "=");
     $taskWrappers = Factory::getTaskWrapperFactory()->filter([Factory::FILTER => $qF]);
@@ -481,8 +497,9 @@ class TaskUtils {
    * @param int $chunkTime
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function changeChunkTime($taskId, $chunkTime, $user) {
+  public static function changeChunkTime(int $taskId, int $chunkTime, User $user): void {
     // update task chunk time
     $task = Factory::getTaskFactory()->get($taskId);
     if ($task == null) {
@@ -492,7 +509,6 @@ class TaskUtils {
     if (!AccessUtils::userCanAccessTask($taskWrapper, $user)) {
       throw new HTException("No access to this task!");
     }
-    $chunktime = intval($chunkTime);
     Factory::getAgentFactory()->getDB()->beginTransaction();
     $qF = new QueryFilter(Assignment::TASK_ID, $task->getId(), "=", Factory::getTaskFactory());
     $jF = new JoinFilter(Factory::getTaskFactory(), Task::TASK_ID, Assignment::TASK_ID);
@@ -501,10 +517,10 @@ class TaskUtils {
     $assignments = $join[Factory::getAssignmentFactory()->getModelName()];
     foreach ($assignments as $assignment) {
       if ($task->getUseNewBench() == 0) {
-        Factory::getAssignmentFactory()->set($assignment, Assignment::BENCHMARK, $assignment->getBenchmark() / $task->getChunkTime() * $chunktime);
+        Factory::getAssignmentFactory()->set($assignment, Assignment::BENCHMARK, $assignment->getBenchmark() / $task->getChunkTime() * $chunkTime);
       }
     }
-    $task->setChunkTime($chunktime);
+    $task->setChunkTime($chunkTime);
     Factory::getTaskFactory()->update($task);
     Factory::getAgentFactory()->getDB()->commit();
   }
@@ -513,9 +529,10 @@ class TaskUtils {
    * @param int $chunkId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function abortChunk($chunkId, $user) {
-    // reset chunk state and progress to zero
+  public static function abortChunk(int $chunkId, User $user): void {
+    // set chunk to aborted
     $chunk = Factory::getChunkFactory()->get($chunkId);
     if ($chunk == null) {
       throw new HTException("No such chunk!");
@@ -532,8 +549,9 @@ class TaskUtils {
    * @param int $chunkId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function resetChunk($chunkId, $user) {
+  public static function resetChunk(int $chunkId, User $user): void {
     // reset chunk state and progress to zero
     $chunk = Factory::getChunkFactory()->get($chunkId);
     if ($chunk == null) {
@@ -560,8 +578,9 @@ class TaskUtils {
    * @param string $benchmark
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setBenchmark($agentId, $benchmark, $user) {
+  public static function setBenchmark(int $agentId, string $benchmark, User $user): void {
     // adjust agent benchmark
     $qF = new QueryFilter(Assignment::AGENT_ID, $agentId, "=");
     $assignment = Factory::getAssignmentFactory()->filter([Factory::FILTER => $qF], true);
@@ -579,8 +598,9 @@ class TaskUtils {
    * @param int $taskId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function purgeTask($taskId, $user) {
+  public static function purgeTask(int $taskId, User $user): void {
     // delete all task chunks, forget its keyspace value and reset progress to zero
     $task = Factory::getTaskFactory()->get($taskId);
     if ($task == null) {
@@ -625,10 +645,11 @@ class TaskUtils {
   /**
    * @param int $taskId
    * @param User $user
-   * @param boolean $api
+   * @param bool $api
    * @throws HTException
+   * @throws Exception
    */
-  public static function delete($taskId, $user, $api = false) {
+  public static function delete(int $taskId, User $user, bool $api = false): void {
     // delete a task
     $task = Factory::getTaskFactory()->get($taskId);
     if ($task == null) {
@@ -660,10 +681,10 @@ class TaskUtils {
    * @param int $isSmall
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setSmallTask($taskId, $isSmall, $user) {
+  public static function setSmallTask(int $taskId, int $isSmall, User $user): void {
     $task = TaskUtils::getTask($taskId, $user);
-    $isSmall = intval($isSmall);
     if ($isSmall != 0 && $isSmall != 1) {
       $isSmall = 0;
     }
@@ -675,11 +696,11 @@ class TaskUtils {
    * @param int $maxAgents
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setTaskMaxAgents($taskId, $maxAgents, $user) {
+  public static function setTaskMaxAgents(int $taskId, int $maxAgents, User $user): void {
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
-    $maxAgents = intval($maxAgents);
     Factory::getTaskFactory()->set($task, Task::MAX_AGENTS, $maxAgents);
     if ($taskWrapper->getTaskType() != DTaskTypes::SUPERTASK) {
       Factory::getTaskWrapperFactory()->set($taskWrapper, TaskWrapper::MAX_AGENTS, $maxAgents);
@@ -691,10 +712,10 @@ class TaskUtils {
    * @param int $maxAgents
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function setSuperTaskMaxAgents($superTaskId, $maxAgents, $user) {
+  public static function setSuperTaskMaxAgents(int $superTaskId, int $maxAgents, User $user): void {
     $taskWrapper = TaskUtils::getTaskWrapper($superTaskId, $user);
-    $maxAgents = intval($maxAgents);
     Factory::getTaskWrapperFactory()->set($taskWrapper, TaskWrapper::MAX_AGENTS, $maxAgents);
   }
   
@@ -703,8 +724,9 @@ class TaskUtils {
    * @param string $color
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function updateColor($taskId, $color, $user) {
+  public static function updateColor(int $taskId, string $color, User $user): void {
     // change task color
     $task = TaskUtils::getTask($taskId, $user);
     if (preg_match("/[0-9A-Za-z]{6}/", $color) == 0) {
@@ -718,8 +740,9 @@ class TaskUtils {
    * @param string $name
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function rename($taskId, $name, $user) {
+  public static function rename(int $taskId, string $name, User $user): void {
     // change task name
     $task = TaskUtils::getTask($taskId, $user);
     Factory::getTaskFactory()->set($task, Task::TASK_NAME, $name);
@@ -730,18 +753,15 @@ class TaskUtils {
    * @param int $statusTimer
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function updateStatusTimer($taskId, $statusTimer, $user) {
+  public static function updateStatusTimer(int $taskId, int $statusTimer, User $user): void {
     // change the statusTimer value, the interval in seconds clients should report back to the server
     $task = TaskUtils::getTask($taskId, $user);
-    if ($task == null) {
-      throw new HTException("No such task!");
-    }
     $taskWrapper = Factory::getTaskWrapperFactory()->get($task->getTaskWrapperId());
     if (!AccessUtils::userCanAccessTask($taskWrapper, $user)) {
       throw new HTException("No access to this task!");
     }
-    $statusTimer = intval($statusTimer);
     
     if ($statusTimer <= 0) {
       throw new HTException("Invalid status interval!");
@@ -759,8 +779,9 @@ class TaskUtils {
    * @param User $user
    * @param bool $topPriority
    * @throws HTException
+   * @throws Exception
    */
-  public static function updatePriority($taskId, $priority, $user, $topPriority = false) {
+  public static function updatePriority(int $taskId, int $priority, User $user, bool $topPriority = false): void {
     // change task priority
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
@@ -776,20 +797,14 @@ class TaskUtils {
    * @param int $maxAgents
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function updateMaxAgents($taskId, $maxAgents, $user) {
+  public static function updateMaxAgents(int $taskId, int $maxAgents, User $user): void {
     $task = TaskUtils::getTask($taskId, $user);
-    if ($task == null) {
-      throw new HTException("No such task!");
-    }
     $taskWrapper = Factory::getTaskWrapperFactory()->get($task->getTaskWrapperId());
     if (!AccessUtils::userCanAccessTask($taskWrapper, $user)) {
       throw new HTException("No access to this task!");
     }
-    if (!is_numeric($maxAgents)) {
-      throw new HTException("Invalid number of agents!");
-    }
-    $maxAgents = intval($maxAgents);
     if ($maxAgents < 0) {
       throw new HTException("Invalid number of agents!");
     }
@@ -809,8 +824,8 @@ class TaskUtils {
    * @param string $color
    * @param boolean $isCpuOnly
    * @param boolean $isSmall
-   * @param $usePreprocessor
-   * @param $preprocessorCommand
+   * @param int $usePreprocessor
+   * @param string $preprocessorCommand
    * @param int $skip
    * @param int $priority
    * @param int $maxAgents
@@ -820,10 +835,14 @@ class TaskUtils {
    * @param string $notes
    * @param int $staticChunking
    * @param int $chunkSize
+   * @param int $enforcePipe
    * @return Task
+   * @throws HTException
    * @throws HttpError
+   * @throws HttpForbidden
+   * @throws Exception
    */
-  public static function createTask($hashlistId, $name, $attackCmd, $chunkTime, $status, $benchtype, $color, $isCpuOnly, $isSmall, $usePreprocessor, $preprocessorCommand, $skip, $priority, $maxAgents, $files, $crackerVersionId, $user, $notes = "", $staticChunking = DTaskStaticChunking::NORMAL, $chunkSize = 0, $enforcePipe = 0) {
+  public static function createTask(int $hashlistId, string $name, string $attackCmd, int $chunkTime, int $status, string $benchtype, string $color, bool $isCpuOnly, bool $isSmall, int $usePreprocessor, string $preprocessorCommand, int $skip, int $priority, int $maxAgents, array $files, int $crackerVersionId, User $user, string $notes = "", int $staticChunking = DTaskStaticChunking::NORMAL, int $chunkSize = 0, int $enforcePipe = 0): Task {
     $hashlist = Factory::getHashlistFactory()->get($hashlistId);
     if ($hashlist == null) {
       throw new HttpError("Invalid hashlist ID!");
@@ -846,7 +865,7 @@ class TaskUtils {
     if ($cracker == null) {
       throw new HttpError("Invalid cracker ID!");
     }
-    else if (strpos($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
+    else if (!str_contains($attackCmd, SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS))) {
       throw new HttpError("Attack command does not contain hashlist alias!");
     }
     else if (strlen($attackCmd) > 65535) {
@@ -931,7 +950,7 @@ class TaskUtils {
     );
     $task = Factory::getTaskFactory()->save($task);
     
-    if (is_array($files) && sizeof($files) > 0) {
+    if (sizeof($files) > 0) {
       foreach ($files as $fileId) {
         $taskFile = new FileTask(null, $fileId, $task->getId());
         Factory::getFileTaskFactory()->save($taskFile);
@@ -949,8 +968,9 @@ class TaskUtils {
    * @param $agent Agent
    * @param bool $all set true to get all matching tasks for this agent
    * @return Task|Task[]|null
+   * @throws Exception
    */
-  public static function getBestTask($agent, $all = false) {
+  public static function getBestTask(Agent $agent, bool $all = false): Task|array|null {
     $allTasks = array();
     
     // load all groups where this agent has access to
@@ -1009,7 +1029,14 @@ class TaskUtils {
     return null;
   }
   
-  private static function getCandidateTasks($agent, $accessGroups, $taskWrapper) {
+  /**
+   * @param Agent $agent
+   * @param array $accessGroups
+   * @param TaskWrapper $taskWrapper
+   * @return array
+   * @throws Exception
+   */
+  private static function getCandidateTasks(Agent $agent, array $accessGroups, TaskWrapper $taskWrapper): array {
     $totalAssignments = 0;
     $candidateTasks = [];
     
@@ -1066,8 +1093,9 @@ class TaskUtils {
   
   /**
    * @param $task Task
+   * @throws Exception
    */
-  public static function deleteTask($task) {
+  public static function deleteTask(Task $task): void {
     $qF = new QueryFilter(Chunk::TASK_ID, $task->getId(), "=");
     $chunkIds = Util::arrayOfIds(Factory::getChunkFactory()->filter([Factory::FILTER => $qF]));
     
@@ -1128,8 +1156,9 @@ class TaskUtils {
    * @param User $user
    * @return Chunk
    * @throws HTException
+   * @throws Exception
    */
-  public static function getChunk($chunkId, $user) {
+  public static function getChunk(int $chunkId, User $user): Chunk {
     $chunk = Factory::getChunkFactory()->get($chunkId);
     if ($chunk == null) {
       throw new HTException("Invalid chunk ID!");
@@ -1145,11 +1174,12 @@ class TaskUtils {
   /**
    * Checks if a task is completed or fully dispatched.
    *
-   * @param $task Task
-   * @param $agent Agent
-   * @return Task|null null if the task is completed or fully dispatched
+   * @param Task $task
+   * @param ?Agent $agent
+   * @return ?Task null if the task is completed or fully dispatched
+   * @throws Exception
    */
-  public static function checkTask($task, $agent = null) {
+  public static function checkTask(Task $task, ?Agent $agent = null): ?Task {
     if ($task->getIsArchived() == 1) {
       return null;
     }
@@ -1205,9 +1235,10 @@ class TaskUtils {
   }
   
   /**
-   * @param $hashlists Hashlist[]
+   * @param Hashlist[] $hashlists
+   * @throws Exception
    */
-  public static function unassignAllAgents($hashlists) {
+  public static function unassignAllAgents(array $hashlists): void {
     $twFilter = new ContainFilter(TaskWrapper::HASHLIST_ID, Util::arrayOfIds($hashlists));
     $taskWrappers = Factory::getTaskWrapperFactory()->filter([Factory::FILTER => $twFilter]);
     foreach ($taskWrappers as $taskWrapper) {
@@ -1221,11 +1252,12 @@ class TaskUtils {
   }
   
   /**
-   * @param $task1 Task
-   * @param $task2 Task
+   * @param ?Task $task1
+   * @param ?Task $task2
    * @return Task task which should be worked on
+   * @throws Exception
    */
-  public static function getImportantTask($task1, $task2) {
+  public static function getImportantTask(?Task $task1, ?Task $task2): Task {
     if ($task1 == null) {
       return $task2;
     }
@@ -1246,8 +1278,9 @@ class TaskUtils {
   
   /**
    * @param $hashlists Hashlist[]
+   * @throws Exception
    */
-  public static function depriorizeAllTasks($hashlists) {
+  public static function depriorizeAllTasks(array $hashlists): void {
     $qF = new ContainFilter(TaskWrapper::HASHLIST_ID, Util::arrayOfIds($hashlists));
     $uS = new UpdateSet(TaskWrapper::PRIORITY, 0);
     Factory::getTaskWrapperFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => $uS]);
@@ -1260,10 +1293,11 @@ class TaskUtils {
   }
   
   /**
-   * @param $task Task
+   * @param Task $task
    * @return File[]
+   * @throws Exception
    */
-  public static function getFilesOfTask($task) {
+  public static function getFilesOfTask(Task $task): array {
     $qF = new QueryFilter(FileTask::TASK_ID, $task->getId(), "=", Factory::getFileTaskFactory());
     $jF = new JoinFilter(Factory::getFileTaskFactory(), File::FILE_ID, FileTask::FILE_ID);
     $joined = Factory::getFileFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
@@ -1271,10 +1305,11 @@ class TaskUtils {
   }
   
   /**
-   * @param $pretask Pretask
+   * @param Pretask $pretask
    * @return File[]
+   * @throws Exception
    */
-  public static function getFilesOfPretask($pretask) {
+  public static function getFilesOfPretask(Pretask $pretask): array {
     $qF = new QueryFilter(FilePretask::PRETASK_ID, $pretask->getId(), "=", Factory::getFilePretaskFactory());
     $jF = new JoinFilter(Factory::getFilePretaskFactory(), File::FILE_ID, FilePretask::FILE_ID);
     $joined = Factory::getFileFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
@@ -1285,8 +1320,9 @@ class TaskUtils {
    * @param int $supertaskId
    * @param User $user
    * @throws HTException
+   * @throws Exception
    */
-  public static function deleteSupertask($supertaskId, $user) {
+  public static function deleteSupertask(int $supertaskId, User $user): void {
     $taskWrapper = Factory::getTaskWrapperFactory()->get($supertaskId);
     if ($taskWrapper === null) {
       throw new HTException("Invalid supertask!");
@@ -1306,12 +1342,13 @@ class TaskUtils {
   }
   
   /**
-   * @param $taskId
-   * @param $user
+   * @param int $taskId
+   * @param User $user
    * @return array
    * @throws HTException
+   * @throws Exception
    */
-  public static function getCrackedHashes($taskId, $user) {
+  public static function getCrackedHashes(int $taskId, User $user): array {
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
     $hashlist = HashlistUtils::getHashlist($taskWrapper->getHashlistId());
@@ -1337,10 +1374,10 @@ class TaskUtils {
   }
   
   /**
-   * @param $task Task
+   * @param Task $task
    * @return bool
    */
-  public static function isFinished($task) {
+  public static function isFinished(Task $task): bool {
     return ($task->getKeyspace() > 0 && Util::getTaskInfo($task)[0] >= $task->getKeyspace());
   }
   
@@ -1348,8 +1385,9 @@ class TaskUtils {
    * @param Task $task
    * @param string $modifier
    * @return string
+   * @throws Exception
    */
-  public static function getCrackerInfo($task, $modifier = "info") {
+  public static function getCrackerInfo(Task $task, string $modifier = "info"): string {
     if (AccessControl::getInstance()->hasPermission(DAccessControl::CRACKER_BINARY_ACCESS)) {
       $qF = new QueryFilter(CrackerBinary::CRACKER_BINARY_ID, $task->getCrackerBinaryId(), "=");
       $binaries = Factory::getCrackerBinaryFactory()->filter([Factory::FILTER => $qF]);
@@ -1374,11 +1412,12 @@ class TaskUtils {
   /**
    * Get the number of agents - apart from given agent -.working on given task.
    *
-   * @param $task
-   * @param $agent
+   * @param Task $task
+   * @param Agent $agent
    * @return int the number of agents working on given task
+   * @throws Exception
    */
-  public static function numberOfOtherAssignedAgents($task, $agent) {
+  public static function numberOfOtherAssignedAgents(Task $task, Agent $agent): int {
     $qF1 = new QueryFilter(Assignment::TASK_ID, $task->getId(), "=");
     $qF2 = new QueryFilter(Assignment::AGENT_ID, $agent->getId(), "<>");
     return Factory::getAssignmentFactory()->countFilter([Factory::FILTER => [$qF1, $qF2]]);
@@ -1391,8 +1430,9 @@ class TaskUtils {
    * @param Task $task
    * @param Agent $agent
    * @return boolean true if maxAgents != 0 and number of assigned agents >= maxAgents, false otherwise
+   * @throws Exception
    */
-  public static function isSaturatedByOtherAgents($task, $agent) {
+  public static function isSaturatedByOtherAgents(Task $task, Agent $agent): bool {
     $numAssignments = self::numberOfOtherAssignedAgents($task, $agent);
     return ($task->getIsSmall() == 1 && $numAssignments > 0) || // at least one agent is already assigned here
       ($task->getMaxAgents() > 0 && $numAssignments >= $task->getMaxAgents()); // at least maxAgents agents are already assigned

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -244,6 +244,7 @@ class TaskUtils {
    * @throws Exception
    */
   public static function toggleArchiveTask(int $taskId, bool $taskState, User $user): void {
+    $taskState = $taskState ? 1 : 0;
     $task = TaskUtils::getTask($taskId, $user);
     $taskWrapper = TaskUtils::getTaskWrapper($task->getTaskWrapperId(), $user);
     switch ($taskWrapper->getTaskType()) {

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -85,6 +85,7 @@ class TaskUtils {
   
   /**
    * @return Task
+   * @throws Exception
    */
   public static function getDefault(): Task {
     return new Task(
@@ -1377,6 +1378,7 @@ class TaskUtils {
   /**
    * @param Task $task
    * @return bool
+   * @throws Exception
    */
   public static function isFinished(Task $task): bool {
     return ($task->getKeyspace() > 0 && Util::getTaskInfo($task)[0] >= $task->getKeyspace());

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -903,6 +903,7 @@ class TaskUtils {
     }
     $isCpuOnly = ($isCpuOnly) ? 1 : 0;
     $isSmall = ($isSmall) ? 1 : 0;
+    $preprocessor = null;
     if ($usePreprocessor < 0) {
       $usePreprocessor = 0;
     }

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -1358,7 +1358,7 @@ class TaskUtils {
           return "Version: " . $binary->getVersion() . " — Binary Name: " . $binary->getBinaryName();
         }
         elseif ($modifier == "id") {
-          return $binary->getCrackerBinaryTypeId();
+          return "" . $binary->getCrackerBinaryTypeId();
         }
         else {
           return "Invalid modifier";

--- a/src/inc/utils/TaskUtils.php
+++ b/src/inc/utils/TaskUtils.php
@@ -883,10 +883,10 @@ class TaskUtils {
     else if (Util::containsBlacklistedChars($preprocessorCommand)) {
       throw new HttpError("Preprocessor command contains blacklisted characters!");
     }
-    else if (!is_numeric($chunkTime) || $chunkTime < 1) {
+    else if ($chunkTime < 1) {
       throw new HttpError("Invalid chunk size!");
     }
-    else if (!is_numeric($status) || $status < 1) {
+    else if ($status < 1) {
       throw new HttpError("Invalid status timer!");
     }
     else if ($benchtype != 'speed' && $benchtype != 'runtime') {

--- a/src/inc/utils/TaskWrapperUtils.php
+++ b/src/inc/utils/TaskWrapperUtils.php
@@ -2,9 +2,11 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\dba\Factory;
 use Hashtopolis\dba\models\TaskWrapper;
 use Hashtopolis\dba\models\Task;
+use Hashtopolis\dba\models\User;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\dba\JoinFilter;
 use Hashtopolis\inc\apiv2\error\HttpError;
@@ -14,26 +16,36 @@ use Hashtopolis\inc\HTException;
 class TaskWrapperUtils {
   
   /**
-   * @param int $taskwrapperId
+   * @param int $taskWrapperId
    * @return Taskwrapper
    * @throws HTException
+   * @throws Exception
    */
-  public static function getTaskwrapper($taskwrapperId) {
-    $taskwrapper = Factory::getTaskWrapperFactory()->get($taskwrapperId);
-    if ($taskwrapper == null) {
+  public static function getTaskWrapper(int $taskWrapperId): TaskWrapper {
+    $taskWrapper = Factory::getTaskWrapperFactory()->get($taskWrapperId);
+    if ($taskWrapper == null) {
       throw new HTException("Invalid taskwrapper!");
     }
-    return $taskwrapper;
+    return $taskWrapper;
   }
   
-  public static function updatePriority($taskWrapperId, $priority, $user) {
-    $taskwrapper = TaskWrapperUtils::getTaskwrapper($taskWrapperId);
+  /**
+   * @param int $taskWrapperId
+   * @param int $priority
+   * @param User $user
+   * @return void
+   * @throws HTException
+   * @throws HttpError
+   * @throws Exception
+   */
+  public static function updatePriority(int $taskWrapperId, int $priority, User $user): void {
+    $taskWrapper = TaskWrapperUtils::getTaskWrapper($taskWrapperId);
     
     // Priority is a bit special, when called on a 'NORMAL' running task 
     // the underlying Task object priority also gets updated
-    switch ($taskwrapper->getTaskType()) {
+    switch ($taskWrapper->getTaskType()) {
       case DTaskTypes::NORMAL:
-        $qF = new QueryFilter(TaskWrapper::TASK_WRAPPER_ID, $taskwrapper->getId(), "=", Factory::getTaskWrapperFactory());
+        $qF = new QueryFilter(TaskWrapper::TASK_WRAPPER_ID, $taskWrapper->getId(), "=", Factory::getTaskWrapperFactory());
         $jF = new JoinFilter(Factory::getTaskWrapperFactory(), Task::TASK_WRAPPER_ID, TaskWrapper::TASK_WRAPPER_ID);
         $joined = Factory::getTaskFactory()->filter([Factory::FILTER => $qF, Factory::JOIN => $jF]);
         $task = $joined[Factory::getTaskFactory()->getModelName()][0];

--- a/src/inc/utils/UserUtils.php
+++ b/src/inc/utils/UserUtils.php
@@ -2,6 +2,7 @@
 
 namespace Hashtopolis\inc\utils;
 
+use Exception;
 use Hashtopolis\inc\DataSet;
 use Hashtopolis\inc\Encryption;
 use Hashtopolis\dba\UpdateSet;
@@ -30,8 +31,9 @@ use Hashtopolis\inc\Util;
 class UserUtils {
   /**
    * @return User[]
+   * @throws Exception
    */
-  public static function getUsers() {
+  public static function getUsers(): array {
     return Factory::getUserFactory()->filter([]);
   }
   
@@ -39,6 +41,7 @@ class UserUtils {
    * @param int $userId
    * @param User $adminUser
    * @throws HTException
+   * @throws Exception
    */
   public static function deleteUser(int $userId, User $adminUser): void {
     $user = UserUtils::getUser($userId);
@@ -67,13 +70,20 @@ class UserUtils {
     $qF = new QueryFilter(JwtApiKey::USER_ID, $user->getId(), "=");
     $uS1 = new UpdateSet(JwtApiKey::IS_REVOKED, 1);
     $uS2 = new UpdateSet(JwtApiKey::USER_ID, null);
-
+    
     // Revoke all of the API keys of the user
     Factory::getJwtApiKeyFactory()->massUpdate([Factory::FILTER => $qF, Factory::UPDATE => [$uS1, $uS2]]);
     Factory::getUserFactory()->delete($user);
   }
   
-  public static function userForgotPassword($username, $email) {
+  /**
+   * @param string $username
+   * @param string $email
+   * @return void
+   * @throws HTException
+   * @throws Exception
+   */
+  public static function userForgotPassword(string $username, string $email): void {
     $username = htmlentities($username, ENT_QUOTES, "UTF-8");
     $qF = new QueryFilter(User::USERNAME, $username, "=");
     $res = Factory::getUserFactory()->filter([Factory::FILTER => $qF]);
@@ -102,6 +112,7 @@ class UserUtils {
   /**
    * @param int $userId
    * @throws HTException
+   * @throws Exception
    */
   public static function enableUser(int $userId): void {
     $user = UserUtils::getUser($userId);
@@ -112,8 +123,9 @@ class UserUtils {
    * @param int $userId
    * @param User $adminUser
    * @throws HTException
+   * @throws Exception
    */
-  public static function disableUser($userId, $adminUser) {
+  public static function disableUser(int $userId, User $adminUser): void {
     $user = UserUtils::getUser($userId);
     if ($user->getId() == $adminUser->getId()) {
       throw new HTException("You cannot disable yourself!");
@@ -130,6 +142,7 @@ class UserUtils {
    * @param int $groupId
    * @param User $adminUser
    * @throws HTException
+   * @throws Exception
    */
   public static function setRights(int $userId, int $groupId, User $adminUser): void {
     $group = AccessControlUtils::getGroup($groupId);
@@ -147,9 +160,9 @@ class UserUtils {
    * @param string $oldPassword The user's current password (plain text).
    * @param string $newPassword The new password to set (plain text).
    * @param string $confirmPassword Confirmation of the new password (plain text).
+   * @throws HttpError If the old password is incorrect, the new password is too short, the new passwords do not match, or the new password is the same as the old one.
+   * @throws Exception
    *
-   * @throws HTException If the old password is incorrect, the new password is too short,
-   *                     the new passwords do not match, or the new password is the same as the old one.
    *
    * This method performs the following steps:
    * 1. Verifies the old password using the user's stored salt and hash.
@@ -183,6 +196,7 @@ class UserUtils {
    * @param string $password
    * @param User $adminUser
    * @throws HTException
+   * @throws Exception
    */
   public static function setPassword(int $userId, string $password, User $adminUser): void {
     $user = UserUtils::getUser($userId);
@@ -211,6 +225,7 @@ class UserUtils {
    * @throws HttpConflict
    * @throws HttpError
    * @throws InternalError
+   * @throws Exception
    */
   public static function createUser(string $username, string $email, int $rightGroupId, User $adminUser, bool $isValid = true, int $session_lifetime = 3600): User {
     $username = htmlentities($username, ENT_QUOTES, "UTF-8");
@@ -220,9 +235,6 @@ class UserUtils {
     }
     else if (strlen($username) < 2) {
       throw new HttpError("Username is too short!");
-    }
-    else if ($group == null) {
-      throw new HttpError("Invalid group!");
     }
     $qF = new QueryFilter("username", $username, "=");
     $res = Factory::getUserFactory()->filter([Factory::FILTER => $qF], true);
@@ -262,6 +274,7 @@ class UserUtils {
    * @param int $userId
    * @return User
    * @throws HTException
+   * @throws Exception
    */
   public static function getUser(int $userId): User {
     $user = Factory::getUserFactory()->get($userId);

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -383,7 +383,7 @@ else if (isset($_GET['new'])) {
   if ($copy === null) {
     $copy = TaskUtils::getDefault();
   }
-  if (strpos($copy->getAttackCmd(), SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS)) === false) {
+  if (strpos($copy->getAttackCmd(), SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS) ?? "") === false) {
     $copy->setAttackCmd(SConfig::getInstance()->getVal(DConfig::HASHLIST_ALIAS) . " " . $copy->getAttackCmd());
   }
   

--- a/src/tasks.php
+++ b/src/tasks.php
@@ -97,7 +97,7 @@ if (isset($_GET['id'])) {
   if (!AccessUtils::userCanAccessHashlists($hashlist, Login::getInstance()->getUser())) {
     UI::printError("ERROR", "No access to this task!");
   }
-
+  
   UI::add('hashlist', $hashlist);
   $hashtype = Factory::getHashTypeFactory()->get($hashlist->getHashtypeId());
   UI::add('hashtype', $hashtype);
@@ -145,15 +145,17 @@ if (isset($_GET['id'])) {
       $chunkIntervals[] = ["start" => $chunk->getDispatchTime(), "stop" => $chunk->getSolveTime()];
     }
     $cProgress += $chunk->getCheckpoint() - $chunk->getSkip();
-    if (!$agentsProgress->getVal($chunk->getAgentId())) {
-      $agentsProgress->addValue($chunk->getAgentId(), $chunk->getCheckpoint() - $chunk->getSkip());
-      $agentsCracked->addValue($chunk->getAgentId(), $chunk->getCracked());
-      $agentsSpent->addValue($chunk->getAgentId(), max($chunk->getSolveTime() - $chunk->getDispatchTime(), 0));
-    }
-    else {
-      $agentsProgress->addValue($chunk->getAgentId(), $agentsProgress->getVal($chunk->getAgentId()) + $chunk->getCheckpoint() - $chunk->getSkip());
-      $agentsCracked->addValue($chunk->getAgentId(), $agentsCracked->getVal($chunk->getAgentId()) + $chunk->getCracked());
-      $agentsSpent->addValue($chunk->getAgentId(), $agentsSpent->getVal($chunk->getAgentId()) + max($chunk->getSolveTime() - $chunk->getDispatchTime(), 0));
+    if ($chunk->getAgentId() != null) {
+      if (!$agentsProgress->getVal($chunk->getAgentId())) {
+        $agentsProgress->addValue($chunk->getAgentId(), $chunk->getCheckpoint() - $chunk->getSkip());
+        $agentsCracked->addValue($chunk->getAgentId(), $chunk->getCracked());
+        $agentsSpent->addValue($chunk->getAgentId(), max($chunk->getSolveTime() - $chunk->getDispatchTime(), 0));
+      }
+      else {
+        $agentsProgress->addValue($chunk->getAgentId(), $agentsProgress->getVal($chunk->getAgentId()) + $chunk->getCheckpoint() - $chunk->getSkip());
+        $agentsCracked->addValue($chunk->getAgentId(), $agentsCracked->getVal($chunk->getAgentId()) + $chunk->getCracked());
+        $agentsSpent->addValue($chunk->getAgentId(), $agentsSpent->getVal($chunk->getAgentId()) + max($chunk->getSolveTime() - $chunk->getDispatchTime(), 0));
+      }
     }
   }
   UI::add('agentsProgress', $agentsProgress);

--- a/src/templates/agents/detail.template.html
+++ b/src/templates/agents/detail.template.html
@@ -63,7 +63,11 @@
             <button type="submit" class="btn {{IF [[toggledarkmode]] > 0}}btn-dark {{ELSE}}btn-light{{ENDIF}}" data-toggle="tooltip" data-placement="top" title="Set"><i class="fas fa-save" aria-hidden="true"></i></button>
           </form>
           {{ELSE}}
-          [[htmlentities([[Util::getUsernameById([[agent.getUserId()]])]], ENT_QUOTES, "UTF-8")]]
+            {{IF [[agent.getUserId()]] > 0}}
+              [[htmlentities([[Util::getUsernameById([[agent.getUserId()]])]], ENT_QUOTES, "UTF-8")]]
+            {{ELSE}}
+              ---
+            {{ENDIF}}
           {{ENDIF}}
         </td>
       </tr>

--- a/src/templates/hashlists/detail/pretasks.template.html
+++ b/src/templates/hashlists/detail/pretasks.template.html
@@ -16,7 +16,7 @@
             <td>
               <a href="tasks.php?id=[[task.getId()]]">[[task.getId()]]</a>
             </td>
-            <td{{IF [[strlen([[task.getColor()]])]] > 0}} style="background-color: #[[task.getColor()]]""{{ENDIF}}>
+            <td{{IF [[task.getColor()]] != null && [[strlen([[task.getColor()]])]] > 0}} style="background-color: #[[task.getColor()]]""{{ENDIF}}>
               &nbsp;
             </td>
             <td>

--- a/src/templates/hashlists/detail/tasks.template.html
+++ b/src/templates/hashlists/detail/tasks.template.html
@@ -16,7 +16,7 @@
             <td>
               <a href="tasks.php?id=[[task.getVal('task')->getId()]]">[[task.getVal('task')->getId()]]</a>
             </td>
-            <td{{IF [[strlen([[task.getVal('task').getColor()]])]] > 0}} style="background-color: #[[task.getVal('task').getColor()]]""{{ENDIF}}>
+            <td{{IF [[task.getVal('task').getColor()]] != null && [[strlen([[task.getVal('task').getColor()]])]] > 0}} style="background-color: #[[task.getVal('task').getColor()]]""{{ENDIF}}>
               &nbsp;
             </td>
             <td>


### PR DESCRIPTION
The goal of this PR is to update phpdocs and typing to get better coverage and discover further potential issues.

Main change in typing:
- Instead of using just ultra-generic `object` for everything, it is replaced by using AbstractModel now which is declared as template.

Also the change of the DBA handling for the typing should have a large performance effect as it gets rid of all the unnecessary serialization/de-serialization which happened so far.