### PR TITLE
Change from meta to data where results are delivered on helper

### DIFF
--- a/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
+++ b/src/inc/apiv2/helper/GetCracksPerDayHelperAPI.php
@@ -62,9 +62,9 @@ class GetCracksPerDayHelperAPI extends AbstractHelperAPI {
       $counts[$key] = ($counts[$key] ?? 0) + $value;
     }
     
-    $ret = self::createJsonResponse(meta: $counts);
+    $ret = self::createJsonResponse(data: $counts);
     if(empty($counts)) {
-      $ret["meta"] = new stdClass();
+      $ret["data"] = new stdClass();
     }
     
     $body = $response->getBody();


### PR DESCRIPTION
On the GetCracksPerDay helper it makes more sense to send the results in 'data' and not in 'meta' according to the api. 

Note: tests will fail until we adjust this also on the python-hashtopolis implementation: https://github.com/hashtopolis/python-hashtopolis/pull/9