### PR TITLE
Extend upgrade test with a initial data comparison to detect drifts

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -183,13 +183,13 @@ jobs:
             docker exec db pg_dump -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
               --data-only --inserts --no-owner --no-privileges --no-comments \
               -t accessgroup -t agentbinary -t apigroup -t config -t configsection \
-              -t crackerbinary -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
+              -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
               | grep '^INSERT' | sort > upgraded.dump
           else
             docker exec db mysqldump -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
               --no-create-info --skip-extended-insert --skip-comments --skip-triggers \
               AccessGroup AgentBinary ApiGroup Config ConfigSection \
-              CrackerBinary CrackerBinaryType HashType Preprocessor RightGroup \
+              CrackerBinaryType HashType Preprocessor RightGroup \
               | grep '^INSERT' | sort > upgraded.dump
           fi
           echo "Upgraded side dump ($(wc -l < upgraded.dump) rows):"
@@ -237,13 +237,13 @@ jobs:
             docker exec db pg_dump -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
               --data-only --inserts --no-owner --no-privileges --no-comments \
               -t accessgroup -t agentbinary -t apigroup -t config -t configsection \
-              -t crackerbinary -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
+              -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
               | grep '^INSERT' | sort > fresh.dump
           else
             docker exec db mysqldump -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
               --no-create-info --skip-extended-insert --skip-comments --skip-triggers \
               AccessGroup AgentBinary ApiGroup Config ConfigSection \
-              CrackerBinary CrackerBinaryType HashType Preprocessor RightGroup \
+              CrackerBinaryType HashType Preprocessor RightGroup \
               | grep '^INSERT' | sort > fresh.dump
           fi
           echo "Fresh side dump ($(wc -l < fresh.dump) rows):"

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           docker network create ht-test-net
           docker volume create ht-data
+          docker volume create ht-data-fresh
           docker volume create ht-db
 
       - name: Start database container ${{ matrix.db-version }}
@@ -176,6 +177,88 @@ jobs:
             docker exec db mysql -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} -e "SELECT version, description, installed_on, success, HEX(checksum) AS checksum, execution_time FROM _sqlx_migrations ORDER BY version;"
           fi
 
+      - name: Dump upgraded DB seed content
+        run: |
+          if [ "${{ matrix.db-type }}" = "postgres" ]; then
+            docker exec db pg_dump -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
+              --data-only --inserts --no-owner --no-privileges --no-comments \
+              -t accessgroup -t agentbinary -t apigroup -t config -t configsection \
+              -t crackerbinary -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
+              | grep '^INSERT' | sort > upgraded.dump
+          else
+            docker exec db mysqldump -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
+              --no-create-info --skip-extended-insert --skip-comments --skip-triggers \
+              AccessGroup AgentBinary ApiGroup Config ConfigSection \
+              CrackerBinary CrackerBinaryType HashType Preprocessor RightGroup \
+              | grep '^INSERT' | sort > upgraded.dump
+          fi
+          echo "Upgraded side dump ($(wc -l < upgraded.dump) rows):"
+          cat upgraded.dump
+
+      - name: Stop upgraded backend
+        run: |
+          docker stop backend
+          docker rm backend
+
+      - name: Reset database for fresh install
+        run: |
+          if [ "${{ matrix.db-type }}" = "postgres" ]; then
+            docker exec db psql -U ${{ env.DB_USER }} -d postgres -c "DROP DATABASE IF EXISTS ${{ env.DB_NAME }};"
+            docker exec db psql -U ${{ env.DB_USER }} -d postgres -c "CREATE DATABASE ${{ env.DB_NAME }} OWNER ${{ env.DB_USER }};"
+          else
+            docker exec db mysql -u root -p${{ env.DB_PASS }} -e "DROP DATABASE IF EXISTS ${{ env.DB_NAME }}; CREATE DATABASE ${{ env.DB_NAME }};"
+          fi
+
+      - name: Start fresh backend (newest version)
+        run: |
+          docker run -d --network ht-test-net --name backend \
+            -e HASHTOPOLIS_DB_TYPE=${{ matrix.db-type }} \
+            -e HASHTOPOLIS_DB_USER=${{ env.DB_USER }} \
+            -e HASHTOPOLIS_DB_PASS=${{ env.DB_PASS }} \
+            -e HASHTOPOLIS_DB_HOST=db \
+            -e HASHTOPOLIS_DB_DATABASE=${{ env.DB_NAME }} \
+            -e HASHTOPOLIS_ADMIN_USER=admin \
+            -e HASHTOPOLIS_ADMIN_PASSWORD=hashtopolis \
+            -v ht-data-fresh:/usr/local/share/hashtopolis \
+            hashtopolis/backend:test
+
+      - name: Wait for fresh backend initialization
+        run: |
+          timeout 60 bash -c 'until docker logs backend 2>&1 | grep -q "Initialization complete!"; do sleep 3; done'
+          echo "Fresh backend initialized"
+
+      - name: Show fresh backend logs
+        if: always()
+        run: docker logs backend
+
+      - name: Dump fresh DB seed content
+        run: |
+          if [ "${{ matrix.db-type }}" = "postgres" ]; then
+            docker exec db pg_dump -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
+              --data-only --inserts --no-owner --no-privileges --no-comments \
+              -t accessgroup -t agentbinary -t apigroup -t config -t configsection \
+              -t crackerbinary -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
+              | grep '^INSERT' | sort > fresh.dump
+          else
+            docker exec db mysqldump -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
+              --no-create-info --skip-extended-insert --skip-comments --skip-triggers \
+              AccessGroup AgentBinary ApiGroup Config ConfigSection \
+              CrackerBinary CrackerBinaryType HashType Preprocessor RightGroup \
+              | grep '^INSERT' | sort > fresh.dump
+          fi
+          echo "Fresh side dump ($(wc -l < fresh.dump) rows):"
+          cat fresh.dump
+
+      - name: Compare fresh vs upgraded DB seed content
+        run: |
+          if ! diff fresh.dump upgraded.dump > seed-drift.diff; then
+            echo "::error::Seed data drift detected between fresh and upgraded install"
+            echo "--- fresh.dump / +++ upgraded.dump"
+            cat seed-drift.diff
+            exit 1
+          fi
+          echo "No seed data drift detected."
+
       - name: Cleanup
         if: always()
         run: |
