### PR TITLE
Added 1.0.0 release to upgrade check

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -65,6 +65,15 @@ jobs:
           - start-tag: v1.0.0-rc3
             db-type: postgres
             db-version: postgres:18
+          - start-tag: v1.0.0
+            db-type: mysql
+            db-version: mysql:8.4
+          - start-tag: v1.0.0
+            db-type: mysql
+            db-version: mysql:9.7
+          - start-tag: v1.0.0
+            db-type: postgres
+            db-version: postgres:18
       fail-fast: false
 
     steps:


### PR DESCRIPTION
after further minor/bug releases we later can remove the rcX releases from the upgrade checks, but I would keep them for now.