### PR TITLE
Only trigger docs workflows when needed

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - 'doc/**'
+      - '.github/workflows/docs-build.yml'
+      - '.github/workflows/docs.yml'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'doc/**'
+      - '.github/workflows/docs-build.yml'
+      - '.github/workflows/docs.yml'
 
 jobs:
   build:


### PR DESCRIPTION
Especially the process of uploading the docs on commits to master is very slow and inefficient. Therefore, I propose to adjust that both the docs build and the docs upload only trigger when there are changes to either any doc/ file or if there is a change on these workflows.