@@ -184,4 +267,4 @@ jobs:
           docker stop db 2>/dev/null || true
           docker rm db 2>/dev/null || true
           docker network rm ht-test-net 2>/dev/null || true
-          docker volume rm ht-db ht-data 2>/dev/null || true
+          docker volume rm ht-db ht-data ht-data-fresh 2>/dev/null || true

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -182,16 +182,23 @@ jobs:
           if [ "${{ matrix.db-type }}" = "postgres" ]; then
             docker exec db pg_dump -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
               --data-only --inserts --no-owner --no-privileges --no-comments \
-              -t accessgroup -t agentbinary -t apigroup -t config -t configsection \
+              -t accessgroup -t agentbinary -t apigroup -t configsection \
               -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
-              | grep '^INSERT' | sort > upgraded.dump
+              | grep '^INSERT' > upgraded.dump
+            docker exec db psql -t -A -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
+              -c "SELECT 'Config\t' || item || E'\t' || configsectionid || E'\t' || value FROM config ORDER BY item;" \
+              >> upgraded.dump
           else
             docker exec db mysqldump -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
               --no-create-info --skip-extended-insert --skip-comments --skip-triggers \
-              AccessGroup AgentBinary ApiGroup Config ConfigSection \
+              AccessGroup AgentBinary ApiGroup ConfigSection \
               CrackerBinaryType HashType Preprocessor RightGroup \
-              | grep '^INSERT' | sort > upgraded.dump
+              | grep '^INSERT' > upgraded.dump
+            docker exec db mysql -N -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
+              -e "SELECT CONCAT('Config\t', item, '\t', configSectionId, '\t', value) FROM Config ORDER BY item;" \
+              >> upgraded.dump
           fi
+          sort -o upgraded.dump upgraded.dump
           echo "Upgraded side dump ($(wc -l < upgraded.dump) rows):"
           cat upgraded.dump
 
@@ -236,16 +243,23 @@ jobs:
           if [ "${{ matrix.db-type }}" = "postgres" ]; then
             docker exec db pg_dump -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
               --data-only --inserts --no-owner --no-privileges --no-comments \
-              -t accessgroup -t agentbinary -t apigroup -t config -t configsection \
+              -t accessgroup -t agentbinary -t apigroup -t configsection \
               -t crackerbinarytype -t hashtype -t preprocessor -t rightgroup \
-              | grep '^INSERT' | sort > fresh.dump
+              | grep '^INSERT' > fresh.dump
+            docker exec db psql -t -A -U ${{ env.DB_USER }} -d ${{ env.DB_NAME }} \
+              -c "SELECT 'Config\t' || item || E'\t' || configsectionid || E'\t' || value FROM config ORDER BY item;" \
+              >> fresh.dump
           else
             docker exec db mysqldump -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
               --no-create-info --skip-extended-insert --skip-comments --skip-triggers \
-              AccessGroup AgentBinary ApiGroup Config ConfigSection \
+              AccessGroup AgentBinary ApiGroup ConfigSection \
               CrackerBinaryType HashType Preprocessor RightGroup \
