### PR TITLE
Fix installation docs: broken download URLs and outdated upgrade guide

### DIFF
--- a/doc/installation_guidelines/advanced_install.md
+++ b/doc/installation_guidelines/advanced_install.md
@@ -24,12 +24,21 @@ docker load --input hashtopolis-frontend.tar
 docker load --input mysql.tar
 ```
 
-Download docker-compose.yml and env.example and transfer them to your Hashtopolis server as well:
+Hashtopolis supports MySQL and PostgreSQL since v.1.0.0-rainbow5. You can choose between both databases. Depending of your choice, download the corresponding files:.
 
+Download docker-compose.mysql.yml and env.mysql.example for MySQL   
 ```
-wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.yml
-wget https://raw.githubusercontent.com/hashtopolis/server/master/env.example -O .env
-```
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.mysql.yml -O docker-compose.yml
+wget https://raw.githubusercontent.com/hashtopolis/server/master/env.mysql.example -O .env
+```   
+
+**or**
+
+Download docker-compose.postgres.yml and env.postgres.example for PostgreSQL   
+ ```
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.postgres.yml -O docker-compose.yml
+wget https://raw.githubusercontent.com/hashtopolis/server/master/env.postgres.example -O .env
+ ```
 
 Continue with the normal docker installation described in the [basic installation section](basic_install.md#setup-hashtopolis-server).
 
@@ -157,7 +166,11 @@ By default (when you use the default docker-compose) the Hashtopolis folder (imp
 
 You can list this volume via docker volume ls. You can also access the volume directly in the backend, because it is mounted at: ```/usr/local/share/hashtopolis``` inside the container.
 
-However, if you prefer not to use Docker volumes and instead use folders on the host OS, you can update the mount points in the *docker-compose.yml* file:
+However, if you prefer not to use Docker volumes and instead use folders on the host OS, you can update the mount points in the *docker-compose.yml* file. 
+
+> [!NOTE]
+> The example shown below is for MySQL, updating the PostgreSQL docker-compose file is identical.
+
 ```
 version: '3.7'
 services:
@@ -239,7 +252,7 @@ When there is the need for a complete reset/clean setup (e.g. for testing), you 
 > [!CAUTION]
 > The following steps will delete all data in your hashtopolis instance (including the database, users, tasks, agents, etc.)!
 
-These steps assume that you have set up your hashtopolis instance using a `docker-compose.yml` file.
+These steps assume that you have set up your hashtopolis instance using a `docker-compose.yml` file (either MySQL or PostgreSQL).
 
 First stop all running all containers and clean them up:
 

--- a/doc/installation_guidelines/basic_install.md
+++ b/doc/installation_guidelines/basic_install.md
@@ -37,17 +37,18 @@ Hashtopolis supports MySQL and PostgreSQL since v.1.0.0-rainbow5. You can choose
 
 2.  Download docker-compose.mysql.yml and env.mysql.example for MySQL   
 ```
-wget https://raw.githubusercontent.com/hashtopolis/server/dev/docker-compose.mysql.yml -O docker-compose.yml
-wget https://raw.githubusercontent.com/hashtopolis/server/dev/env.mysql.example -O .env
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.mysql.yml -O docker-compose.yml
+wget https://raw.githubusercontent.com/hashtopolis/server/master/env.mysql.example -O .env
 ```   
 
 **or**
 
 Download docker-compose.postgres.yml and env.postgres.example for PostgreSQL   
  ```
-wget https://raw.githubusercontent.com/hashtopolis/server/dev/docker-compose.postgres.yml -O docker-compose.yml
-wget https://raw.githubusercontent.com/hashtopolis/server/dev/env.postgres.example -O .env
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.postgres.yml -O docker-compose.yml
+wget https://raw.githubusercontent.com/hashtopolis/server/master/env.postgres.example -O .env
  ```
+
 3. Edit the .env file and change the settings to your likings
 
 ```

--- a/doc/installation_guidelines/update.md
+++ b/doc/installation_guidelines/update.md
@@ -1,9 +1,85 @@
 
-# Updating Hashtopolis 
+# Updating Hashtopolis
 
-## Upgrading to 0.14.0 (from non-Docker to Docker)
+## Upgrading a Docker installation
 
-There are multiple ways to migrate data from a non-Docker setup to Docker. You can start fresh, but if you want to keep your data, several migration options are available.
+This procedure applies to any upgrade between Docker-based releases (version 0.14.0 and up), for example from a 0.14.x or v1.0.0-rainbow release to the latest release. Database schema migrations are applied automatically by the backend container on startup, so the procedure is the same regardless of which version you are coming from.
+
+> [!CAUTION]
+> Upgrades keep the database engine you already use. Switching between MySQL and PostgreSQL as part of an upgrade is not supported. When downloading the docker-compose and env files below, always pick the variant matching your existing database.
+
+1. Back up your database before upgrading:
+
+For MySQL:
+```
+docker exec hashtopolis-db mysqldump -u root -p<root-password> hashtopolis > hashtopolis-backup.sql
+```
+
+For PostgreSQL:
+```
+docker exec db pg_dump -U <postgres-user> hashtopolis > hashtopolis-backup.sql
+```
+
+> [!NOTE]
+> The database container name may differ on older installations. Use ```docker ps``` to find it.
+
+2. Stop the containers:
+```
+docker compose down
+```
+
+3. The docker-compose file may have changed between releases (for example, the *hashtopolis/frontend* container and the separate MySQL/PostgreSQL variants were introduced with v1.0.0). Download the latest docker-compose file matching your database and replace your existing one:
+
+For MySQL:
+```
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.mysql.yml -O docker-compose.yml
+```
+
+**or**
+
+For PostgreSQL:
+```
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.postgres.yml -O docker-compose.yml
+```
+
+If you made local changes to your previous docker-compose file (custom volumes, ports, additional containers), re-apply them to the new file. Keep your existing *.env* file and Docker volumes: they contain your configuration and data.
+
+4. Pull the new images and restart the containers:
+```
+docker compose pull
+docker compose up --detach
+```
+
+The backend container applies any pending database migrations on startup and the upgrade is complete.
+
+## Upgrading offline systems
+
+1. On a system with internet access, pull the new images and save them as tar-files:
+
+```
+docker pull hashtopolis/backend:latest
+docker pull hashtopolis/frontend:latest
+docker save hashtopolis/backend:latest --output hashtopolis-backend.tar
+docker save hashtopolis/frontend:latest --output hashtopolis-frontend.tar
+```
+
+If the docker-compose file changed since your installed version, also download the latest variant matching your database (see the previous section) and transfer it along with the tar-files.
+
+2. Next, transfer the files to your Hashtopolis server and import them using the following commands:
+
+```
+docker compose down
+docker load --input hashtopolis-backend.tar
+docker load --input hashtopolis-frontend.tar
+docker compose up --detach
+```
+
+## Migrating a non-Docker installation to Docker (pre-0.14.0)
+
+Versions before 0.14.0 were installed directly on a webserver. There are multiple ways to migrate such a setup to Docker. You can start fresh, but if you want to keep your data, several migration options are available.
+
+> [!NOTE]
+> Pre-Docker Hashtopolis installations use MySQL, so this migration must use the MySQL variants of the docker-compose and env files. Switching to PostgreSQL is not possible as part of this migration — if you want PostgreSQL, perform a fresh installation instead.
 
 ### Importing the existing database in docker
 You can reuse your old database server or also migrate the database within a docker container.
@@ -22,7 +98,7 @@ mysqldump <database-name> > hashtopolis-backup.sql
 
 4. Download the docker compose file: 
 ```
-wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.yml
+wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.mysql.yml -O docker-compose.yml
 ```
 
 5. Edit the docker compose file
@@ -37,7 +113,7 @@ wget https://raw.githubusercontent.com/hashtopolis/server/master/docker-compose.
 
 6. Download the env file 
 ```
-wget https://raw.githubusercontent.com/hashtopolis/server/master/env.example -O .env
+wget https://raw.githubusercontent.com/hashtopolis/server/master/env.mysql.example -O .env
 ```
 
 7. Edit the .env file and adjust the settings according to your desired configuration:
@@ -102,33 +178,3 @@ docker compose down && docker compose up
 ### Preserving the existing database 
 
 Repeat the above steps, but you do not need to export or import the database. Just ensure the .env file points to your database server and that it is reachable from the container.
-
-## Upgrading from docker to docker (version 0.14.0 and up)
-
-For this process, you need to stop your containers, pull the new ones and then restart the containers.
-```
-docker compose down
-docker compose pull
-docker compose up
-```
-
-## Upgrading from docker to docker (version 0.14.0 and up) - Offline System(s)
-
-1. On a system with internet access execute the following commands:
-
-```
-docker pull hashtopolis/backend:latest
-docker pull hashtopolis/frontend:latest
-docker save hashtopolis/backend:latest --output hashtopolis-backend.tar
-docker save hashtopolis/frontend:latest --output hashtopolis-frontend.tar
-```
-
-2. Next, transfer both tar-files to your Hashtopolis server and import them using the following commands:
-
-```
-docker compose down
-docker load --input hashtopolis-backend.tar
-docker load --input hashtopolis-frontend.tar
-docker compose up
-```
-


### PR DESCRIPTION
Following the issue [2308](https://github.com/hashtopolis/server/issues/2308) I suggest the following changes:
- basic_install.md: download compose/env files from master instead of dev
- advanced_install.md: mimic the version of the basic install underlining the two potential path for MySQL or PostgreSQL
- update.md: was a bit outdated ans was missing the update process from 1.0 rc. I have inserted a mention that switching database in an upgrade is not supported.
