### PR TITLE
Removed obselete version attribute from dockerfiles

### DIFF
--- a/.devcontainer/docker-compose.mysql.yml
+++ b/.devcontainer/docker-compose.mysql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   hashtopolis-server-dev:
     container_name: hashtopolis-server-dev

--- a/.devcontainer/docker-compose.postgres.yml
+++ b/.devcontainer/docker-compose.postgres.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   hashtopolis-server-dev:
     container_name: hashtopolis-server-dev

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   hashtopolis-backend:
     container_name: hashtopolis-backend

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   hashtopolis-backend:
     container_name: hashtopolis-backend


### PR DESCRIPTION
this solves the docker compose warning: "`version` is obsolete" by removing the version attribute from all the docker compose yaml files