### PR TITLE
Add a filename-terminated agent download URL

### DIFF
--- a/ci/phpunit/inc/UtilTest.php
+++ b/ci/phpunit/inc/UtilTest.php
@@ -54,7 +54,27 @@ final class UtilTest extends TestBase {
   public function testExtractFileExtensionEmpty(): void {
     $this->assertEquals("", Util::extractFileExtension(""));
   }
-  
+
+  /**
+   * getAgentDownloadId extracts the numeric id from a filename-terminated path.
+   */
+  public function testGetAgentDownloadIdExtractsId(): void {
+    $this->assertSame(1, Util::getAgentDownloadId("/download/1/hashtopolis.zip"));
+    $this->assertSame(42, Util::getAgentDownloadId("/download/42/foo.7z"));
+    $this->assertSame(1, Util::getAgentDownloadId("/download/1"));
+  }
+
+  /**
+   * getAgentDownloadId returns null for paths that do not match the shape.
+   */
+  public function testGetAgentDownloadIdRejectsNonMatching(): void {
+    $this->assertNull(Util::getAgentDownloadId("/download/abc/x"));
+    $this->assertNull(Util::getAgentDownloadId("/download/1abc"));
+    $this->assertNull(Util::getAgentDownloadId("/other"));
+    $this->assertNull(Util::getAgentDownloadId(""));
+    $this->assertNull(Util::getAgentDownloadId(null));
+  }
+
   /**
    * texEscape leaves normal text unchanged.
    */

--- a/src/agents.php
+++ b/src/agents.php
@@ -31,6 +31,15 @@ use Hashtopolis\inc\utils\TaskUtils;
 
 require_once(dirname(__FILE__) . "/inc/startup/load.php");
 
+// Support a filename-terminated download URL (agents.php/download/<id>/<filename>)
+// so clients like wget name the saved file correctly.
+if (!isset($_GET['download'])) {
+  $downloadId = Util::getAgentDownloadId($_SERVER['PATH_INFO'] ?? null);
+  if ($downloadId !== null) {
+    $_GET['download'] = $downloadId;
+  }
+}
+
 if (isset($_GET['download'])) {
   $agentHandler = new AgentHandler();
   try {
@@ -151,7 +160,7 @@ else if (isset($_GET['new']) && AccessControl::getInstance()->hasPermission(DAcc
   $url = explode("/", $_SERVER['PHP_SELF']);
   unset($url[sizeof($url) - 1]);
   UI::add('apiUrl', Util::buildServerUrl() . implode("/", $url) . "/api/server.php");
-  UI::add('agentUrl', Util::buildServerUrl() . implode("/", $url) . "/agents.php?download=");
+  UI::add('agentUrl', Util::buildServerUrl() . implode("/", $url) . "/agents.php/download/");
 }
 else {
   UI::add('pageTitle', "Agents");

--- a/src/inc/Util.php
+++ b/src/inc/Util.php
@@ -73,7 +73,24 @@ class Util {
     }
     return $split[sizeof($split) - 1];
   }
-  
+
+  /**
+   * Extracts the agent binary id from a filename-terminated download path such
+   * as "/download/1/hashtopolis.zip" (the PATH_INFO of agents.php). The trailing
+   * filename segment is only there so clients name the saved file correctly; the
+   * numeric id is what selects the binary. Returns null if the path does not
+   * match this shape.
+   *
+   * @param string|null $pathInfo
+   * @return int|null
+   */
+  public static function getAgentDownloadId(?string $pathInfo): ?int {
+    if ($pathInfo !== null && preg_match('#^/download/([0-9]+)(?:/|$)#', $pathInfo, $matches)) {
+      return (int)$matches[1];
+    }
+    return null;
+  }
+
   /**
    * Downloads the data at the given url and saves it at the specified destination.
    * It will overwrite files if they already exist.

--- a/src/templates/agents/new.template.html
+++ b/src/templates/agents/new.template.html
@@ -34,7 +34,7 @@
 						  <input type="hidden" name="csrf" value="[[csrf]]">
               <input type="submit" class='btn btn-primary' value="Download">
             </form><br>
-					  <code>[[agentUrl]][[binary.getId()]]</code>
+					  <code>[[agentUrl]][[binary.getId()]]/[[binary.getFilename()]]</code>
           </td>
         </tr>
       {{ENDFOREACH}}


### PR DESCRIPTION
## Problem

`wget http://host/agents.php?download=1` saves the file as
`agents.php?download=1` instead of `hashtopolis.zip`.

The `Content-Disposition: attachment; filename="hashtopolis.zip"` header is
already sent, but clients that name the file from the URL rather than the header
still get it wrong, because the last path segment is `agents.php`, not the
filename:

- `wget` (without `--content-disposition`) appends the query string too, saving
  `agents.php?download=1`.
- `curl -O` drops the query string and saves `agents.php`.

Neither yields `hashtopolis.zip`.

## Fix

Accept an additional, filename-terminated URL:

```
agents.php/download/<id>/<filename>     e.g. agents.php/download/1/hashtopolis.zip
```

The id is read from `PATH_INFO` via a new pure helper
`Util::getAgentDownloadId()`; the trailing `<filename>` is the last path segment
and there is no query string, so wget/curl save `hashtopolis.zip` directly. The
UI's download link on the "new agent" page is switched to this form. The old
`?download=<id>` URL still works (the new branch only triggers when `?download`
is absent).

`AgentHandler::downloadAgent()` is unchanged — the served bytes and the
`Content-Disposition` filename still come from the binary record, so the
`<filename>` in the URL is cosmetic for the client and can't be used to serve a
different file (the numeric id, matched as `[0-9]+`, selects the binary).

## Testing

- New PHPUnit tests in `ci/phpunit/inc/UtilTest.php` cover
  `Util::getAgentDownloadId()`: the `/download/<id>/<file>`, `/download/<id>`
  forms extract the id; `/download/abc/x`, `/other`, `""`, and `null` return
  `null`.
- `php -l` passes on `src/agents.php`, `src/inc/Util.php`, and the test.
- End-to-end with `php -S` + a router mimicking mod_php `PATH_INFO`: `wget` and
  `curl -O` on `agents.php/download/1/hashtopolis.zip` both save
  `hashtopolis.zip`, and the handler receives id `1`.

## Deployment note

This relies on the web server passing `PATH_INFO` to `agents.php`, which the
shipped `php:8.5-apache` (mod_php) image does by default — no `mod_rewrite` or
Apache-config change is needed. A reverse-proxied php-fpm setup that doesn't
forward `PATH_INFO` would simply not see the new URL and fall back to the
still-working `?download=<id>` form, so this is strictly additive.

## Alternatives considered

- A fully clean `agents/download/<id>/<filename>` URL (no `.php`): requires a
  `mod_rewrite` rule in the vhost config (`000-default.conf`), changing the
  deployment for every install. The `PATH_INFO` form gives the same
  client-visible result with no config change.
- Putting the parser inline in `agents.php`: kept it in `Util` instead so it is
  covered by PHPUnit and analysed by phpstan (both scan `src/inc`).
- Adding `Content-Length` / switching `echo file_get_contents()` to `readfile()`
  in `downloadAgent()`: doesn't address the filename problem, and for a ~30 KB
  static zip the streaming change makes no practical difference. Out of scope.