-              | grep '^INSERT' | sort > fresh.dump
+              | grep '^INSERT' > fresh.dump
+            docker exec db mysql -N -u ${{ env.DB_USER }} -p${{ env.DB_PASS }} ${{ env.DB_NAME }} \
+              -e "SELECT CONCAT('Config\t', item, '\t', configSectionId, '\t', value) FROM Config ORDER BY item;" \
+              >> fresh.dump
           fi
+          sort -o fresh.dump fresh.dump
           echo "Fresh side dump ($(wc -l < fresh.dump) rows):"
           cat fresh.dump
 

--- a/src/inc/apiv2/common/AbstractModelAPI.php
+++ b/src/inc/apiv2/common/AbstractModelAPI.php
@@ -29,6 +29,8 @@ use Hashtopolis\dba\OrderFilter;
 use Hashtopolis\dba\PaginationFilter;
 use Hashtopolis\dba\QueryFilter;
 use Hashtopolis\inc\Util;
+use Hashtopolis\inc\SConfig;
+use Hashtopolis\inc\defines\DConfig;
 
 /**
  * @template TModel of AbstractModel
@@ -631,12 +633,9 @@ abstract class AbstractModelAPI extends AbstractBaseAPI {
     $aliasedfeatures = $apiClass->getAliasedFeatures();
     $factory = $apiClass->getFactory();
     
-    $defaultPageSize = 10000;
-    $maxPageSize = 50000;
-    // TODO: if 0.14.4 release has happened, following parameters can be retrieved from config
-    // $defaultPageSize = SConfig::getInstance()->getVal(DConfig::DEFAULT_PAGE_SIZE);
-    // $maxPageSize = SConfig::getInstance()->getVal(DConfig::MAX_PAGE_SIZE);
-    
+    $defaultPageSize = SConfig::getInstance()->getVal(DConfig::DEFAULT_PAGE_SIZE);
+    $maxPageSize = SConfig::getInstance()->getVal(DConfig::MAX_PAGE_SIZE);
+
     $pageAfter = $apiClass->getQueryParameterFamilyMember($request, 'page', 'after');
     $pageBefore = $apiClass->getQueryParameterFamilyMember($request, 'page', 'before');
     $pageSize = $apiClass->getQueryParameterFamilyMember($request, 'page', 'size') ?? $defaultPageSize;

--- a/src/migrations/mysql/20260730120000_config-pagination-backfill.sql
+++ b/src/migrations/mysql/20260730120000_config-pagination-backfill.sql
@@ -1,0 +1,10 @@
+-- Backfill config defaults added in PR #1173 (pagination page size) for installs
+-- that started on v0.14.4-v0.14.8 and were never backfilled, as the legacy upgrade
+-- script update_v0.14.3_v0.14.x.php only ran for installed versions <= 0.14.3.
+INSERT INTO `Config` (`configSectionId`, `item`, `value`)
+SELECT 3, 'defaultPageSize', '10000'
+WHERE NOT EXISTS (SELECT 1 FROM `Config` WHERE `item` = 'defaultPageSize');
+
+INSERT INTO `Config` (`configSectionId`, `item`, `value`)
+SELECT 3, 'maxPageSize', '50000'
+WHERE NOT EXISTS (SELECT 1 FROM `Config` WHERE `item` = 'maxPageSize');

--- a/src/migrations/postgres/20260730120000_config-pagination-backfill.sql
+++ b/src/migrations/postgres/20260730120000_config-pagination-backfill.sql
@@ -1,0 +1,10 @@
+-- Backfill config defaults added in PR #1173 (pagination page size) for installs
+-- that started on v0.14.4-v0.14.8 and were never backfilled, as the legacy upgrade
+-- script update_v0.14.3_v0.14.x.php only ran for installed versions <= 0.14.3.
+INSERT INTO config (configsectionid, item, value)
+SELECT 3, 'defaultPageSize', '10000'
+WHERE NOT EXISTS (SELECT 1 FROM config WHERE item = 'defaultPageSize');
+
+INSERT INTO config (configsectionid, item, value)
+SELECT 3, 'maxPageSize', '50000'
+WHERE NOT EXISTS (SELECT 1 FROM config WHERE item = 'maxPageSize');


### PR DESCRIPTION
This adds additional test steps into the upgrade tests where we make sure that some initial data (i.e. which is typically inserted on the very first fresh setup) to be consistent over the upgraded versions. This way we would detect if there is a value which was lost during some upgrade steps and some setups may have it and some may not.

When adding this, there was actually such a case already discovered (defaultPageSize / maxPageSize) which was lost on versions 0.14.4-0.14.8. This is also fixed within this PR with a new migration to make sure all are in the same state.